### PR TITLE
Claude Commands Export 2025-10-18: Directory Exclusions Applied

### DIFF
--- a/.claude/commands/exportcommands.py
+++ b/.claude/commands/exportcommands.py
@@ -1086,9 +1086,9 @@ This is a filtered reference export from a working Claude Code project. Commands
         }
 
         # Create the .claude/ subdirectories (but not for files like settings.json)
+        file_targets = {'settings_json'}
         for local_name, target_path in dirs_mapping.items():
-            # Create directory only if target_path is a directory (no file extension)
-            if target_path and target_path.startswith(claude_dir) and not Path(target_path).suffix:
+            if target_path and target_path.startswith(claude_dir) and local_name not in file_targets:
                 os.makedirs(target_path, exist_ok=True)
 
         # Copy content with proper directory mapping

--- a/.claude/commands/exportcommands.py
+++ b/.claude/commands/exportcommands.py
@@ -46,7 +46,7 @@ class ClaudeCommandsExporter:
         self.github_token = os.environ.get('GITHUB_TOKEN')
 
         # Export configuration - all directories will be exported automatically
-        self.EXPORT_SUBDIRS = ['commands', 'hooks', 'agents', 'scripts', 'orchestration']
+        self.EXPORT_SUBDIRS = ['commands', 'hooks', 'agents', 'scripts', 'skills', 'orchestration']
 
         # Commands to skip during export (project-specific and user-specified exclusions)
         self.COMMANDS_SKIP_LIST = [
@@ -62,6 +62,7 @@ class ClaudeCommandsExporter:
         self.hooks_count = 0
         self.agents_count = 0
         self.scripts_count = 0
+        self.skills_count = 0
 
         # Versioning is now handled by LLM in exportcommands.md
         # These are kept for backward compatibility but not actively used
@@ -95,7 +96,7 @@ class ClaudeCommandsExporter:
         print("\n📂 Phase 1: Creating Local Export...")
         print("-" * 40)
 
-        print("🔍 Using comprehensive directory export (commands, hooks, agents, scripts, orchestration)")
+        print("🔍 Using comprehensive directory export (commands, hooks, agents, scripts, skills, orchestration)")
 
         # Create staging directory
         staging_dir = os.path.join(self.export_dir, "staging")
@@ -121,6 +122,9 @@ class ClaudeCommandsExporter:
 
         # Export .claude/scripts directory
         self._export_claude_scripts(staging_dir)
+
+        # Export .claude/skills directory
+        self._export_skills(staging_dir)
 
         # Export settings.json
         self._export_settings(staging_dir)
@@ -428,6 +432,31 @@ class ClaudeCommandsExporter:
 
         print(f"✅ Exported {scripts_count} .claude/scripts files")
 
+    def _export_skills(self, staging_dir):
+        """Export .claude/skills directory for reference skills"""
+        print("🧠 Exporting .claude/skills directory...")
+
+        source_dir = os.path.join(self.project_root, '.claude', 'skills')
+        if not os.path.exists(source_dir):
+            print("⚠️  Warning: .claude/skills directory not found")
+            return
+
+        target_dir = os.path.join(staging_dir, 'skills')
+        os.makedirs(target_dir, exist_ok=True)
+
+        # Reuse directory copy helper for filtering and transformations
+        self._copy_directory_with_filtering(source_dir, target_dir)
+
+        allowed_extensions = ('.sh', '.py', '.md', '.json', '.toml', '.txt')
+        for root, dirs, files in os.walk(target_dir):
+            for file in files:
+                if file.endswith(allowed_extensions):
+                    self.skills_count += 1
+                    rel_path = os.path.relpath(os.path.join(root, file), target_dir)
+                    print(f"   🧠 {rel_path}")
+
+        print(f"✅ Exported {self.skills_count} skills")
+
     def _export_settings(self, staging_dir):
         """Export settings.json file"""
         print("⚙️  Exporting settings.json...")
@@ -691,6 +720,7 @@ class ClaudeCommandsExporter:
 - **{self.commands_count} Commands**: Complete workflow orchestration system
 - **{self.hooks_count} Hooks**: Claude Code automation and workflow hooks
 - **{self.scripts_count} Scripts**: Development and automation tools (scripts/ directory)
+- **{self.skills_count} Skills**: Shared knowledge references (.claude/skills/)
 
 **Major Changes**:
 - **Script Allowlist Expansion**: Added 12 generally useful development scripts to the scripts export
@@ -779,13 +809,14 @@ class ClaudeCommandsExporter:
             r'\*\*(\d+) Hooks\*\*': f'**{self.hooks_count} Hooks**',
             r'\*\*(\d+) Scripts\*\*': f'**{self.scripts_count} Scripts**',
             r'\*\*(\d+) Agents\*\*': f'**{self.agents_count} Agents**',
+            r'\*\*(\d+) Skills\*\*': f'**{self.skills_count} Skills**',
         }
 
         # Apply all replacements
         for pattern, replacement in replacements.items():
             content = re.sub(pattern, replacement, content)
 
-        print(f"   📊 Dynamic counts: {self.commands_count} commands, {self.hooks_count} hooks, {self.scripts_count} scripts, {self.agents_count} agents")
+        print(f"   📊 Dynamic counts: {self.commands_count} commands, {self.hooks_count} hooks, {self.scripts_count} scripts, {self.agents_count} agents, {self.skills_count} skills")
         return content
 
     def _generate_readme(self):
@@ -825,6 +856,7 @@ class ClaudeCommandsExporter:
 - **{self.commands_count} commands** workflow orchestration commands
 - **{self.hooks_count} hooks** Claude Code automation hooks
 - **{self.scripts_count} scripts** reusable automation scripts (scripts/)
+- **{self.skills_count} skills** shared knowledge references (.claude/skills/)
 
 ## MANUAL INSTALLATION
 
@@ -835,6 +867,7 @@ Copy the exported commands and hooks to your project's `.claude/` directory:
 - Hooks → `.claude/hooks/`
 - Agents → `.claude/agents/`
 - Scripts → `scripts/` in your project root
+- Skills → `.claude/skills/`
 
 ## 📊 **Export Contents**
 
@@ -842,6 +875,7 @@ This comprehensive export includes:
 - **📋 {self.commands_count} Command Definitions** - Complete workflow orchestration system (.claude/commands/)
 - **📎 {self.hooks_count} Claude Code Hooks** - Essential workflow automation (.claude/hooks/)
 - **🤖 {self.agents_count} Agent Definitions** - Specialized task agents for autonomous workflows (.claude/agents/)
+- **🧠 {self.skills_count} Skills** - Knowledge base exports (.claude/skills/)
 - **🔧 {self.scripts_count} Scripts** - Development environment management (scripts/)
 - **🤖 Orchestration System** - Core multi-agent task delegation (project-specific parts excluded)
 - **📚 Complete Documentation** - Setup guide with adaptation examples
@@ -1045,6 +1079,7 @@ This is a filtered reference export from a working Claude Code project. Commands
             'hooks': os.path.join(claude_dir, 'hooks'),
             'agents': os.path.join(claude_dir, 'agents'),
             'claude_scripts': os.path.join(claude_dir, 'scripts'),  # .claude/scripts directory
+            'skills': os.path.join(claude_dir, 'skills'),           # .claude/skills directory
             'settings_json': os.path.join(claude_dir, 'settings.json'),  # .claude/settings.json file
             'orchestration': 'orchestration',  # Goes to repo root
             'scripts': None                    # Goes to repo root within scripts/
@@ -1052,7 +1087,8 @@ This is a filtered reference export from a working Claude Code project. Commands
 
         # Create the .claude/ subdirectories (but not for files like settings.json)
         for local_name, target_path in dirs_mapping.items():
-            if target_path and target_path.startswith(claude_dir) and not target_path.endswith('.json'):
+            # Create directory only if target_path is a directory (no file extension)
+            if target_path and target_path.startswith(claude_dir) and not Path(target_path).suffix:
                 os.makedirs(target_path, exist_ok=True)
 
         # Copy content with proper directory mapping
@@ -1169,6 +1205,7 @@ This is a filtered reference export from a working Claude Code project. Commands
 - 📋 Commands: {self.commands_count} command definitions with content filtering
 - 📎 Hooks: {self.hooks_count} Claude Code hooks with nested structure
 - 🚀 Scripts: {self.scripts_count} reusable automation scripts (scripts/ directory)
+- 🧠 Skills: {self.skills_count} shared knowledge references (.claude/skills/)
 - 🤖 Orchestration: Multi-agent task delegation system (core components only)
 - 📚 Documentation: Complete README with installation guide and adaptation examples
 
@@ -1209,17 +1246,19 @@ This export **excludes** the following project-specific directories:
 - **📋 {self.commands_count} Commands**: Complete workflow orchestration system
 - **📎 {self.hooks_count} Hooks**: Essential Claude Code workflow automation
 - **🚀 {self.scripts_count} Scripts**: Development environment management (scripts/ directory)
+- **🧠 {self.skills_count} Skills**: Reference knowledge exports (.claude/skills/)
 - **🤖 Orchestration System**: Core multi-agent task delegation (WIP prototype)
 - **📚 Complete Documentation**: Setup guide with adaptation examples
 
 ## Manual Installation
 From your project root:
 ```bash
-mkdir -p .claude/{{commands,hooks,agents}}
+mkdir -p .claude/{{commands,hooks,agents,skills}}
 mkdir -p scripts
 cp -R commands/. .claude/commands/
 cp -R hooks/. .claude/hooks/
 cp -R agents/. .claude/agents/
+cp -R skills/. .claude/skills/
 # Optional scripts directory
 cp -n scripts/* ./scripts/
 ```
@@ -1278,6 +1317,7 @@ This is a filtered reference export. Commands may need adaptation for specific e
         print(f"   Hooks: {self.hooks_count}")
         print(f"   Agents: {self.agents_count}")
         print(f"   Scripts: {self.scripts_count}")
+        print(f"   Skills: {self.skills_count}")
         print(f"   Excluded: analysis/, automation/, claude-bot-commands/, coding_prompts/, prototype/")
         print(f"\n🎯 The export has been published and is ready for review!")
 

--- a/.claude/commands/second_opinion.md
+++ b/.claude/commands/second_opinion.md
@@ -1,0 +1,50 @@
+---
+description: Get multi-model second opinion on design, code review, or bugs
+aliases: [secondopinion]
+---
+
+# Second Opinion Command
+
+Get comprehensive multi-model AI feedback on your code, design decisions, or bug analysis.
+
+## Usage
+
+```bash
+# Get second opinion on current context
+/secondo
+
+# Specify feedback type
+/secondo design
+/secondo code-review
+/secondo bugs
+
+# With specific question
+/secondo "Should I use Redis or in-memory caching for rate limiting?"
+```
+
+## How It Works
+
+This command:
+1. Analyzes your current context (open files, recent changes, or provided question)
+2. Sends request to AI Universe MCP server for multi-model analysis
+3. Returns comprehensive synthesis from 5+ AI models (Cerebras, Gemini, Perplexity, OpenAI, Grok)
+4. Provides actionable recommendations with industry sources
+
+## Authentication
+
+Requires authentication token from `node scripts/auth-cli.mjs login`
+
+## Rate Limits
+
+- **Authenticated**: 60 requests/hour
+- **Multi-model synthesis**: 1 per hour
+- Token expires after 1 hour
+
+## Output Format
+
+Display results in markdown with:
+- 📊 Summary (models used, tokens, cost)
+- 🎯 Primary Opinion (Cerebras)
+- 💡 Secondary Perspectives (Gemini, Perplexity, OpenAI, Grok)
+- ✨ Final Synthesis (consensus with sources)
+- 🔗 Industry Sources (clickable links)

--- a/.claude/commands/secondo.md
+++ b/.claude/commands/secondo.md
@@ -1,0 +1,33 @@
+---
+description: Get multi-model second opinion (alias for /second_opinion)
+aliases: [secondopinion]
+type: ai
+execution_mode: immediate
+---
+
+# /secondo - Second Opinion Command Alias
+
+This is an alias for the `/second_opinion` command.
+
+See [second_opinion.md](second_opinion.md) for complete documentation.
+
+## Quick Usage
+
+```bash
+# Get second opinion on current context
+/secondo
+
+# Specify feedback type
+/secondo design
+/secondo code-review
+/secondo bugs
+
+# With specific question
+/secondo "Should I use Redis or in-memory caching for rate limiting?"
+```
+
+## Full Documentation
+
+For complete documentation, authentication setup, and detailed usage instructions, see:
+- [second_opinion.md](second_opinion.md)
+- Skills: `test-credentials` for OAuth testing setup

--- a/.claude/commands/secondo.md
+++ b/.claude/commands/secondo.md
@@ -1,6 +1,5 @@
 ---
 description: Get multi-model second opinion (alias for /second_opinion)
-aliases: [secondopinion]
 type: ai
 execution_mode: immediate
 ---

--- a/.claude/skills/ai-universe-auth.md
+++ b/.claude/skills/ai-universe-auth.md
@@ -1,0 +1,127 @@
+---
+description: Authenticate with AI Universe MCP server for multi-model commands
+type: setup
+scope: project
+---
+
+# AI Universe Authentication Setup
+
+This skill provides authentication setup for the AI Universe MCP server, which powers the `/secondo` command for multi-model AI feedback.
+
+## Prerequisites
+
+- Node.js installed
+- Firebase project configured
+- Browser for OAuth flow
+
+## Authentication Flow
+
+### 1. Initial Login
+
+```bash
+# Start browser-based OAuth authentication
+node scripts/auth-cli.mjs login
+```
+
+**What happens:**
+- Starts local callback server on port 9005
+- Opens browser to Firebase Google sign-in
+- User signs in with Google account
+- Token saved to `~/.ai-universe/auth-token.json`
+- Token expires after 1 hour
+
+### 2. Check Authentication Status
+
+```bash
+# Verify current authentication status
+node scripts/auth-cli.mjs status
+```
+
+**Output includes:**
+- User information (name, email, UID)
+- Token creation time
+- Token expiration time
+- Current validity status
+
+### 3. Get Token for Scripts
+
+```bash
+# Output token for use in other scripts
+TOKEN=$(node scripts/auth-cli.mjs token)
+echo $TOKEN
+```
+
+### 4. Test MCP Connection
+
+```bash
+# Verify authenticated connection to MCP server
+node scripts/auth-cli.mjs test
+```
+
+**Validates:**
+- Authentication works
+- MCP server is accessible
+- Rate limit status
+- Current usage and remaining requests
+
+### 5. Logout
+
+```bash
+# Remove saved authentication token
+node scripts/auth-cli.mjs logout
+```
+
+## Troubleshooting
+
+### Port 9005 Already in Use
+
+```bash
+# Find process using port 9005
+lsof -ti:9005 | xargs kill -9
+
+# Or use different port (requires code modification)
+```
+
+### Token Expired
+
+```bash
+# Simply login again to refresh
+node scripts/auth-cli.mjs login
+```
+
+### Firebase Config Missing
+
+If you see errors about Firebase configuration:
+
+```bash
+# Set environment variables
+export FIREBASE_API_KEY="your-api-key"
+export FIREBASE_AUTH_DOMAIN="your-project.firebaseapp.com"
+export FIREBASE_PROJECT_ID="your-project-id"
+
+# Or run setup script if available
+./scripts/setup-firebase-config.sh
+```
+
+## Rate Limits
+
+**Authenticated Users:**
+- 60 requests per hour
+- Multi-model synthesis: 1 per hour
+- Token TTL: 1 hour
+
+## Security Notes
+
+- Token stored in `~/.ai-universe/auth-token.json`
+- OAuth flow uses localhost callback (127.0.0.1:9005)
+- Browser-based authentication (similar to gh CLI, gcloud CLI)
+- Never commit authentication tokens
+- Tokens auto-expire after 1 hour
+
+## Integration with Commands
+
+Once authenticated, use with:
+- `/secondo` - Multi-model second opinion
+- Direct HTTPie/curl calls to MCP server
+
+See [ai-universe-httpie.md](ai-universe-httpie.md) for HTTPie usage examples.

--- a/.claude/skills/ai-universe-httpie.md
+++ b/.claude/skills/ai-universe-httpie.md
@@ -1,0 +1,309 @@
+---
+description: Use HTTPie to call AI Universe MCP server for multi-model analysis
+type: usage
+scope: project
+---
+
+# AI Universe HTTPie Usage Guide
+
+This skill demonstrates how to use HTTPie to call the AI Universe MCP server directly for multi-model AI feedback.
+
+## Prerequisites
+
+1. **Install HTTPie:**
+   ```bash
+   # macOS
+   brew install httpie
+
+   # Ubuntu/Debian
+   apt-get install httpie
+
+   # Python (universal)
+   pip install httpie
+   ```
+
+2. **Authenticate:**
+   ```bash
+   node scripts/auth-cli.mjs login
+   ```
+
+## Basic HTTPie Usage with MCP
+
+### Get Authentication Token
+
+```bash
+# Export token for reuse
+export TOKEN=$(node scripts/auth-cli.mjs token)
+```
+
+### MCP Server Configuration
+
+```bash
+MCP_URL="https://ai-universe-backend-final.onrender.com/mcp"
+```
+
+## Example: Second Opinion Request
+
+### 1. Simple Question
+
+```bash
+echo '{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "agent.second_opinion",
+    "arguments": {
+      "question": "Should I use Redis or in-memory caching for rate limiting?"
+    }
+  },
+  "id": 1
+}' | http POST "$MCP_URL" \
+  Accept:'application/json, text/event-stream' \
+  Authorization:"Bearer $TOKEN" \
+  --timeout=180
+```
+
+### 2. Design Review Request
+
+```bash
+# Create request JSON
+REQUEST_JSON=$(cat <<'EOF'
+{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "agent.second_opinion",
+    "arguments": {
+      "question": "Design Review: Authentication system using Firebase\n\nAnalyze the architectural decisions:\n- Is OAuth flow appropriate?\n- Are there better alternatives?\n- What are potential security issues?\n- Industry best practices comparison?"
+    }
+  },
+  "id": 1
+}
+EOF
+)
+
+# Send request with HTTPie
+echo "$REQUEST_JSON" | http POST "$MCP_URL" \
+  Accept:'application/json, text/event-stream' \
+  Authorization:"Bearer $TOKEN" \
+  --timeout=180 \
+  --print=b
+```
+
+### 3. Code Review Request
+
+```bash
+QUESTION="Code Review: Review this authentication flow for:
+- Security vulnerabilities
+- Token handling best practices
+- Error handling gaps
+- Rate limiting implementation
+- Session management"
+
+echo "{
+  \"jsonrpc\": \"2.0\",
+  \"method\": \"tools/call\",
+  \"params\": {
+    \"name\": \"agent.second_opinion\",
+    \"arguments\": {
+      \"question\": $(echo "$QUESTION" | jq -Rs .)
+    }
+  },
+  \"id\": 1
+}" | http POST "$MCP_URL" \
+  Accept:'application/json, text/event-stream' \
+  Authorization:"Bearer $TOKEN" \
+  --timeout=180
+```
+
+### 4. Bug Investigation Request
+
+```bash
+http POST "$MCP_URL" \
+  Accept:'application/json, text/event-stream' \
+  Authorization:"Bearer $TOKEN" \
+  jsonrpc=2.0 \
+  method=tools/call \
+  params:='{
+    "name": "agent.second_opinion",
+    "arguments": {
+      "question": "Bug Investigation: Investigate potential issues:\n- Race conditions in async operations\n- Memory leaks in long-running processes\n- Edge cases in error handling\n- Type safety concerns"
+    }
+  }' \
+  id:=1
+```
+
+## HTTPie Features for MCP Calls
+
+### 1. Pretty Print Response
+
+```bash
+# Default behavior - pretty JSON output
+echo "$REQUEST_JSON" | http POST "$MCP_URL" \
+  Authorization:"Bearer $TOKEN"
+```
+
+### 2. Download Response to File
+
+```bash
+echo "$REQUEST_JSON" | http POST "$MCP_URL" \
+  Authorization:"Bearer $TOKEN" \
+  --download \
+  --output=response.json
+```
+
+### 3. Show Request Headers
+
+```bash
+echo "$REQUEST_JSON" | http POST "$MCP_URL" \
+  Authorization:"Bearer $TOKEN" \
+  --print=HhBb  # H=request headers, h=response headers, B=request body, b=response body
+```
+
+### 4. Follow Redirects
+
+```bash
+echo "$REQUEST_JSON" | http POST "$MCP_URL" \
+  Authorization:"Bearer $TOKEN" \
+  --follow
+```
+
+### 5. Custom Timeout
+
+```bash
+echo "$REQUEST_JSON" | http POST "$MCP_URL" \
+  Authorization:"Bearer $TOKEN" \
+  --timeout=300  # 5 minutes
+```
+
+## Parse Response with jq
+
+### Extract Primary Opinion
+
+```bash
+RESPONSE=$(echo "$REQUEST_JSON" | http POST "$MCP_URL" \
+  Authorization:"Bearer $TOKEN" \
+  --print=b)
+
+echo "$RESPONSE" | jq -r '.result.content[0].text' | jq -r '.primary.response'
+```
+
+### Extract Synthesis
+
+```bash
+echo "$RESPONSE" | jq -r '.result.content[0].text' | jq -r '.synthesis.response'
+```
+
+### Extract Cost Information
+
+```bash
+echo "$RESPONSE" | jq -r '.result.content[0].text' | jq '{
+  models: .summary.totalModels,
+  tokens: .summary.totalTokens,
+  cost: .summary.totalCost
+}'
+```
+
+## Rate Limit Status Check
+
+```bash
+# Get current rate limit status
+echo '{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "rate-limit.status",
+    "arguments": {
+      "userId": "'$(node scripts/auth-cli.mjs status | grep UID | awk "{print \$2}")'"
+    }
+  },
+  "id": 1
+}' | http POST "$MCP_URL" \
+  Authorization:"Bearer $TOKEN"
+```
+
+## Error Handling
+
+### Check for Errors in Response
+
+```bash
+if echo "$RESPONSE" | jq -e '.error' >/dev/null 2>&1; then
+  echo "Error:" $(echo "$RESPONSE" | jq -r '.error')
+
+  # Check for rate limit
+  if echo "$RESPONSE" | jq -e '.details.resetTime' >/dev/null 2>&1; then
+    echo "Rate limited. Reset at:" $(echo "$RESPONSE" | jq -r '.details.resetTime')
+  fi
+fi
+```
+
+## Integration with Scripts
+
+### Complete HTTPie Script Example
+
+```bash
+#!/bin/bash
+
+# Get token
+TOKEN=$(node scripts/auth-cli.mjs token 2>/dev/null)
+if [ $? -ne 0 ]; then
+  echo "❌ Not authenticated. Run: node scripts/auth-cli.mjs login"
+  exit 1
+fi
+
+# Construct question
+QUESTION="$1"
+if [ -z "$QUESTION" ]; then
+  echo "Usage: $0 'your question here'"
+  exit 1
+fi
+
+# Send request
+RESPONSE=$(echo "{
+  \"jsonrpc\": \"2.0\",
+  \"method\": \"tools/call\",
+  \"params\": {
+    \"name\": \"agent.second_opinion\",
+    \"arguments\": {
+      \"question\": $(echo "$QUESTION" | jq -Rs .)
+    }
+  },
+  \"id\": 1
+}" | http POST "https://ai-universe-backend-final.onrender.com/mcp" \
+  Accept:'application/json, text/event-stream' \
+  Authorization:"Bearer $TOKEN" \
+  --timeout=180 \
+  --print=b)
+
+# Parse and display
+echo "$RESPONSE" | jq -r '.result.content[0].text' | jq '.'
+```
+
+## HTTPie vs curl
+
+**Why HTTPie is preferred:**
+- ✅ More readable syntax
+- ✅ Automatic JSON formatting
+- ✅ Pretty-printed output by default
+- ✅ Better error messages
+- ✅ Session support
+- ✅ Easier header management
+
+**HTTPie Example:**
+```bash
+http POST $URL Authorization:"Bearer $TOKEN" < request.json
+```
+
+**curl Equivalent:**
+```bash
+curl -X POST "$URL" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @request.json
+```
+
+## See Also
+
+- [ai-universe-auth.md](ai-universe-auth.md) - Authentication setup
+- [second_opinion.md](../commands/second_opinion.md) - Second opinion command docs
+- `scripts/secondo-cli.sh` - Implementation reference

--- a/.claude/skills/secondo-dependencies.md
+++ b/.claude/skills/secondo-dependencies.md
@@ -12,7 +12,7 @@ This document lists the dependencies required for the `/secondo` command to func
 
 The authentication system (`scripts/auth-cli.mjs`) requires Node.js packages.
 
-**✅ Included in PR**: A root `package.json` with express dependency is now included.
+**ℹ️ Note**: Ensure your project root contains a `package.json` with the `express` dependency.
 
 ```bash
 # Install all dependencies (from project root)

--- a/.claude/skills/secondo-dependencies.md
+++ b/.claude/skills/secondo-dependencies.md
@@ -1,0 +1,166 @@
+---
+description: Dependencies required for /secondo command
+type: setup
+scope: project
+---
+
+# /secondo Command Dependencies
+
+This document lists the dependencies required for the `/secondo` command to function properly.
+
+## Node.js Dependencies
+
+The authentication system (`scripts/auth-cli.mjs`) requires Node.js packages.
+
+**✅ Included in PR**: A root `package.json` with express dependency is now included.
+
+```bash
+# Install all dependencies (from project root)
+npm install
+```
+
+**Required packages:**
+- `express` (^4.19.2) - Web framework for OAuth callback server
+- Node.js built-ins (http, fs, os, path, child_process)
+
+**Note**: The `package.json` includes `"type": "module"` to support ES modules used by `auth-cli.mjs`.
+
+## System Dependencies
+
+### HTTPie (Preferred)
+
+```bash
+# macOS
+brew install httpie
+
+# Ubuntu/Debian
+apt-get install httpie
+
+# Python (universal)
+pip install httpie
+```
+
+### curl (Fallback)
+
+Usually pre-installed on most systems. If not:
+
+```bash
+# macOS
+brew install curl
+
+# Ubuntu/Debian
+apt-get install curl
+```
+
+### jq (JSON Processing)
+
+Required for JSON parsing in the CLI script:
+
+```bash
+# macOS
+brew install jq
+
+# Ubuntu/Debian
+apt-get install jq
+```
+
+## Firebase Configuration
+
+Set environment variables for Firebase authentication:
+
+```bash
+export FIREBASE_API_KEY="your-api-key"
+export FIREBASE_AUTH_DOMAIN="your-project.firebaseapp.com"
+export FIREBASE_PROJECT_ID="your-project-id"
+```
+
+**Optional:** Create a setup script (not included) to configure Firebase.
+
+## Verification
+
+### Check Node.js Dependencies
+
+```bash
+# Verify express module can be required
+node -e "require('express')" && echo "✅ express installed" || echo "❌ express missing"
+
+# Test auth-cli.mjs loads without errors
+node scripts/auth-cli.mjs
+# Should show help message, not module resolution errors
+```
+
+### Check System Tools
+
+```bash
+command -v http >/dev/null && echo "✅ HTTPie installed" || echo "❌ HTTPie missing"
+command -v curl >/dev/null && echo "✅ curl installed" || echo "❌ curl missing"
+command -v jq >/dev/null && echo "✅ jq installed" || echo "❌ jq missing"
+```
+
+### Test Authentication (After Dependencies)
+
+```bash
+# Should show help/error, not crash
+node scripts/auth-cli.mjs status
+```
+
+## Complete Setup
+
+```bash
+# 1. Install Node.js dependencies
+npm install express
+
+# 2. Install system tools (if needed)
+brew install httpie jq  # macOS
+# or
+apt-get install httpie jq  # Ubuntu/Debian
+
+# 3. Set Firebase environment variables
+export FIREBASE_API_KEY="your-key"
+export FIREBASE_AUTH_DOMAIN="your-domain"
+export FIREBASE_PROJECT_ID="your-project"
+
+# 4. Test authentication
+node scripts/auth-cli.mjs login
+
+# 5. Test secondo command
+./scripts/secondo-cli.sh "test question"
+```
+
+## Troubleshooting
+
+### "Cannot find package 'express'"
+
+Install Node.js dependencies:
+```bash
+npm install express
+```
+
+### "http: command not found"
+
+The script will automatically fall back to curl. But for best experience:
+```bash
+brew install httpie  # or apt-get install httpie
+```
+
+### "jq: command not found"
+
+Install jq for JSON processing:
+```bash
+brew install jq  # or apt-get install jq
+```
+
+### Firebase configuration errors
+
+Ensure environment variables are set:
+```bash
+echo $FIREBASE_API_KEY  # Should output your API key
+echo $FIREBASE_AUTH_DOMAIN  # Should output your domain
+echo $FIREBASE_PROJECT_ID  # Should output your project ID
+```
+
+## See Also
+
+- [ai-universe-auth.md](ai-universe-auth.md) - Authentication setup guide
+- [ai-universe-httpie.md](ai-universe-httpie.md) - HTTPie usage examples
+- [second_opinion.md](../commands/second_opinion.md) - Command documentation

--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ The productivity gains available right now represent the largest arbitrage oppor
 
 ## 📚 Version History
 
-### v1.1.0 (2025-10-18)
+### v1.20.0 (2025-10-18)
 
 **Export Statistics**:
 - **181 Commands**: Complete workflow orchestration system

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ tmux attach-session -t task-agent-frontend  # Direct agent access
 
 ## 🎯 What You're Really Getting: A Cognitive Capital Management System
 
-This export contains **179 commands** that transform Claude Code from a productivity tool into a **cognitive capital allocation platform**:
+This export contains **181 commands** that transform Claude Code from a productivity tool into a **cognitive capital allocation platform**:
 
 > **Note**: Command count is automatically updated during export to reflect the actual number of commands, libraries, and utilities included.
 
@@ -812,6 +812,36 @@ The productivity gains available right now represent the largest arbitrage oppor
 **This framework is how you seize that opportunity.**
 
 ## 📚 Version History
+
+### v1.1.0 (2025-10-18)
+
+**Export Statistics**:
+- **181 Commands**: Complete workflow orchestration system
+- **41 Hooks**: Claude Code automation and workflow hooks
+- **21 Scripts**: Development and automation tools (scripts/ directory)
+- **3 Skills**: Shared knowledge references (.claude/skills/)
+
+**Major Changes**:
+- **Script Allowlist Expansion**: Added 12 generally useful development scripts to the scripts export
+- **Development Workflow Tools**: Now includes git workflow, code analysis, testing, and CI/CD scripts
+- **Enhanced Export Utility**: Broader coverage of reusable development infrastructure
+
+**New Scripts Included**:
+- **Git Workflow**: create_worktree.sh, push.sh for branch management
+- **Code Analysis**: codebase_loc.sh, loc.sh, loc_simple.sh for metrics
+- **Testing Utilities**: run_tests_with_coverage.sh, run_lint.sh
+- **CI/CD Tools**: setup-github-runner.sh, setup_email.sh
+- **Development Environment**: create_snapshot.sh, schedule_branch_work.sh
+
+**Technical Improvements**:
+- Expanded script_patterns list from 5 to 15 generally useful scripts
+- Better categorization of Claude Code specific vs universally useful tools
+- Enhanced documentation for script adaptability across projects
+
+**Documentation**:
+- Updated scripts export description
+- Clear separation between project-specific and generally useful scripts
+- Improved adaptation guidance for cross-project usage
 
 ### v1.19.0 (2025-10-13)
 

--- a/scripts/loc_simple.sh
+++ b/scripts/loc_simple.sh
@@ -9,90 +9,279 @@ IFS=$'\n\t'
 echo "📊 Lines of Code Count (Production Focus)"
 echo "=========================================="
 
-# Function to count lines with proper exclusions
-count_files() {
-    local ext="$1"
-    local mode="$2"
-    local scope_pattern="${3:-}"
+# Utility to normalize glob scopes used for functional area summaries
+normalize_scope_glob() {
+    local scope="$1"
 
-    local -a find_args=(
-        find .
-        -type f
-        -name "*.${ext}"
-        ! -path "*/node_modules/*"
-        ! -path "*/.git/*"
-        ! -path "*/venv/*"
-        ! -path "*/__pycache__/*"
-        ! -path "./tmp/*"
-        ! -path "./roadmap/*"
-    )
-
-    if [[ -n "$scope_pattern" ]]; then
-        local scope_glob="$scope_pattern"
-
-        if [[ "$scope_glob" != ./* && "$scope_glob" != /* ]]; then
-            scope_glob="./${scope_glob#./}"
-        fi
-
-        if [[ "$scope_glob" != *\** ]]; then
-            scope_glob="${scope_glob%/}/*"
-        elif [[ "$scope_glob" == */ ]]; then
-            scope_glob="${scope_glob}*"
-        fi
-
-        find_args+=( -path "$scope_glob" )
+    if [[ -z "$scope" ]]; then
+        echo ""
+        return
     fi
 
-    local -a test_selector=(
-        \( -path "*/tests/*"
-        -o -path "*/test/*"
-        -o -path "*/testing/*"
-        -o -name "test_*.${ext}"
-        -o -name "*_test.${ext}"
-        -o -name "*_tests.${ext}"
-        \)
-    )
+    local glob="$scope"
 
-    local count
-    if [[ "$mode" == "test" ]]; then
-        count=$(
-            "${find_args[@]}" "${test_selector[@]}" -exec wc -l {} + 2>/dev/null \
-                | awk '!/ total$/ {sum += $1} END {print sum+0}'
-        )
-    else
-        count=$(
-            "${find_args[@]}" ! "${test_selector[@]}" -exec wc -l {} + 2>/dev/null \
-                | awk '!/ total$/ {sum += $1} END {print sum+0}'
-        )
+    if [[ "$glob" != ./* && "$glob" != /* ]]; then
+        glob="./${glob#./}"
     fi
 
-    echo "${count:-0}"
+    if [[ "$glob" == */ ]]; then
+        glob="${glob}*"
+    elif [[ "$glob" != *\** && "$glob" != *\?* ]]; then
+        glob="${glob%/}/*"
+    fi
+
+    echo "$glob"
 }
 
-# Overall language totals
-echo "🐍 Python (.py):"
-py_prod=$(count_files "py" "prod")
-py_test=$(count_files "py" "test")
-echo "  Production: ${py_prod:-0} lines"
-echo "  Test:       ${py_test:-0} lines"
+# Identify whether a file path should be considered test code
+is_test_file() {
+    local path="$1"
+    local ext="$2"
 
-echo "🌟 JavaScript (.js):"
-js_prod=$(count_files "js" "prod")
-js_test=$(count_files "js" "test")
-echo "  Production: ${js_prod:-0} lines"
-echo "  Test:       ${js_test:-0} lines"
+    local path_lc="${path,,}"
+    if [[ "$path_lc" == *"/tests/"* \
+        || "$path_lc" == *"/test/"* \
+        || "$path_lc" == *"/testing/"* \
+        || "$path_lc" == *"/__tests__/"* \
+        || "$path_lc" == *"/__test__/"* \
+        || "$path_lc" == *"/spec/"* \
+        || "$path_lc" == *"/specs/"* \
+        || "$path_lc" == *"/integration_tests/"* \
+        || "$path_lc" == *"/integration-test/"* \
+        || "$path_lc" == *"/qa/"* ]]; then
+        return 0
+    fi
 
-echo "🌐 HTML (.html):"
-html_prod=$(count_files "html" "prod")
-html_test=$(count_files "html" "test")
-echo "  Production: ${html_prod:-0} lines"
-echo "  Test:       ${html_test:-0} lines"
+    local filename="${path##*/}"
+    local filename_lc="${filename,,}"
+
+    if [[ "$filename_lc" == test_* ]]; then
+        return 0
+    fi
+
+    case "$filename_lc" in
+        *_test."${ext}"|*_tests."${ext}"|*_spec."${ext}")
+            return 0
+            ;;
+        *.test."${ext}"|*.tests."${ext}"|*.spec."${ext}"|*.unit."${ext}"|*.integration."${ext}"|*.e2e."${ext}")
+            return 0
+            ;;
+    esac
+
+    return 1
+}
+
+declare -a LANGUAGE_SPECS=(
+    "py|🐍 Python (.py)"
+    "pyi|🐍 Python Stubs (.pyi)"
+    "pyx|🐍 Cython (.pyx)"
+    "pxd|🐍 Cython Declarations (.pxd)"
+    "js|🌟 JavaScript (.js)"
+    "mjs|✨ JavaScript Modules (.mjs)"
+    "cjs|📦 CommonJS (.cjs)"
+    "jsx|⚛️ React JSX (.jsx)"
+    "ts|🌀 TypeScript (.ts)"
+    "tsx|🧩 TypeScript JSX (.tsx)"
+    "cts|🌀 TypeScript (.cts)"
+    "mts|🌀 TypeScript (.mts)"
+    "vue|🗂️ Vue Single File (.vue)"
+    "svelte|🔥 Svelte (.svelte)"
+    "astro|🌌 Astro (.astro)"
+    "html|🌐 HTML (.html)"
+    "htm|🌐 HTML (.htm)"
+    "css|🎨 CSS (.css)"
+    "scss|🎨 SCSS (.scss)"
+    "sass|🎨 SASS (.sass)"
+    "less|🎨 LESS (.less)"
+    "styl|🎨 Stylus (.styl)"
+    "json|🧾 JSON (.json)"
+    "jsonc|🧾 JSONC (.jsonc)"
+    "yaml|🧾 YAML (.yaml)"
+    "yml|🧾 YAML (.yml)"
+    "toml|🧾 TOML (.toml)"
+    "ini|🧾 INI (.ini)"
+    "cfg|🧾 Config (.cfg)"
+    "conf|🧾 Config (.conf)"
+    "xml|🧾 XML (.xml)"
+    "xsd|🧾 XML Schema (.xsd)"
+    "xsl|🧾 XSL (.xsl)"
+    "sql|🗄️ SQL (.sql)"
+    "graphql|🧬 GraphQL (.graphql)"
+    "gql|🧬 GraphQL (.gql)"
+    "prisma|🗄️ Prisma (.prisma)"
+    "proto|🔌 Protobuf (.proto)"
+    "rb|💎 Ruby (.rb)"
+    "php|🐘 PHP (.php)"
+    "go|🐹 Go (.go)"
+    "rs|🦀 Rust (.rs)"
+    "java|☕ Java (.java)"
+    "kt|📱 Kotlin (.kt)"
+    "kts|📱 Kotlin Script (.kts)"
+    "swift|🕊️ Swift (.swift)"
+    "cs|#️⃣ C# (.cs)"
+    "fs|🧠 F# (.fs)"
+    "fsx|🧠 F# Script (.fsx)"
+    "scala|🛠️ Scala (.scala)"
+    "clj|🌿 Clojure (.clj)"
+    "cljs|🌿 ClojureScript (.cljs)"
+    "groovy|🛠️ Groovy (.groovy)"
+    "dart|🎯 Dart (.dart)"
+    "r|📊 R (.r)"
+    "jl|🔬 Julia (.jl)"
+    "hs|📐 Haskell (.hs)"
+    "ex|⚙️ Elixir (.ex)"
+    "exs|⚙️ Elixir Script (.exs)"
+    "erl|⚙️ Erlang (.erl)"
+    "lua|🌙 Lua (.lua)"
+    "pl|🐪 Perl (.pl)"
+    "pm|🐪 Perl Module (.pm)"
+    "ps1|🪟 PowerShell (.ps1)"
+    "sh|🐚 Shell (.sh)"
+    "bash|🐚 Bash (.bash)"
+    "zsh|🐚 Zsh (.zsh)"
+    "fish|🐚 Fish (.fish)"
+    "bat|🪟 Batch (.bat)"
+    "cmd|🪟 Command (.cmd)"
+    "make|🛠️ Make (.make)"
+    "mk|🛠️ Make (.mk)"
+    "cmake|🛠️ CMake (.cmake)"
+    "gradle|🛠️ Gradle (.gradle)"
+    "c|🔧 C (.c)"
+    "cc|⚙️ C++ (.cc)"
+    "cpp|⚙️ C++ (.cpp)"
+    "cxx|⚙️ C++ (.cxx)"
+    "h|📄 Header (.h)"
+    "hh|📄 Header (.hh)"
+    "hpp|📄 Header (.hpp)"
+    "inl|📄 Inline Header (.inl)"
+    "ipp|📄 Inline Header (.ipp)"
+    "mm|🍎 Objective-C++ (.mm)"
+    "m|🍎 Objective-C (.m)"
+    "cshtml|🌐 Razor (.cshtml)"
+    "mdx|📝 MDX (.mdx)"
+    "nix|🧪 Nix (.nix)"
+    "tf|🌍 Terraform (.tf)"
+    "tfvars|🌍 Terraform Vars (.tfvars)"
+    "hcl|🌍 HCL (.hcl)"
+)
+
+declare -A LANGUAGE_LABELS=()
+declare -A PROD_COUNTS=()
+declare -A TEST_COUNTS=()
+declare -a ORDERED_EXTS=()
+declare -a ACTIVE_LANGUAGE_EXTS=()
+
+for spec in "${LANGUAGE_SPECS[@]}"; do
+    IFS='|' read -r ext label <<< "$spec"
+    ORDERED_EXTS+=("$ext")
+    LANGUAGE_LABELS["$ext"]="$label"
+done
+
+declare -a FIND_NAME_ARGS=()
+for ext in "${ORDERED_EXTS[@]}"; do
+    if (( ${#FIND_NAME_ARGS[@]} == 0 )); then
+        FIND_NAME_ARGS+=( -iname "*.${ext}" )
+    else
+        FIND_NAME_ARGS+=( -o -iname "*.${ext}" )
+    fi
+done
+
+declare -a FIND_CMD=( find . -type f )
+if (( ${#FIND_NAME_ARGS[@]} > 0 )); then
+    FIND_CMD+=( "(" "${FIND_NAME_ARGS[@]}" ")" )
+else
+    echo "📚 Language Breakdown:"
+    echo "  No language extensions configured."
+    exit 0
+fi
+
+FIND_CMD+=(
+    ! -path "*/node_modules/*"
+    ! -path "*/.git/*"
+    ! -path "*/venv/*"
+    ! -path "*/__pycache__/*"
+    ! -path "./tmp/*"
+    ! -path "./roadmap/*"
+    -print0
+)
+
+declare -a FILE_PATHS=()
+declare -a FILE_EXTS=()
+declare -a FILE_LINES=()
+declare -a FILE_MODES=()
+
+while IFS= read -r -d '' file; do
+    ext="${file##*.}"
+    ext="${ext,,}"
+
+    if [[ -z ${LANGUAGE_LABELS["$ext"]+x} ]]; then
+        continue
+    fi
+
+    lines=$(wc -l < "$file" 2>/dev/null || echo 0)
+    lines=${lines//[[:space:]]/}
+    if [[ -z "$lines" ]]; then
+        lines=0
+    fi
+
+    mode="prod"
+    if is_test_file "$file" "$ext"; then
+        mode="test"
+    fi
+
+    if [[ "$mode" == "test" ]]; then
+        current_test=${TEST_COUNTS["$ext"]:-0}
+        TEST_COUNTS["$ext"]=$((current_test + lines))
+    else
+        current_prod=${PROD_COUNTS["$ext"]:-0}
+        PROD_COUNTS["$ext"]=$((current_prod + lines))
+    fi
+
+    FILE_PATHS+=("$file")
+    FILE_EXTS+=("$ext")
+    FILE_LINES+=("$lines")
+    FILE_MODES+=("$mode")
+done < <("${FIND_CMD[@]}")
+
+for ext in "${ORDERED_EXTS[@]}"; do
+    prod_value=${PROD_COUNTS["$ext"]:-0}
+    test_value=${TEST_COUNTS["$ext"]:-0}
+    if (( prod_value + test_value > 0 )); then
+        ACTIVE_LANGUAGE_EXTS+=("$ext")
+    fi
+done
+
+echo "📚 Language Breakdown:"
+if (( ${#ACTIVE_LANGUAGE_EXTS[@]} > 0 )); then
+    for ext in "${ORDERED_EXTS[@]}"; do
+        prod_value=${PROD_COUNTS["$ext"]:-0}
+        test_value=${TEST_COUNTS["$ext"]:-0}
+        total_value=$((prod_value + test_value))
+        if (( total_value == 0 )); then
+            continue
+        fi
+        label=${LANGUAGE_LABELS["$ext"]}
+        echo "$label:"
+        echo "  Production: ${prod_value} lines"
+        echo "  Test:       ${test_value} lines"
+    done
+else
+    echo "  No source files found for the configured extensions."
+fi
 
 # Summary
 echo ""
 echo "📋 Summary:"
-total_prod=$((${py_prod:-0} + ${js_prod:-0} + ${html_prod:-0}))
-total_test=$((${py_test:-0} + ${js_test:-0} + ${html_test:-0}))
+
+total_prod=0
+total_test=0
+for ext in "${ORDERED_EXTS[@]}"; do
+    prod_value=${PROD_COUNTS["$ext"]:-0}
+    test_value=${TEST_COUNTS["$ext"]:-0}
+    total_prod=$((total_prod + prod_value))
+    total_test=$((total_test + test_value))
+done
+
 total_all=$((total_prod + total_test))
 
 echo "  Production Code: $total_prod lines"
@@ -113,14 +302,67 @@ count_functional_area() {
     local pattern="$1"
     local name="$2"
 
-    py_count=$(count_files "py" "prod" "$pattern")
-    js_count=$(count_files "js" "prod" "$pattern")
-    html_count=$(count_files "html" "prod" "$pattern")
+    local scope_glob
+    scope_glob=$(normalize_scope_glob "$pattern")
 
-    total=$((py_count + js_count + html_count))
+    local total=0
+    local -a languages_to_scan=()
+    local -A area_counts=()
 
-    if [[ $total -gt 0 ]]; then
-        printf "  %-20s: %6d lines (py:%5d js:%4d html:%4d)\n" "$name" "$total" "$py_count" "$js_count" "$html_count"
+    if (( ${#ACTIVE_LANGUAGE_EXTS[@]} > 0 )); then
+        languages_to_scan=("${ACTIVE_LANGUAGE_EXTS[@]}")
+    else
+        languages_to_scan=("${ORDERED_EXTS[@]}")
+    fi
+
+    local -A allowed_exts=()
+    for ext in "${languages_to_scan[@]}"; do
+        allowed_exts["$ext"]=1
+    done
+
+    for idx in "${!FILE_PATHS[@]}"; do
+        if [[ "${FILE_MODES[$idx]}" != "prod" ]]; then
+            continue
+        fi
+
+        local ext="${FILE_EXTS[$idx]}"
+        if [[ -z ${allowed_exts["$ext"]+x} ]]; then
+            continue
+        fi
+
+        local path="${FILE_PATHS[$idx]}"
+        if [[ -n "$scope_glob" ]]; then
+            case "$path" in
+                $scope_glob) ;;
+                *) continue ;;
+            esac
+        fi
+
+        local lines=${FILE_LINES[$idx]}
+        area_counts["$ext"]=$(( ${area_counts["$ext"]:-0} + lines ))
+        total=$((total + lines))
+    done
+
+    if (( total > 0 )); then
+        local -a segments=()
+        for ext in "${languages_to_scan[@]}"; do
+            local count=${area_counts["$ext"]:-0}
+            if (( count > 0 )); then
+                segments+=("${ext}:${count}")
+            fi
+        done
+
+        local joined=""
+        if (( ${#segments[@]} > 0 )); then
+            joined=$(printf ", %s" "${segments[@]}")
+            joined=${joined:2}
+        fi
+
+        if [[ -n "$joined" ]]; then
+            printf "  %-20s: %6d lines (%s)\n" "$name" "$total" "$joined"
+        else
+            printf "  %-20s: %6d lines\n" "$name" "$total"
+        fi
     fi
 }
 


### PR DESCRIPTION
**🚨 AUTOMATED EXPORT** with directory exclusions applied per requirements.

## 🎯 Directory Exclusions Applied
This export **excludes** the following project-specific directories:
- ❌ `analysis/` - Project-specific analytics and reporting
- ❌ `automation/` - Project-specific automation scripts
- ❌ `claude-bot-commands/` - Project-specific bot implementation
- ❌ `coding_prompts/` - Project-specific AI prompting templates
- ❌ `prototype/` - Project-specific experimental code

## ✅ Export Contents
- **📋 181 Commands**: Complete workflow orchestration system
- **📎 41 Hooks**: Essential Claude Code workflow automation
- **🚀 21 Scripts**: Development environment management (scripts/ directory)
- **🧠 3 Skills**: Reference knowledge exports (.claude/skills/)
- **🤖 Orchestration System**: Core multi-agent task delegation (WIP prototype)
- **📚 Complete Documentation**: Setup guide with adaptation examples

## Manual Installation
From your project root:
```bash
mkdir -p .claude/{commands,hooks,agents,skills}
mkdir -p scripts
cp -R commands/. .claude/commands/
cp -R hooks/. .claude/hooks/
cp -R agents/. .claude/agents/
cp -R skills/. .claude/skills/
# Optional scripts directory
cp -n scripts/* ./scripts/
```

## 🔄 Content Filtering Applied
- **Generic Paths**: mvp_site/ → \$PROJECT_ROOT/
- **Generic Domain**: worldarchitect.ai → your-project.com
- **Generic User**: jleechan → \$USER
- **Generic Commands**: TESTING=true vpython → TESTING=true python

## ⚠️ Reference Export
This is a filtered reference export. Commands may need adaptation for specific environments, but Claude Code excels at helping customize them for any workflow.

---
🤖 **Generated with [Claude Code](https://claude.ai/code)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds skills export to the exporter, introduces a second-opinion command with supporting skills, enhances the LOC script, and secures/extends MCP setup (Render and new Second Opinion server).
> 
> - **Exporter (.claude/commands/exportcommands.py)**
>   - Add `skills` to export flow (`EXPORT_SUBDIRS`, counts, CLI output, README/template replacements, PR/commit text).
>   - Implement `_export_skills` to copy `.claude/skills/` with filtering and extensions; include dir mapping to `.claude/skills/`.
>   - Adjust repo copy logic to avoid treating `settings.json` as a dir.
> - **New Commands/Skills**
>   - Add `commands/second_opinion.md` and alias `commands/secondo.md`.
>   - Add skills: `ai-universe-auth.md`, `ai-universe-httpie.md`, `secondo-dependencies.md` under `.claude/skills/`.
> - **Scripts**
>   - `scripts/loc_simple.sh`: rewrite to multi-language LOC accounting with prod/test detection, scope normalization, and per-area summaries.
>   - `scripts/mcp_common.sh`: add Grok model env support; introduce `add_http_mcp_server` with redaction; rework Render server setup to use it; add `setup_second_opinion_mcp_server` (HTTP MCP, token-based) and invoke it.
> - **Docs**
>   - `README.md`: update command count to `181`; add v1.20.0 release entry including skills stats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4880d86634c4daec790761ea3dc3f04231cf6c0a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Second Opinion command for multi-model AI analysis across leading providers
  * Skills export capability now included in export utility
  * 3 new skills added for AI Universe integration

* **Documentation**
  * New Second Opinion command guides with usage examples and workflow details
  * AI Universe authentication setup documentation
  * HTTPie integration guide for multi-model requests

* **Enhancements**
  * Export utility now exports and counts skills directory
  * Command count increased to 181 with expanded tooling
  * Line-of-code counting script enhanced with language-aware analysis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->