### PR TITLE
Codex follow-up: Harden MCP bootstrap scripts and LOC filtering

### DIFF
--- a/.claude/scripts/mcp_common.sh
+++ b/.claude/scripts/mcp_common.sh
@@ -40,16 +40,24 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+WORLDARCHITECT_MODULE_DIR_DEFAULT="${WORLDARCHITECT_MODULE_DIR:-}"
+if [[ -z "$WORLDARCHITECT_MODULE_DIR_DEFAULT" && -n "${PROJECT_ROOT:-}" ]]; then
+    WORLDARCHITECT_MODULE_DIR_DEFAULT="${PROJECT_ROOT}"
+fi
+WORLDARCHITECT_MODULE_DIR="${WORLDARCHITECT_MODULE_DIR_DEFAULT:-orchestration}"
+
 mcp_common__resolve_repo_root() {
+    local module_dir="$WORLDARCHITECT_MODULE_DIR"
+
     if [[ -n "${WORLDARCHITECT_PROJECT_ROOT:-}" ]] && \
-       [[ -f "${WORLDARCHITECT_PROJECT_ROOT}/$PROJECT_ROOT/mcp_api.py" ]]; then
+       [[ -f "${WORLDARCHITECT_PROJECT_ROOT}/${module_dir}/mcp_api.py" ]]; then
         echo "${WORLDARCHITECT_PROJECT_ROOT}"
         return 0
     fi
 
     local search_dir="$SCRIPT_DIR"
     while [[ "$search_dir" != "/" ]]; do
-        if [[ -f "$search_dir/$PROJECT_ROOT/mcp_api.py" ]]; then
+        if [[ -f "$search_dir/${module_dir}/mcp_api.py" ]]; then
             echo "$search_dir"
             return 0
         fi
@@ -71,7 +79,11 @@ TEST_MODE=${TEST_MODE:-false}
 MCP_PRODUCT_NAME=${MCP_PRODUCT_NAME:-"Claude"}
 MCP_CLI_BIN=${MCP_CLI_BIN:-"claude"}
 MCP_SCOPE=${MCP_SCOPE:-local}
-MCP_INSTALL_DUAL_SCOPE=${MCP_INSTALL_DUAL_SCOPE:-true}  # Install to both local and user scopes
+# MCP_INSTALL_DUAL_SCOPE controls whether the MCP server is installed in both project-local
+# and user scopes. Dual scope keeps the server available for local development as well as
+# global use, but can be disabled (set to "false") to restrict installation to a single scope
+# or to avoid permission prompts on system-wide installs.
+MCP_INSTALL_DUAL_SCOPE=${MCP_INSTALL_DUAL_SCOPE:-true}
 MCP_STATS_LOCK_FILE=${MCP_STATS_LOCK_FILE:-"/tmp/${MCP_CLI_BIN}_mcp_stats.lock"}
 MCP_LOG_FILE_PREFIX=${MCP_LOG_FILE_PREFIX:-"/tmp/${MCP_CLI_BIN}_mcp"}
 MCP_BACKUP_PREFIX=${MCP_BACKUP_PREFIX:-${MCP_CLI_BIN}}
@@ -1783,8 +1795,23 @@ else
     FS_SERVER_DIRS=("$HOME/projects")
     wide_fs_enabled=false
     if [[ "${ALLOW_WIDE_FS:-false}" == "true" ]]; then
-        FS_SERVER_DIRS+=("/tmp" "$HOME")
-        wide_fs_enabled=true
+        if [[ "$TEST_MODE" == true ]] || [[ "${ALLOW_WIDE_FS_ASSUME_RISK:-false}" == "true" ]]; then
+            FS_SERVER_DIRS+=("/tmp" "$HOME")
+            wide_fs_enabled=true
+        elif [[ -t 0 ]]; then
+            echo -e "${YELLOW}⚠️  SECURITY WARNING: Granting filesystem server access to /tmp and \\$HOME can expose sensitive data, including SSH keys, browser profiles, and credentials. Proceed only if you understand these risks.${NC}"
+            read -r -p "Type YES to continue with wide filesystem access (or anything else to abort): " WIDE_FS_CONFIRM
+            if [[ "$WIDE_FS_CONFIRM" == "YES" ]]; then
+                FS_SERVER_DIRS+=("/tmp" "$HOME")
+                wide_fs_enabled=true
+            else
+                echo -e "${RED}Aborting: Wide filesystem access not confirmed.${NC}"
+                safe_exit 1
+            fi
+        else
+            echo -e "${RED}Wide filesystem access requires confirmation. Re-run with interactive input or set ALLOW_WIDE_FS_ASSUME_RISK=true to acknowledge the risk.${NC}"
+            safe_exit 1
+        fi
     fi
 
     allowed_dirs_display=$(printf "%s, " "${FS_SERVER_DIRS[@]}")
@@ -1821,7 +1848,7 @@ install_react_mcp
 display_step "Setting up WorldArchitect MCP Server..."
 TOTAL_SERVERS=$((TOTAL_SERVERS + 1))
 echo -e "${BLUE}  🎮 Configuring project MCP server for application mechanics...${NC}"
-log_with_timestamp "Setting up MCP server: worldarchitect (local: $PROJECT_ROOT/mcp_api.py)"
+log_with_timestamp "Setting up MCP server: worldarchitect (local: ${WORLDARCHITECT_MODULE_DIR}/mcp_api.py)"
 
 # Check if server already exists
 if server_already_exists "worldarchitect"; then
@@ -1831,7 +1858,7 @@ if server_already_exists "worldarchitect"; then
     SUCCESSFUL_INSTALLS=$((SUCCESSFUL_INSTALLS + 1))
 else
     # Get the absolute path to the WorldArchitect project
-    WORLDARCHITECT_MCP_PATH="$REPO_ROOT/$PROJECT_ROOT/mcp_api.py"
+    WORLDARCHITECT_MCP_PATH="$REPO_ROOT/$WORLDARCHITECT_MODULE_DIR/mcp_api.py"
     WORLDARCHITECT_PYTHON="$REPO_ROOT/venv/bin/python"
 
     # Check if mcp_api.py exists

--- a/.claude/scripts/mcp_dual_background.sh
+++ b/.claude/scripts/mcp_dual_background.sh
@@ -6,13 +6,18 @@ set -Eeuo pipefail
 trap 'echo "ERROR: mcp_dual_background.sh failed at line $LINENO" >&2' ERR
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORLDARCHITECT_MODULE_DIR_DEFAULT="${WORLDARCHITECT_MODULE_DIR:-}"
+if [[ -z "$WORLDARCHITECT_MODULE_DIR_DEFAULT" && -n "${PROJECT_ROOT:-}" ]]; then
+    WORLDARCHITECT_MODULE_DIR_DEFAULT="${PROJECT_ROOT}"
+fi
+WORLDARCHITECT_MODULE_DIR="${WORLDARCHITECT_MODULE_DIR_DEFAULT:-orchestration}"
 
 resolve_project_root() {
     local search_dir="$SCRIPT_DIR"
 
     # Walk up the directory tree until we find the repo assets we depend on
     while [[ "$search_dir" != "/" ]]; do
-        if [[ -f "$search_dir/scripts/setup_production_env.sh" && -f "$search_dir/$PROJECT_ROOT/mcp_api.py" ]]; then
+        if [[ -f "$search_dir/scripts/setup_production_env.sh" && -f "$search_dir/${WORLDARCHITECT_MODULE_DIR}/mcp_api.py" ]]; then
             echo "$search_dir"
             return 0
         fi
@@ -21,7 +26,7 @@ resolve_project_root() {
 
     if [[ -n "${WORLDARCHITECT_PROJECT_ROOT:-}" ]] && \
        [[ -f "${WORLDARCHITECT_PROJECT_ROOT}/scripts/setup_production_env.sh" && \
-          -f "${WORLDARCHITECT_PROJECT_ROOT}/$PROJECT_ROOT/mcp_api.py" ]]; then
+          -f "${WORLDARCHITECT_PROJECT_ROOT}/${WORLDARCHITECT_MODULE_DIR}/mcp_api.py" ]]; then
         echo "${WORLDARCHITECT_PROJECT_ROOT}"
         return 0
     fi
@@ -29,12 +34,12 @@ resolve_project_root() {
     return 1
 }
 
-PROJECT_ROOT="$(resolve_project_root)" || {
-    echo "ERROR: Unable to locate project root containing scripts/setup_production_env.sh and $PROJECT_ROOT/mcp_api.py" >&2
+REPO_ROOT="$(resolve_project_root)" || {
+    echo "ERROR: Unable to locate project root containing scripts/setup_production_env.sh and ${WORLDARCHITECT_MODULE_DIR}/mcp_api.py" >&2
     exit 1
 }
 
-SETUP_SCRIPT="$PROJECT_ROOT/scripts/setup_production_env.sh"
+SETUP_SCRIPT="$REPO_ROOT/scripts/setup_production_env.sh"
 if [[ -f "$SETUP_SCRIPT" ]]; then
     # shellcheck disable=SC1090
     source "$SETUP_SCRIPT"
@@ -47,7 +52,7 @@ fi
 
 echo "Starting MCP server in production mode (dual transport: stdio + HTTP)..." >&2
 
-PYTHON_BIN="$PROJECT_ROOT/venv/bin/python"
+PYTHON_BIN="$REPO_ROOT/venv/bin/python"
 if [[ ! -x "$PYTHON_BIN" ]]; then
     PYTHON_BIN="${PYTHON_EXEC:-python3}"
 fi
@@ -59,9 +64,9 @@ fi
 
 MCP_SERVER_PATH=""
 for candidate in \
-    "$PROJECT_ROOT/$PROJECT_ROOT/mcp_api.py" \
-    "$PROJECT_ROOT/src/mcp_api.py" \
-    "$PROJECT_ROOT/mcp_api.py"
+    "$REPO_ROOT/${WORLDARCHITECT_MODULE_DIR}/mcp_api.py" \
+    "$REPO_ROOT/src/mcp_api.py" \
+    "$REPO_ROOT/mcp_api.py"
 do
     if [[ -f "$candidate" ]]; then
         MCP_SERVER_PATH="$candidate"
@@ -70,14 +75,14 @@ do
 done
 
 if [[ -z "$MCP_SERVER_PATH" ]]; then
-    echo "ERROR: Unable to locate mcp_api.py under $PROJECT_ROOT" >&2
+    echo "ERROR: Unable to locate mcp_api.py under $REPO_ROOT" >&2
     exit 1
 fi
 
 if [[ -z "${PYTHONPATH:-}" ]]; then
-    export PYTHONPATH="$PROJECT_ROOT"
+    export PYTHONPATH="$REPO_ROOT"
 else
-    export PYTHONPATH="$PROJECT_ROOT:$PYTHONPATH"
+    export PYTHONPATH="$REPO_ROOT:$PYTHONPATH"
 fi
 
 # Securely create a named pipe for persistent stdin

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Node.js dependencies for Your Project automation scripts",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=16.0.0"
   },
   "dependencies": {
     "express": "^4.19.2"

--- a/scripts/secondo-cli.sh
+++ b/scripts/secondo-cli.sh
@@ -76,7 +76,8 @@ check_auth() {
 # Get authentication token
 get_token() {
   TOKEN=$(node scripts/auth-cli.mjs token 2>/dev/null)
-  if [ $? -ne 0 ] || [ -z "$TOKEN" ]; then
+  token_exit=$?
+  if [ $token_exit -ne 0 ] || [ -z "$TOKEN" ]; then
     error "Failed to get authentication token"
     return 1
   fi


### PR DESCRIPTION
## Summary
- Guard MCP bootstrap scripts against unset PROJECT_ROOT by deriving a shared WORLDARCHITECT_MODULE_DIR across the MCP installers and launchers, and reuse the safe_remove helper for dual-scope clean-up.
- Require explicit acknowledgement before enabling ALLOW_WIDE_FS=true and document dual-scope installation defaults, keeping the behaviour consistent in both exported and repo scripts.
- Relax the Node.js engine requirement to >=16 and add optional LOC_INCLUDE_LANGUAGES/LOC_INCLUDE_EXTS filtering so the LOC script only scans requested extensions.
- Capture the auth token command's exit code correctly in `scripts/secondo-cli.sh` to avoid false positives.

## Testing
- ./scripts/loc_simple.sh >/tmp/loc_output.txt

------
https://chatgpt.com/codex/tasks/task_e_68fd1bffef34832f98d4e0cc634d728f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden MCP scripts with module-dir based root resolution and safer wide-FS prompts, add optional LOC extension filtering, relax Node engine to >=16, and fix auth token exit-code capture.
> 
> - **Scripts — MCP installers/launchers**:
>   - Derive and use `WORLDARCHITECT_MODULE_DIR` to resolve `mcp_api.py` (replacing `PROJECT_ROOT` assumptions); switch to `REPO_ROOT` in launchers; update log paths.
>   - Add `safe_remove` and `safe_remove_dual_if_enabled`; handle `codex` scope differences for removes.
>   - Filesystem server: gate wide access to `/tmp` and `$HOME` behind explicit confirmation or `ALLOW_WIDE_FS_ASSUME_RISK=true`; abort when non-interactive; improved messages.
> - **LOC tooling**:
>   - Add `LOC_INCLUDE_LANGUAGES`/`LOC_INCLUDE_EXTS` filtering; case-insensitive extension handling; only scan requested extensions.
> - **Package**:
>   - Relax Node.js engine requirement to `>=16.0.0` in `package.json`.
> - **CLI**:
>   - Correctly capture auth token command exit code in `scripts/secondo-cli.sh`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9927759a4e0f2c189e4ea4b9f415a9e0c166552a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->