### PR TITLE
Claude Commands Export 2025-11-26: Directory Exclusions Applied

### DIFF
--- a/.claude/commands/exportcommands.md
+++ b/.claude/commands/exportcommands.md
@@ -504,6 +504,7 @@ testing_ui/
 testing_mcp/
 ci_replica/
 analysis/
+automation/
 claude-bot-commands/
 coding_prompts/
 prototype/

--- a/.claude/commands/exportcommands.md
+++ b/.claude/commands/exportcommands.md
@@ -504,7 +504,6 @@ testing_ui/
 testing_mcp/
 ci_replica/
 analysis/
-automation/
 claude-bot-commands/
 coding_prompts/
 prototype/

--- a/.claude/commands/pair-examples.md
+++ b/.claude/commands/pair-examples.md
@@ -123,7 +123,7 @@ ACTIONS:
 
 Bob implements:
 
-**File: `your_project/utils/validators.py`** (new file or addition)
+**File: `$PROJECT_ROOT/utils/validators.py`** (new file or addition)
 ```python
 import re
 
@@ -190,7 +190,7 @@ Alice runs automated audit:
 📊 AUTOMATED AUDIT RESULTS: PASS
 
 IMPLEMENTATION FILES:
-- your_project/utils/validators.py
+- $PROJECT_ROOT/utils/validators.py
 
 GIT DIFF:
 + def validate_email(email):
@@ -208,7 +208,7 @@ ACTIONS:
 **Phase 4: Merge (Alice)**
 
 ```bash
-$ git add your_project/utils/validators.py
+$ git add $PROJECT_ROOT/utils/validators.py
 $ git commit -m "Pair Protocol: Add email validation function
 
 Planner: alice
@@ -383,14 +383,14 @@ CHANGE ORDER DETAILS:
 
 🤖 AUTOMATED ANALYSIS:
 - Skill issue detected: boto3 library is already in dependencies
-- Existing code shows S3 usage in your_project/storage/s3_client.py
+- Existing code shows S3 usage in $PROJECT_ROOT/storage/s3_client.py
 - Builder should use existing S3 client utilities
 
 ACTIONS:
 - Type "REJECT CHANGE: Use existing S3 client" to send builder a strategy
 ```
 
-**User Response:** `REJECT CHANGE: Check your_project/storage/s3_client.py - we already have S3 utilities. Import get_s3_client() and use upload_file() method.`
+**User Response:** `REJECT CHANGE: Check $PROJECT_ROOT/storage/s3_client.py - we already have S3 utilities. Import get_s3_client() and use upload_file() method.`
 
 Alice sends `CHANGE_ORDER_REJECTED` with strategy.
 
@@ -404,7 +404,7 @@ from your_project.storage.s3_client import get_s3_client, upload_file
 def upload_profile_image(user_id, image_file):
     """Upload user profile image to S3"""
     s3_client = get_s3_client()
-    bucket = 'your-project-uploads'
+    bucket = 'your-bucket-name'
     key = f'profiles/{user_id}/avatar.jpg'
 
     # Upload to S3
@@ -514,7 +514,7 @@ Alice runs automated audit:
       "type": "integrity",
       "severity": "CRITICAL",
       "description": "Environment variable gaming detected: function returns True when TESTING env var is set, bypassing all business logic",
-      "location": "your_project/auth/admin.py:15"
+      "location": "$PROJECT_ROOT/auth/admin.py:15"
     }
   ],
   "notes": [

--- a/.claude/scripts/mcp_common.sh
+++ b/.claude/scripts/mcp_common.sh
@@ -40,7 +40,7 @@ if [[ -z "${MCP_BASH_REEXEC_DONE:-}" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # Allow callers to preconfigure behaviour while providing sensible defaults.
 TEST_MODE=${TEST_MODE:-false}

--- a/README.md
+++ b/README.md
@@ -880,6 +880,36 @@ The productivity gains available right now represent the largest arbitrage oppor
 
 ## 📚 Version History
 
+### v1.1.0 (2025-11-26)
+
+**Export Statistics**:
+- **193 Commands**: Complete workflow orchestration system
+- **43 Hooks**: Claude Code automation and workflow hooks
+- **19 Scripts**: Development and automation tools (scripts/ directory)
+- **21 Skills**: Shared knowledge references (.claude/skills/)
+
+**Major Changes**:
+- **Script Allowlist Expansion**: Added 12 generally useful development scripts to the scripts export
+- **Development Workflow Tools**: Now includes git workflow, code analysis, testing, and CI/CD scripts
+- **Enhanced Export Utility**: Broader coverage of reusable development infrastructure
+
+**New Scripts Included**:
+- **Git Workflow**: create_worktree.sh, push.sh for branch management
+- **Code Analysis**: codebase_loc.sh, loc.sh, loc_simple.sh for metrics
+- **Testing Utilities**: run_tests_with_coverage.sh, run_lint.sh
+- **CI/CD Tools**: setup-github-runner.sh, setup_email.sh
+- **Development Environment**: create_snapshot.sh, schedule_branch_work.sh
+
+**Technical Improvements**:
+- Expanded script_patterns list from 5 to 15 generally useful scripts
+- Better categorization of Claude Code specific vs universally useful tools
+- Enhanced documentation for script adaptability across projects
+
+**Documentation**:
+- Updated scripts export description
+- Clear separation between project-specific and generally useful scripts
+- Improved adaptation guidance for cross-project usage
+
 ### v1.1.0 (2025-11-25)
 
 **Export Statistics**:

--- a/automation/AUTOMATION_SAFETY_LIMITS.md
+++ b/automation/AUTOMATION_SAFETY_LIMITS.md
@@ -1,0 +1,172 @@
+# PR Automation Safety Limits & Configuration
+
+## 🚨 **Critical Safety Limits**
+
+The PR automation system has built-in safety mechanisms to prevent excessive API usage and maintain system stability:
+
+### **Primary Safety Limits**
+
+| Limit Type | Value | Purpose |
+|------------|-------|---------|
+| **Daily Run Limit** | 50 runs per day | Prevents excessive API usage, resets at midnight |
+| **Max Batch Size** | 5 PRs per run | Prevents overwhelming the system |
+| **Max Fix Attempts** | 3 attempts per PR | Prevents infinite retry loops |
+| **Run Frequency** | Every 10 minutes | Reasonable processing interval |
+| **Processing Timeout** | 20 minutes per PR | Prevents hanging processes |
+| **Cooldown Period** | 4 hours after success | Prevents duplicate processing |
+
+### **Daily Run Calculations**
+
+**When automation is enabled**, the system runs every 30 minutes with a **50 runs per day limit**:
+- **Maximum runs per day**: 50 runs (resets at midnight)
+- **PRs processed per day**: Maximum 250 PRs (50 runs × 5 PRs max per run)
+- **Actual scheduling**: Every 30 minutes (48 possible slots), but limited to 50 successful runs
+
+⚠️ **Practical limits are lower due to:**
+- Daily 50-run limit (automatic reset at midnight)
+- 4-hour cooldown between successful processing
+- 3-attempt limit before email notification and cooldown
+- Only processes PRs updated in last 24 hours
+- Skips already processed PRs within cooldown period
+
+### **Realistic Daily Processing**
+
+With safety mechanisms in effect:
+- **Daily run limit**: 50 runs maximum (resets at midnight)
+- **Active PRs per day**: Typically 5-15 PRs
+- **Actual processing attempts**: Up to 50 runs per day
+- **Successful completions**: ~10-25 PRs per day (depending on batch sizes)
+- **Failed PRs**: Stopped after 3 attempts, require manual intervention
+- **Auto-reset**: Counter resets to 0 at midnight daily
+
+## 🔧 **Configuration Details**
+
+### **File Locations**
+```bash
+# Configuration in script
+MAX_BATCH_SIZE=5        # PRs per run
+MAX_FIX_ATTEMPTS=3      # Attempts per PR
+COMMENT_TIMEOUT=1200    # 20 minutes per Codex comment attempt
+
+# Status tracking files
+/tmp/pr_automation_processed.txt    # Successfully processed PRs with timestamps
+/tmp/pr_fix_attempts.txt           # Failed attempt counters per PR
+/tmp/pr_automation.log             # Comprehensive activity log
+```
+
+### **Cron Configuration**
+```bash
+# ENABLED (processes every 10 minutes)
+*/10 * * * * cd ~/projects/your-project.com && ./automation/simple_pr_batch.sh >> /tmp/pr_automation.log 2>&1
+
+# DISABLED (commented out for safety)
+# */10 * * * * cd ~/projects/your-project.com/worktree_autofix && ./automation/simple_pr_batch.sh >> /tmp/pr_automation.log 2>&1
+```
+
+## ⚡ **Performance Impact**
+
+### **Resource Usage per Run**
+- **Memory**: Minimal (gh CLI comment invocation)
+- **Storage**: Negligible temporary data
+- **Network**: GitHub API call to post comment
+- **CPU**: Minimal during Codex comment posting (CLI invocation only)
+
+### **API Usage Limits**
+- **GitHub API**: Rate limited by GitHub (5000 requests/hour)
+- **Git Operations**: Limited by network bandwidth (light usage)
+
+## 🛡️ **Safety Mechanisms**
+
+### **Automatic Safeguards**
+1. **Batch Size Limiting**: Never processes more than 5 PRs per run
+2. **Attempt Limiting**: Stops after 3 failed attempts per PR
+3. **Timeout Protection**: Kills processes after 20 minutes
+4. **Cooldown Enforcement**: 4-hour delay between successful processing
+5. **Workspace Isolation**: Each PR processed in separate temporary directory
+6. **Automatic Cleanup**: Temporary workspaces removed after processing
+
+### **Failure Handling**
+1. **Email Notifications**: Sent when PR reaches 3 failed attempts
+2. **Graceful Degradation**: Continues with other PRs if one fails
+3. **Log Preservation**: All activity logged to `/tmp/pr_automation.log`
+4. **Status Tracking**: Maintains state between runs
+5. **Manual Override**: Can reset attempt counters or processed status
+
+## 🚨 **Emergency Controls**
+
+### **Disable Automation**
+```bash
+# Comment out cron job
+crontab -e
+# Add # at start of automation line
+
+# Or remove entirely
+crontab -l | grep -v "simple_pr_batch.sh" | crontab -
+```
+
+### **Reset All State**
+```bash
+# Clear all tracking files
+rm -f /tmp/pr_automation_processed.txt
+rm -f /tmp/pr_fix_attempts.txt
+rm -f /tmp/pr_automation.log
+
+# Clean up any remaining workspaces
+rm -rf /tmp/pr-automation-*
+```
+
+### **Manual Processing**
+```bash
+# Run manually for specific PR
+cd ~/projects/your-project.com
+./automation/simple_pr_batch.sh
+
+# Or trigger the orchestrator to post a Codex instruction for a specific PR
+# (see automation/JLEECHANORG_AUTOMATION.md for the /commentreply command summary)
+   /commentreply [PR_NUMBER] "$CODEX_COMMENT"
+```
+
+## 📊 **Monitoring**
+
+### **Check Status**
+```bash
+# View recent activity
+tail -20 /tmp/pr_automation.log
+
+# Check processed PRs
+cat /tmp/pr_automation_processed.txt
+
+# Check failed attempts
+cat /tmp/pr_fix_attempts.txt
+
+# Check active cron job
+crontab -l | grep automation
+```
+
+### **Health Indicators**
+- ✅ **Healthy**: 5-10 successful PR completions per day
+- ⚠️ **Warning**: Multiple PRs reaching 3 failed attempts
+- 🚨 **Critical**: No successful completions for >24 hours
+- 🔥 **Emergency**: Log file growing >100MB or excessive API errors
+
+## 🎯 **Recommendations**
+
+### **For Normal Operation**
+- Monitor logs weekly for failure patterns
+- Check email notifications for manual intervention needs
+- Verify automation is processing recent PRs appropriately
+
+### **For High Activity Periods**
+- Consider temporarily increasing cooldown period
+- Monitor API rate limit usage
+- Watch for excessive temporary workspace creation
+
+### **For Maintenance**
+- Disable automation during system updates
+- Clean up old log files periodically
+- Reset state files if corruption suspected
+
+---
+
+**Last Updated**: 2025-08-04
+**Automation Status**: Currently DISABLED for safety during system updates

--- a/automation/JLEECHANORG_AUTOMATION.md
+++ b/automation/JLEECHANORG_AUTOMATION.md
@@ -1,0 +1,286 @@
+# jleechanorg Cross-Organization PR Automation
+
+## 🎯 Overview
+
+A sophisticated automation system that monitors **ALL open PRs across the entire jleechanorg organization** using isolated worktrees and comprehensive safety limits.
+
+## 🏢 Organization Coverage
+
+**Monitors ALL repositories in jleechanorg:**
+- ai_universe (4 open PRs)
+- ai_universe_frontend (2 open PRs)
+- your-project.com (30 open PRs)
+- claude-commands (1 open PR)
+- projects_fake_repo (1 open PR)
+- ai_web_crawler (1 open PR)
+- claude-commands-deprecated (3 open PRs)
+- enhanced-claude-cli (1 open PR)
+- claude_llm_proxy (1 open PR)
+- **Total: 44 open PRs discovered**
+
+## 🔄 Worktree Isolation Architecture
+
+### Independent Processing
+Each PR gets its own isolated environment:
+
+```
+~/tmp/jleechanorg-pr-workspaces/
+├── ai_universe-pr-11/           # Isolated worktree for PR #11
+├── worldarchitect-ai-pr-1634/   # Isolated worktree for PR #1634
+├── claude-commands-pr-42/       # Isolated worktree for PR #42
+└── [repo-name]-pr-[number]/     # Pattern for all PRs
+```
+
+### Branch Management
+- **Existing Local Branch**: Checks out existing local branch
+- **Remote Branch Only**: Creates local branch tracking remote
+- **Automatic Sync**: Ensures remote target matches local branch
+- **Clean Workspace**: Fresh worktree per processing cycle
+
+## 🛡️ Enhanced Safety System
+
+### Multi-Level Protection
+1. **Per-PR Limits**: Max 5 attempts per `repo-pr` combination
+2. **Global Limits**: Max 50 total automation runs across all repos
+3. **Manual Approval**: Required after global limit reached
+4. **Email Notifications**: Automatic alerts at safety thresholds
+
+### Safety Tracking
+```bash
+# Check overall automation status
+python3 automation/automation_safety_manager.py --status
+
+# Example output:
+# Global runs: 23/50
+# Requires approval: False
+# Has approval: False
+# PR attempts:
+#   ai_universe-11: 2/5 (OK)
+#   worldarchitect-ai-1634: 1/5 (OK)
+#   claude-commands-42: 5/5 (BLOCKED)
+```
+
+## 🚀 Installation & Setup
+
+### Prerequisites
+```bash
+# GitHub CLI with organization access
+brew install gh
+gh auth login
+
+# Verify organization access
+gh repo list jleechanorg --limit 5
+```
+
+### Installation
+```bash
+# One-command setup
+./automation/install_jleechanorg_automation.sh
+
+# Verify service
+launchctl list | grep jleechanorg
+```
+
+## ⚙️ Processing Workflow
+
+### Discovery Phase (Every 10 minutes)
+1. **Organization Scan**: `gh repo list jleechanorg` discovers all repositories
+2. **PR Discovery**: `gh pr list --repo [repo]` finds open PRs per repository
+3. **Safety Check**: Validates global and per-PR attempt limits
+4. **Priority Queue**: Orders PRs for processing (max 10 per cycle)
+
+### Processing Phase (Per PR)
+1. **Worktree Creation**: `git worktree add [workspace] [branch]`
+2. **Branch Sync**: Ensures local branch tracks correct remote
+3. **Codex Instruction Comment**: Posts the Codex directive once per head commit, appending a hidden commit marker so future automation passes only re-request help after new commits are pushed.
+4. **Result Tracking**: Records success/failure for safety counters
+5. **Workspace Cleanup**: `git worktree remove [workspace]`
+
+### Safety Recording
+1. **Attempt Tracking**: Records success/failure per PR
+2. **Global Counter**: Tracks total automation runs
+3. **Limit Enforcement**: Blocks processing when limits reached
+4. **Notification System**: Emails when manual approval needed
+
+## 🔧 Configuration
+
+### Environment Variables
+```bash
+# Optional: Custom workspace location
+export PR_AUTOMATION_WORKSPACE=/custom/path/to/workspaces
+
+# Safety limits (defaults shown)
+export AUTOMATION_PR_LIMIT=5        # Max attempts per PR
+export AUTOMATION_GLOBAL_LIMIT=50   # Max total runs
+
+# Email notifications
+export SMTP_SERVER=smtp.gmail.com
+export SMTP_USERNAME=your_email@gmail.com
+export SMTP_PASSWORD=your_app_password
+export MEMORY_EMAIL_FROM=automation@jleechanorg.com
+export MEMORY_EMAIL_TO=admin@jleechanorg.com
+```
+
+### Schedule Modification
+Edit launchd plist for different intervals:
+```xml
+<!-- Every 5 minutes -->
+<key>StartInterval</key>
+<integer>300</integer>
+
+<!-- Every 30 minutes -->
+<key>StartInterval</key>
+<integer>1800</integer>
+```
+
+## 🧪 Testing & Validation
+
+### Dry Run Testing
+```bash
+# Test PR discovery only
+python3 automation/jleechanorg_pr_monitor.py --dry-run
+
+# Test specific repository
+python3 automation/jleechanorg_pr_monitor.py --dry-run --single-repo ai_universe
+
+# Limited PR testing
+python3 automation/jleechanorg_pr_monitor.py --dry-run --max-prs 3
+```
+
+### Live Processing
+```bash
+# Single manual run
+python3 automation/jleechanorg_pr_monitor.py
+
+# Monitor real-time
+tail -f ~/Library/Logs/worldarchitect-automation/jleechanorg_pr_monitor.log
+```
+
+## 📊 Monitoring & Management
+
+### Service Status
+```bash
+# Check service status
+launchctl list | grep jleechanorg
+
+# Recent automation logs
+tail -f ~/Library/Logs/worldarchitect-automation/jleechanorg_pr_monitor.log
+
+# Safety status across all repos
+python3 automation/automation_safety_manager.py --status
+```
+
+### Manual Intervention
+```bash
+# Grant approval for continued automation
+python3 automation/automation_safety_manager.py --approve admin@jleechanorg.com
+
+# Check specific PR can be processed
+python3 automation/automation_safety_manager.py --check-pr ai_universe-11
+
+# Reset PR attempts (if needed)
+python3 automation/automation_safety_manager.py --record-pr ai_universe-11 success
+```
+
+### Service Management
+```bash
+# Stop automation
+launchctl unload ~/Library/LaunchAgents/com.jleechanorg.pr-automation.plist
+
+# Start automation
+launchctl load ~/Library/LaunchAgents/com.jleechanorg.pr-automation.plist
+
+# Restart automation
+launchctl unload ~/Library/LaunchAgents/com.jleechanorg.pr-automation.plist
+launchctl load ~/Library/LaunchAgents/com.jleechanorg.pr-automation.plist
+```
+
+## 🔍 Troubleshooting
+
+### Common Issues
+
+**No PRs Discovered**
+```bash
+# Check GitHub authentication
+gh auth status
+
+# Verify organization access
+gh repo list jleechanorg --limit 1
+
+# Check network connectivity
+curl -s https://api.github.com/orgs/jleechanorg
+```
+
+**Worktree Creation Fails**
+```bash
+# Check local repository exists
+ls ~/projects/[repo-name]
+
+# Verify git repository
+cd ~/projects/[repo-name] && git status
+
+# Clean stale worktrees
+git worktree prune
+```
+
+**Safety Limits Reached**
+```bash
+# Check current status
+python3 automation/automation_safety_manager.py --status
+
+# Grant manual approval
+python3 automation/automation_safety_manager.py --approve admin@email.com
+
+# Reset specific PR if needed
+python3 automation/automation_safety_manager.py --record-pr [repo-pr] success
+```
+
+### Log Analysis
+```bash
+# Service logs
+cat ~/Library/Logs/worldarchitect-automation/jleechanorg-launchd.out
+cat ~/Library/Logs/worldarchitect-automation/jleechanorg-launchd.err
+
+# Application logs
+tail -100 ~/Library/Logs/worldarchitect-automation/jleechanorg_pr_monitor.log
+
+# Safety manager logs
+grep "automation_safety_manager" ~/Library/Logs/worldarchitect-automation/*.log
+```
+
+## 🎯 Key Features
+
+### ✅ **Cross-Organization Coverage**
+- Automatically discovers ALL repositories in jleechanorg
+- Processes open PRs across multiple projects simultaneously
+- No manual repository configuration required
+
+### ✅ **Worktree Isolation**
+- Each PR processed in completely isolated environment
+- Prevents conflicts between simultaneous PR processing
+- Automatic workspace cleanup after processing
+
+### ✅ **Intelligent Branch Management**
+- Detects existing local branches vs remote-only branches
+- Creates appropriate local tracking branches automatically
+- Syncs with correct remote targets
+
+### ✅ **Comprehensive Safety**
+- Per-PR attempt limits prevent infinite retry loops
+- Global run limits prevent automation runaway
+- Manual approval system for oversight
+- Email notifications at safety thresholds
+
+### ✅ **macOS Native Integration**
+- launchd service for reliable scheduling
+- Proper environment variable handling
+- User session awareness
+- Automatic restart on failure
+
+### ✅ **Production Ready**
+- Comprehensive error handling and logging
+- Timeout protection for long-running processes
+- Resource limits and process management
+- Graceful degradation on failures
+
+This system provides enterprise-grade automation for the entire jleechanorg organization while maintaining safety, isolation, and reliability.

--- a/automation/README.md
+++ b/automation/README.md
@@ -1,0 +1,364 @@
+# jleechanorg-pr-automation
+
+A comprehensive GitHub PR automation system with safety limits, actionable counting, and intelligent filtering.
+
+## Features
+
+- **Actionable PR Counting**: Only processes PRs that need attention, excluding already-processed ones
+- **Safety Limits**: Built-in rate limiting and attempt tracking to prevent automation abuse
+- **Cross-Process Safety**: Thread-safe operations with file-based persistence
+- **Email Notifications**: Optional SMTP integration for automation alerts
+- **Commit-Based Tracking**: Avoids duplicate processing using commit SHAs
+- **Comprehensive Testing**: 200+ test cases with matrix-driven coverage
+
+## Installation
+
+```bash
+pip install jleechanorg-pr-automation
+```
+
+### Optional Dependencies
+
+For email notifications:
+```bash
+pip install jleechanorg-pr-automation[email]
+```
+
+For development:
+```bash
+pip install jleechanorg-pr-automation[dev]
+```
+
+## Quick Start
+
+### Basic PR Monitoring
+
+```python
+from jleechanorg_pr_automation import JleechanorgPRMonitor
+
+# Initialize monitor
+monitor = JleechanorgPRMonitor()
+
+# Process up to 20 actionable PRs
+result = monitor.run_monitoring_cycle_with_actionable_count(target_actionable_count=20)
+
+print(f"Processed {result['actionable_processed']} actionable PRs")
+print(f"Skipped {result['skipped_count']} non-actionable PRs")
+```
+
+### Safety Management
+
+```python
+from jleechanorg_pr_automation import AutomationSafetyManager
+
+# Initialize safety manager with data directory
+safety = AutomationSafetyManager(data_dir="/tmp/automation_safety")
+
+# Limits are configured via automation_safety_config.json inside the data directory
+# or the AUTOMATION_PR_LIMIT / AUTOMATION_GLOBAL_LIMIT environment variables.
+
+# Check if PR can be processed
+if safety.can_process_pr(pr_number=123, repo="my-repo"):
+    # Process PR...
+    safety.record_pr_attempt(pr_number=123, result="success", repo="my-repo")
+```
+
+## Configuration
+
+### Environment Variables
+
+- `GITHUB_TOKEN`: GitHub personal access token (required)
+- `PR_AUTOMATION_WORKSPACE`: Custom workspace directory (optional)
+- `AUTOMATION_PR_LIMIT`: Maximum attempts per PR (default: 5)
+- `AUTOMATION_GLOBAL_LIMIT`: Maximum global automation runs (default: 50)
+- `AUTOMATION_APPROVAL_HOURS`: Hours before approval expires (default: 24)
+
+### Email Configuration (Optional)
+
+- `SMTP_SERVER`: SMTP server hostname
+- `SMTP_PORT`: SMTP server port (default: 587)
+- `EMAIL_USER`: SMTP username
+- `EMAIL_PASS`: SMTP password
+- `EMAIL_TO`: Notification recipient
+- `EMAIL_FROM`: Sender address (defaults to EMAIL_USER)
+
+## Command Line Interface
+
+### PR Monitor
+
+```bash
+# Monitor all repositories
+jleechanorg-pr-monitor
+
+# Process specific repository
+jleechanorg-pr-monitor --single-repo your-project.com
+
+# Process specific PR
+jleechanorg-pr-monitor --target-pr 123 --target-repo jleechanorg/your-project.com
+
+# Dry run (discovery only)
+jleechanorg-pr-monitor --dry-run
+```
+
+### Safety Manager CLI
+
+```bash
+# Check current status
+automation-safety-cli status
+
+# Clear all safety data
+automation-safety-cli clear
+
+# Check specific PR
+automation-safety-cli check-pr 123 --repo my-repo
+```
+
+## Architecture
+
+### Actionable PR Logic
+
+The system implements intelligent PR filtering:
+
+1. **State Check**: Only processes open PRs
+2. **Commit Tracking**: Skips PRs already processed with current commit SHA
+3. **Safety Limits**: Respects per-PR and global automation limits
+4. **Ordering**: Processes most recently updated PRs first
+
+### Safety Features
+
+- **Dual Limiting**: Per-PR consecutive failure limits + global run limits
+- **Cross-Process Safety**: File-based locking for concurrent automation instances
+- **Attempt Tracking**: Full history of success/failure with timestamps
+- **Graceful Degradation**: Continues processing other PRs if one fails
+
+### Testing
+
+The library includes comprehensive test coverage:
+
+- **Matrix Testing**: All PR state combinations (Open/Closed × New/Old Commits × Processed/Fresh)
+- **Actionable Counting**: Batch processing with skip exclusion
+- **Safety Limits**: Concurrent access and edge cases
+- **Integration Tests**: Real GitHub API interactions (optional)
+
+## Development
+
+```bash
+# Clone repository
+git clone https://github.com/jleechanorg/your-project.com.git
+cd your-project.com/automation
+
+# Install in development mode
+pip install -e .[dev]
+
+# Run tests
+pytest
+
+# Run tests with coverage
+pytest --cov=jleechanorg_pr_automation
+
+# Format code
+black .
+ruff check .
+```
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Add tests for new functionality
+4. Ensure all tests pass
+5. Submit a pull request
+
+## Claude Code Integration
+
+### Slash Command Plugin
+
+This automation system is integrated with Claude Code through a custom slash command plugin located at `.claude/commands/automation.md`. This allows seamless PR automation directly from your Claude Code sessions.
+
+#### Installation
+
+**Option 1: Via `/exportcommands` (Recommended)**
+
+If you're using the Your Project command system, the automation command is automatically exported:
+
+```bash
+/exportcommands
+```
+
+**Option 2: Manual Installation**
+
+Copy the automation command from this repository to your Claude Code commands directory:
+
+```bash
+# From the your-project.com repository root
+# For project-specific installation
+cp .claude/commands/automation.md <your-project>/.claude/commands/
+
+# For user-wide installation (available across all projects)
+cp .claude/commands/automation.md ~/.claude/commands/
+```
+
+#### Usage in Claude Code
+
+Once installed, you can use the `/automation` command directly in Claude Code:
+
+```bash
+# Check automation status
+/automation status
+
+# Process PRs for a specific repository
+/automation monitor your-project.com
+
+# Process a specific PR
+/automation process 123 --repo jleechanorg/your-project.com
+
+# Check safety limits and configuration
+/automation safety check
+
+# Clear safety data (resets limits)
+/automation safety clear
+```
+
+#### Features Available Through Claude Code
+
+- **PR Monitoring**: Automatically discover and process actionable PRs
+- **Safety Management**: Built-in safety limits prevent automation abuse
+- **Actionable Counting**: Only processes PRs that need attention
+- **Cross-Process Safety**: Thread-safe operations with file-based persistence
+- **Email Notifications**: Optional SMTP integration for automation alerts
+
+#### Configuration for Claude Code
+
+The automation system uses environment variables for configuration. Set these in your shell profile or `.env` file:
+
+```bash
+# Required
+export GITHUB_TOKEN="your_github_token_here"
+
+# Optional - Customize safety limits
+export AUTOMATION_PR_LIMIT=5           # Max attempts per PR (default: 5)
+export AUTOMATION_GLOBAL_LIMIT=50      # Max global runs (default: 50)
+export AUTOMATION_APPROVAL_HOURS=24    # Approval expiry (default: 24)
+
+# Optional - Custom workspace
+export PR_AUTOMATION_WORKSPACE="/custom/path"
+
+# Optional - Email notifications
+export SMTP_SERVER="smtp.gmail.com"
+export SMTP_PORT=587
+export EMAIL_USER="your-email@gmail.com"
+export EMAIL_PASS="your-app-password"
+export EMAIL_TO="recipient@example.com"
+```
+
+#### Plugin Architecture
+
+The automation plugin follows Claude Code's plugin architecture:
+
+- **Slash Commands**: `.claude/commands/automation.md` - Main automation interface
+- **Hooks Integration**: Can be triggered via Claude Code hooks for automated workflows
+- **MCP Integration**: Compatible with Memory MCP for learning from automation patterns
+- **TodoWrite Integration**: Tracks automation tasks in Claude Code's todo system
+
+#### Advanced: Automation Hooks
+
+You can create Claude Code hooks to automatically trigger PR automation:
+
+**Example: Post-Push Hook** (`.claude/hooks/post-push.sh`)
+
+```bash
+#!/bin/bash
+# Automatically check for PRs after pushing
+
+# Get current repo and branch
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+BRANCH=$(git branch --show-current)
+
+# Check if there's an open PR for this branch
+PR_NUMBER=$(gh pr list --head "$BRANCH" --json number -q '.[0].number')
+
+if [[ -n "$PR_NUMBER" ]]; then
+    echo "🤖 PR #$PR_NUMBER detected - triggering automation check"
+    jleechanorg-pr-monitor --target-pr "$PR_NUMBER" --target-repo "$REPO"
+fi
+```
+
+**Example: Scheduled Monitoring** (Cron Job)
+
+```bash
+# Add to crontab for hourly PR monitoring
+0 * * * * cd $(git rev-parse --show-toplevel) && jleechanorg-pr-monitor
+```
+
+#### Slash Command Documentation
+
+The `/automation` slash command provides a multi-phase execution workflow:
+
+**Phase 0: Preflight Installation & Token Check**
+- Verifies `jleechanorg-pr-automation` package is installed
+- Checks GitHub token environment variable
+- Validates dependencies before execution
+
+**Phase 1: Parse Action and Arguments**
+- Extracts action (status, monitor, process, safety) from command
+- Validates action type and parameters
+- Sets defaults for missing values
+
+**Phase 2: STATUS Action** - `/automation status`
+- Displays global automation runs vs limits
+- Shows per-PR attempt counts
+- Reports safety configuration and active PRs
+
+**Phase 3: MONITOR Action** - `/automation monitor [repository]`
+- Discovers and processes actionable PRs
+- Respects safety limits
+- Reports results and skip reasons
+
+**Phase 4: PROCESS Action** - `/automation process <pr_number> --repo <repository>`
+- Processes a specific PR
+- Initializes safety manager
+- Records attempt results
+
+**Phase 5: SAFETY Action** - `/automation safety <subaction>`
+- `check`: Display safety limits and status
+- `clear`: Reset all safety data (with warning)
+- `check-pr`: Check specific PR's processability
+
+**Phase 6: TodoWrite Integration**
+- Tracks complex operations as todo items
+- Updates progress in real-time
+- Maintains error context
+
+For complete execution workflow details, see `.claude/commands/automation.md` in this repository.
+
+#### Plugin Export
+
+When you run `/exportcommands`, the automation slash command (`.claude/commands/automation.md`) is automatically included in the export to the `jleechanorg/claude-commands` repository. This allows others to install the automation plugin in their Claude Code environments.
+
+The export process:
+1. Copies `.claude/commands/automation.md` to the commands export
+2. Includes automation documentation in the exported README
+3. Provides installation instructions for end users
+4. Transforms project-specific paths to generic placeholders
+
+## License
+
+MIT License - see LICENSE file for details.
+
+## Changelog
+
+### 0.1.1 (2025-10-06)
+
+- Fix daily reset of global automation limit so automation never stalls overnight
+- Track latest reset timestamp in safety data for observability
+- Expand safety manager tests to cover daily rollover behaviour
+
+### 0.1.0 (2025-09-28)
+
+- Initial release
+- Actionable PR counting system
+- Safety management with dual limits
+- Cross-process file-based persistence
+- Email notification support
+- Comprehensive test suite (200+ tests)
+- CLI interfaces for monitoring and safety management

--- a/automation/cron_entry.txt
+++ b/automation/cron_entry.txt
@@ -1,0 +1,2 @@
+# Run jleechanorg PR automation every hour via private registry monitor
+0 * * * * . $HOME/.token && $HOME/.pyenv/versions/3.11.10/bin/python3 -m jleechanorg_pr_automation.jleechanorg_pr_monitor >> $HOME/Library/Logs/worldarchitect-automation/jleechanorg_pr_monitor.log 2>&1

--- a/automation/install_cron_entries.sh
+++ b/automation/install_cron_entries.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s extglob
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CRON_FILE="$SCRIPT_DIR/cron_entry.txt"
+
+if ! command -v crontab >/dev/null 2>&1; then
+    echo "crontab command not found; install cron before running this script" >&2
+    exit 1
+fi
+
+if [[ ! -f "$CRON_FILE" ]]; then
+    echo "Cron template not found at $CRON_FILE" >&2
+    exit 1
+fi
+
+TEMP_CRON=$(mktemp)
+trap 'rm -f "$TEMP_CRON"' EXIT
+
+if ! crontab -l >"$TEMP_CRON" 2>/dev/null; then
+    : >"$TEMP_CRON"
+fi
+
+added=0
+pending_comments=""
+while IFS= read -r line || [[ -n "$line" ]]; do
+    trimmed_leading="${line##+([[:space:]])}"
+    if [[ -z "${line//[[:space:]]/}" ]]; then
+        pending_comments=""
+        continue
+    fi
+
+    if [[ -n "$trimmed_leading" && "${trimmed_leading:0:1}" == "#" ]]; then
+        if [[ -z "$pending_comments" ]]; then
+            pending_comments="$line"
+        else
+            pending_comments+=$'\n'"$line"
+        fi
+        continue
+    fi
+
+    if grep -Fx -- "$line" "$TEMP_CRON" >/dev/null; then
+        pending_comments=""
+        continue
+    fi
+
+    if [[ -n "$pending_comments" ]]; then
+        printf '%s\n' "$pending_comments" >>"$TEMP_CRON"
+        pending_comments=""
+    fi
+
+    printf '%s\n' "$line" >>"$TEMP_CRON"
+    added=1
+
+done <"$CRON_FILE"
+
+if [[ $added -eq 1 ]]; then
+    crontab "$TEMP_CRON"
+    echo "Installed missing cron entries from $CRON_FILE"
+else
+    echo "Cron entries already present; no changes made"
+fi

--- a/automation/install_jleechanorg_automation.sh
+++ b/automation/install_jleechanorg_automation.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 PLIST_SOURCE="$SCRIPT_DIR/com.jleechanorg.pr-automation.plist"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.jleechanorg.pr-automation.plist"
-LOG_DIR="$HOME/Library/Logs/worldarchitect-automation"
+LOG_DIR="$HOME/Library/Logs/jleechanorg-automation"
 
 echo "🚀 Installing jleechanorg PR Automation for macOS"
 echo "   🏢 Organization: jleechanorg (all repositories)"
@@ -60,9 +60,10 @@ echo "   Logs: $LOG_DIR"
 # Update plist with correct paths and user
 echo "🔧 Configuring launchd service..."
 CURRENT_USER=$(whoami)
-sed "s|/Users/$USER/projects/worktree_worker2|$PROJECT_ROOT|g" "$PLIST_SOURCE" | \
+ESCAPED_TOKEN=$(printf '%s\n' "${GITHUB_TOKEN:-}" | sed 's/[&/\\]/\\&/g')
+sed "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" "$PLIST_SOURCE" | \
 sed "s|$USER|$CURRENT_USER|g" | \
-sed "s|\\$GITHUB_TOKEN|$GITHUB_TOKEN|g" > "$PLIST_DEST"
+sed "s|\\\$GITHUB_TOKEN|$ESCAPED_TOKEN|g" > "$PLIST_DEST"
 
 echo "📄 Created plist: $PLIST_DEST"
 

--- a/automation/install_jleechanorg_automation.sh
+++ b/automation/install_jleechanorg_automation.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install jleechanorg PR automation for macOS
+# This script sets up comprehensive cross-organization PR monitoring
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PLIST_SOURCE="$SCRIPT_DIR/com.jleechanorg.pr-automation.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.jleechanorg.pr-automation.plist"
+LOG_DIR="$HOME/Library/Logs/worldarchitect-automation"
+
+echo "🚀 Installing jleechanorg PR Automation for macOS"
+echo "   🏢 Organization: jleechanorg (all repositories)"
+echo "   ⏰ Schedule: Every 10 minutes"
+echo "   🛡️ Safety: Max 5 attempts per PR, 50 total runs"
+echo "   🔄 Isolation: Individual worktrees per PR"
+
+# Check prerequisites
+echo ""
+echo "🔍 Checking prerequisites..."
+
+# Check GitHub CLI
+if ! command -v gh &> /dev/null; then
+    echo "❌ GitHub CLI (gh) not found. Install with: brew install gh"
+    exit 1
+fi
+
+# Check GitHub authentication
+if ! gh auth status &> /dev/null; then
+    echo "❌ GitHub CLI not authenticated. Run: gh auth login"
+    exit 1
+fi
+
+# Check organization access
+if ! gh repo list jleechanorg --limit 1 &> /dev/null; then
+    echo "❌ Cannot access jleechanorg organization. Check permissions."
+    exit 1
+fi
+
+echo "✅ GitHub CLI authenticated and organization accessible"
+
+# Check Python and required modules
+if ! python3 -c "import json, subprocess, pathlib" &> /dev/null; then
+    echo "❌ Python3 missing required modules"
+    exit 1
+fi
+
+echo "✅ Python3 environment ready"
+
+# Create workspace directories
+WORKSPACE_BASE="$HOME/tmp/jleechanorg-pr-workspaces"
+mkdir -p "$WORKSPACE_BASE"
+mkdir -p "$LOG_DIR"
+
+echo "📁 Created directories:"
+echo "   Workspaces: $WORKSPACE_BASE"
+echo "   Logs: $LOG_DIR"
+
+# Update plist with correct paths and user
+echo "🔧 Configuring launchd service..."
+CURRENT_USER=$(whoami)
+sed "s|/Users/$USER/projects/worktree_worker2|$PROJECT_ROOT|g" "$PLIST_SOURCE" | \
+sed "s|$USER|$CURRENT_USER|g" | \
+sed "s|\\$GITHUB_TOKEN|$GITHUB_TOKEN|g" > "$PLIST_DEST"
+
+echo "📄 Created plist: $PLIST_DEST"
+
+# Make scripts executable
+chmod +x "$SCRIPT_DIR/jleechanorg_pr_automation/jleechanorg_pr_monitor.py"
+chmod +x "$SCRIPT_DIR/jleechanorg_pr_automation/automation_safety_manager.py"
+echo "🔐 Made scripts executable"
+
+# Unload existing job if running
+echo "🔄 Managing launchd service..."
+if launchctl list | grep -q "com.jleechanorg.pr-automation"; then
+    echo "   Unloading existing service..."
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+fi
+
+# Also unload old worldarchitect service if it exists
+OLD_PLIST="$HOME/Library/LaunchAgents/com.worldarchitect.pr-automation.plist"
+if [[ -f "$OLD_PLIST" ]] && launchctl list | grep -q "com.worldarchitect.pr-automation"; then
+    echo "   Unloading old worldarchitect service..."
+    launchctl unload "$OLD_PLIST" 2>/dev/null || true
+fi
+
+# Load the new job
+echo "   Loading jleechanorg automation service..."
+launchctl load "$PLIST_DEST"
+
+# Verify it's loaded
+sleep 2
+if launchctl list | grep -q "com.jleechanorg.pr-automation"; then
+    echo "✅ Automation service loaded successfully!"
+else
+    echo "❌ Failed to load automation service"
+    echo "Check logs: cat $LOG_DIR/jleechanorg-launchd.err"
+    exit 1
+fi
+
+# Test discovery functionality
+echo ""
+echo "🧪 Testing PR discovery..."
+if python3 "$SCRIPT_DIR/jleechanorg_pr_monitor.py" --dry-run --max-prs 5; then
+    echo "✅ PR discovery test successful"
+else
+    echo "⚠️ PR discovery test failed - check configuration"
+fi
+
+echo ""
+echo "🎯 Installation Complete!"
+echo ""
+echo "📊 Service Configuration:"
+echo "   • Organization: jleechanorg (all repositories)"
+echo "   • Schedule: Every 10 minutes"
+echo "   • Workspace: $WORKSPACE_BASE"
+echo "   • Logs: $LOG_DIR"
+echo ""
+echo "🛡️ Safety Features:"
+echo "   • PR Limits: 5 attempts per PR before blocking"
+echo "   • Global Limits: 50 total runs before manual approval"
+echo "   • Worktree Isolation: Each PR processed in separate workspace"
+echo "   • Email Notifications: Automatic alerts at limits"
+echo ""
+echo "🔧 Management Commands:"
+echo "   • Status: launchctl list | grep jleechanorg"
+echo "   • Stop: launchctl unload '$PLIST_DEST'"
+echo "   • Start: launchctl load '$PLIST_DEST'"
+echo "   • Logs: tail -f '$LOG_DIR/jleechanorg_pr_monitor.log'"
+echo ""
+echo "🧪 Manual Testing:"
+echo "   • Dry run: python3 '$SCRIPT_DIR/jleechanorg_pr_monitor.py' --dry-run"
+echo "   • Single repo: python3 '$SCRIPT_DIR/jleechanorg_pr_monitor.py' --dry-run --single-repo repo-name"
+echo "   • Safety status: python3 '$SCRIPT_DIR/automation_safety_manager.py' --status"
+echo ""
+echo "💡 Grant manual approval when needed:"
+echo "   python3 '$SCRIPT_DIR/automation_safety_manager.py' --approve user@example.com"
+echo ""
+echo "🔍 Monitor real-time activity:"
+echo "   tail -f '$LOG_DIR/jleechanorg_pr_monitor.log'"

--- a/automation/install_jleechanorg_automation.sh
+++ b/automation/install_jleechanorg_automation.sh
@@ -102,7 +102,7 @@ fi
 # Test discovery functionality
 echo ""
 echo "🧪 Testing PR discovery..."
-if python3 "$SCRIPT_DIR/jleechanorg_pr_monitor.py" --dry-run --max-prs 5; then
+if python3 "$SCRIPT_DIR/jleechanorg_pr_automation/jleechanorg_pr_monitor.py" --dry-run --max-prs 5; then
     echo "✅ PR discovery test successful"
 else
     echo "⚠️ PR discovery test failed - check configuration"
@@ -130,12 +130,12 @@ echo "   • Start: launchctl load '$PLIST_DEST'"
 echo "   • Logs: tail -f '$LOG_DIR/jleechanorg_pr_monitor.log'"
 echo ""
 echo "🧪 Manual Testing:"
-echo "   • Dry run: python3 '$SCRIPT_DIR/jleechanorg_pr_monitor.py' --dry-run"
-echo "   • Single repo: python3 '$SCRIPT_DIR/jleechanorg_pr_monitor.py' --dry-run --single-repo repo-name"
-echo "   • Safety status: python3 '$SCRIPT_DIR/automation_safety_manager.py' --status"
+echo "   • Dry run: python3 '$SCRIPT_DIR/jleechanorg_pr_automation/jleechanorg_pr_monitor.py' --dry-run"
+echo "   • Single repo: python3 '$SCRIPT_DIR/jleechanorg_pr_automation/jleechanorg_pr_monitor.py' --dry-run --single-repo repo-name"
+echo "   • Safety status: python3 '$SCRIPT_DIR/jleechanorg_pr_automation/automation_safety_manager.py' --status"
 echo ""
 echo "💡 Grant manual approval when needed:"
-echo "   python3 '$SCRIPT_DIR/automation_safety_manager.py' --approve user@example.com"
+echo "   python3 '$SCRIPT_DIR/jleechanorg_pr_automation/automation_safety_manager.py' --approve user@example.com"
 echo ""
 echo "🔍 Monitor real-time activity:"
 echo "   tail -f '$LOG_DIR/jleechanorg_pr_monitor.log'"

--- a/automation/install_launchd_automation.sh
+++ b/automation/install_launchd_automation.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 PLIST_SOURCE="$SCRIPT_DIR/com.worldarchitect.pr-automation.plist"
 PLIST_DEST="$HOME/Library/LaunchAgents/com.worldarchitect.pr-automation.plist"
-LOG_DIR="$HOME/Library/Logs/worldarchitect-automation"
+LOG_DIR="$HOME/Library/Logs/jleechanorg-automation"
 
 echo "🚀 Installing WorldArchitect PR Automation for macOS"
 echo "   Project: $PROJECT_ROOT"
@@ -20,7 +20,7 @@ echo "📁 Created log directory: $LOG_DIR"
 
 # Update plist with correct paths
 echo "🔧 Updating plist paths..."
-sed "s|/Users/$USER/projects/worktree_worker2|$PROJECT_ROOT|g" "$PLIST_SOURCE" > "$PLIST_DEST"
+sed "s|__PROJECT_ROOT__|$PROJECT_ROOT|g" "$PLIST_SOURCE" > "$PLIST_DEST"
 
 # Update username in plist
 CURRENT_USER=$(whoami)

--- a/automation/install_launchd_automation.sh
+++ b/automation/install_launchd_automation.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install launchd automation for macOS PR processing
+# This script sets up the safety-wrapped automation system
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+PLIST_SOURCE="$SCRIPT_DIR/com.worldarchitect.pr-automation.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.worldarchitect.pr-automation.plist"
+LOG_DIR="$HOME/Library/Logs/worldarchitect-automation"
+
+echo "🚀 Installing WorldArchitect PR Automation for macOS"
+echo "   Project: $PROJECT_ROOT"
+echo "   Safety: Max 5 attempts per PR, 50 total runs before approval"
+
+# Create log directory
+mkdir -p "$LOG_DIR"
+echo "📁 Created log directory: $LOG_DIR"
+
+# Update plist with correct paths
+echo "🔧 Updating plist paths..."
+sed "s|/Users/$USER/projects/worktree_worker2|$PROJECT_ROOT|g" "$PLIST_SOURCE" > "$PLIST_DEST"
+
+# Update username in plist
+CURRENT_USER=$(whoami)
+sed -i '' "s|$USER|$CURRENT_USER|g" "$PLIST_DEST"
+
+echo "📄 Installed plist: $PLIST_DEST"
+
+# Secure plist file permissions (contains GITHUB_TOKEN)
+chmod 600 "$PLIST_DEST"
+echo "🔒 Set restrictive permissions on plist (chmod 600)"
+
+# Make scripts executable
+chmod +x "$SCRIPT_DIR/jleechanorg_pr_automation/automation_safety_wrapper.py"
+chmod +x "$SCRIPT_DIR/jleechanorg_pr_automation/automation_safety_manager.py"
+chmod +x "$SCRIPT_DIR/simple_pr_batch.sh"
+echo "🔐 Made scripts executable"
+
+# Unload existing job if running
+if launchctl list | grep -q "com.worldarchitect.pr-automation"; then
+    echo "🔄 Unloading existing automation job..."
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+fi
+
+# Load the new job
+echo "⚡ Loading automation job..."
+launchctl load "$PLIST_DEST"
+
+# Verify it's loaded
+if launchctl list | grep -q "com.worldarchitect.pr-automation"; then
+    echo "✅ Automation job loaded successfully!"
+else
+    echo "❌ Failed to load automation job"
+    exit 1
+fi
+
+echo ""
+echo "🎯 Installation Complete!"
+echo ""
+echo "📊 Configuration:"
+echo "   • Schedule: Every 10 minutes"
+echo "   • PR Limit: 5 attempts per PR"
+echo "   • Global Limit: 50 total runs"
+echo "   • Safety Wrapper: automation_safety_wrapper.py"
+echo "   • Logs: $LOG_DIR"
+echo ""
+echo "🔧 Management Commands:"
+echo "   • Status: launchctl list | grep worldarchitect"
+echo "   • Stop: launchctl unload '$PLIST_DEST'"
+echo "   • Start: launchctl load '$PLIST_DEST'"
+echo "   • Logs: tail -f '$LOG_DIR/automation_safety.log'"
+echo ""
+echo "🚨 Safety Features:"
+echo "   • Automatic email notifications at limits"
+echo "   • Manual approval required after 50 runs"
+echo "   • Thread-safe PR attempt tracking"
+echo "   • 1-hour timeout per automation cycle"
+echo ""
+echo "💡 Grant manual approval when needed:"
+echo "   python3 '$SCRIPT_DIR/jleechanorg_pr_automation/automation_safety_manager.py' --approve user@example.com"
+echo ""
+echo "📈 Check status:"
+echo "   python3 '$SCRIPT_DIR/jleechanorg_pr_automation/automation_safety_manager.py' --status"

--- a/automation/jleechanorg_pr_automation/__init__.py
+++ b/automation/jleechanorg_pr_automation/__init__.py
@@ -17,8 +17,8 @@ from .utils import (
 )
 
 __version__ = "0.1.2"
-__author__ = "$USER"
-__email__ = "jlee@$USER.org"
+__author__ = "automation-user"
+__email__ = "automation@example.com"
 
 __all__ = [
     "AutomationSafetyManager",

--- a/automation/jleechanorg_pr_automation/__init__.py
+++ b/automation/jleechanorg_pr_automation/__init__.py
@@ -1,0 +1,32 @@
+"""
+jleechanorg-pr-automation: GitHub PR automation system with safety limits and actionable counting.
+
+This package provides comprehensive PR monitoring and automation capabilities with built-in
+safety features, intelligent filtering, and cross-process synchronization.
+"""
+
+from .automation_safety_manager import AutomationSafetyManager
+from .jleechanorg_pr_monitor import JleechanorgPRMonitor
+from .utils import (
+    SafeJSONManager,
+    get_automation_limits,
+    get_email_config,
+    json_manager,
+    setup_logging,
+    validate_email_config,
+)
+
+__version__ = "0.1.2"
+__author__ = "$USER"
+__email__ = "jlee@$USER.org"
+
+__all__ = [
+    "AutomationSafetyManager",
+    "JleechanorgPRMonitor",
+    "SafeJSONManager",
+    "get_automation_limits",
+    "get_email_config",
+    "json_manager",
+    "setup_logging",
+    "validate_email_config",
+]

--- a/automation/jleechanorg_pr_automation/automation_safety_manager.py
+++ b/automation/jleechanorg_pr_automation/automation_safety_manager.py
@@ -1,0 +1,821 @@
+#!/usr/bin/env python3
+"""
+Automation Safety Manager - GREEN Phase Implementation
+
+Minimal implementation to pass the RED phase tests with:
+- PR attempt limits (max 5 per PR)
+- Global run limits (max 50 per day with automatic midnight reset)
+- Manual approval system
+- Thread-safe operations
+- Email notifications
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import smtplib
+import sys
+import threading
+from datetime import datetime, timedelta
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Dict, Optional, Union
+
+REAL_DATETIME = datetime
+
+# Number of characters in the ISO 8601 date prefix ("YYYY-MM-DD").
+ISO_DATE_PREFIX_LENGTH = len("YYYY-MM-DD")
+
+# Optional keyring import for email functionality
+_keyring_spec = importlib.util.find_spec("keyring")
+if _keyring_spec:
+    import keyring  # type: ignore
+    HAS_KEYRING = True
+else:
+    keyring = None  # type: ignore
+    HAS_KEYRING = False
+
+# Import shared utilities
+from .utils import (
+    get_automation_limits,
+    json_manager,
+    setup_logging,
+)
+
+
+class AutomationSafetyManager:
+    """Thread-safe automation safety manager with configurable limits"""
+
+    def __init__(self, data_dir: str):
+        self.data_dir = data_dir
+        self.lock = threading.RLock()  # Use RLock to prevent deadlock
+        self.logger = setup_logging(__name__)
+
+        # Get limits from shared utility
+        limits = get_automation_limits()
+        self.pr_limit = limits["pr_limit"]
+        self.global_limit = limits["global_limit"]
+
+        # File paths
+        self.pr_attempts_file = os.path.join(data_dir, "pr_attempts.json")
+        self.global_runs_file = os.path.join(data_dir, "global_runs.json")
+        self.approval_file = os.path.join(data_dir, "manual_approval.json")
+        self.config_file = os.path.join(data_dir, "automation_safety_config.json")
+        self.inflight_file = os.path.join(data_dir, "pr_inflight.json")  # NEW: Persist inflight cache
+
+        # In-memory counters for thread safety
+        self._pr_attempts_cache = {}
+        self._global_runs_cache = 0
+        self._pr_inflight_cache: Dict[str, int] = {}
+
+        # Initialize files if they don't exist
+        self._ensure_files_exist()
+
+        # Load configuration from file if it exists
+        self._load_config_if_exists()
+
+        # Load initial state from files
+        self._load_state_from_files()
+
+    def _ensure_files_exist(self):
+        """Initialize tracking files if they don't exist"""
+        os.makedirs(self.data_dir, exist_ok=True)
+
+        if not os.path.exists(self.pr_attempts_file):
+            self._write_json_file(self.pr_attempts_file, {})
+
+        if not os.path.exists(self.global_runs_file):
+            now = datetime.now()
+            today = now.date().isoformat()
+            self._write_json_file(self.global_runs_file, {
+                "total_runs": 0,
+                "start_date": now.isoformat(),
+                "current_date": today,
+                "last_run": None,
+                "last_reset": now.isoformat(),
+            })
+
+        if not os.path.exists(self.approval_file):
+            self._write_json_file(self.approval_file, {
+                "approved": False,
+                "approval_date": None
+            })
+
+        if not os.path.exists(self.inflight_file):
+            self._write_json_file(self.inflight_file, {})
+
+    def _load_config_if_exists(self):
+        """Load configuration from file if it exists, create default if not"""
+        if os.path.exists(self.config_file):
+            # Load existing config
+            try:
+                with open(self.config_file) as f:
+                    config = json.load(f)
+                    # Update limits from config
+                    if "pr_limit" in config:
+                        self.pr_limit = config["pr_limit"]
+                    if "global_limit" in config:
+                        self.global_limit = config["global_limit"]
+            except (FileNotFoundError, json.JSONDecodeError):
+                pass  # Use defaults
+        else:
+            # Create default config
+            default_config = {
+                "global_limit": self.global_limit,
+                "pr_limit": self.pr_limit,
+            }
+            self._write_json_file(self.config_file, default_config)
+
+    def _load_state_from_files(self):
+        """Load state from files into memory cache"""
+        with self.lock:
+            pr_data = self._read_json_file(self.pr_attempts_file)
+            self._pr_attempts_cache = self._normalize_pr_attempt_keys(pr_data)
+
+            # Load global runs
+            global_data = self._read_json_file(self.global_runs_file)
+            self._global_runs_cache = global_data.get("total_runs", 0)
+
+            # Load inflight cache
+            inflight_data = self._read_json_file(self.inflight_file)
+            self._pr_inflight_cache = {k: int(v) for k, v in inflight_data.items()}
+
+    def _sync_state_to_files(self):
+        """Sync in-memory state to files"""
+        with self.lock:
+            # Sync PR attempts - keys already normalized
+            self._write_json_file(self.pr_attempts_file, self._pr_attempts_cache)
+
+            # Sync inflight cache to prevent concurrent processing
+            self._write_json_file(self.inflight_file, self._pr_inflight_cache)
+
+    def _make_pr_key(
+        self,
+        pr_number: Union[int, str],
+        repo: Optional[str] = None,
+        branch: Optional[str] = None,
+    ) -> str:
+        """Create a labeled key for PR attempt tracking."""
+
+        repo_part = f"r={repo or ''}"
+        pr_part = f"p={pr_number!s}"
+        branch_part = f"b={branch or ''}"
+        return "||".join((repo_part, pr_part, branch_part))
+
+    def _normalize_pr_attempt_keys(self, raw_data: Dict) -> Dict[str, list]:
+        """Normalize legacy PR attempt keys to the labeled format."""
+
+        normalized: Dict[str, list] = {}
+
+        for key, value in (raw_data or {}).items():
+            if not isinstance(value, list):
+                # Older versions stored counts; coerce to list of failures
+                try:
+                    count = int(value)
+                    value = [{"result": "failure"}] * count
+                except (TypeError, ValueError):
+                    value = []
+
+            if isinstance(key, str) and "||p=" in key:
+                normalized[key] = value
+                continue
+
+            repo = None
+            branch = None
+            pr_number: Union[str, int] = ""
+
+            if isinstance(key, str):
+                parts = key.split("::")
+                if len(parts) == 1:
+                    pr_number = parts[0]
+                elif len(parts) == 2:
+                    repo, pr_number = parts
+                elif len(parts) >= 3:
+                    repo, pr_number, branch = parts[0], parts[1], parts[2]
+                else:
+                    pr_number = key
+            else:
+                pr_number = key
+
+            normalized_key = self._make_pr_key(pr_number, repo, branch)
+            normalized[normalized_key] = value
+
+        return normalized
+
+    def _read_json_file(self, file_path: str) -> dict:
+        """Safely read JSON file using shared utility"""
+        return json_manager.read_json(file_path, {})
+
+    def _write_json_file(self, file_path: str, data: dict):
+        """Atomically write JSON file using shared utility"""
+        try:
+            if not json_manager.write_json(file_path, data):
+                self.logger.error(f"Failed to write safety data file {file_path}")
+        except Exception as e:
+            self.logger.error(f"Exception writing safety data file {file_path}: {e}")
+
+    def _normalize_global_run_payload(
+        self,
+        payload: Optional[dict],
+        *,
+        now: Optional[datetime] = None,
+    ) -> tuple[dict, int, bool]:
+        """Normalize persisted global run data and determine if it is stale."""
+
+        current_time = now or datetime.now()
+        today = current_time.date().isoformat()
+
+        if isinstance(payload, dict):
+            data = dict(payload)
+        else:
+            data = {}
+
+        # Ensure start_date is always present and well-formed
+        start_date = data.get("start_date")
+        if isinstance(start_date, str):
+            try:
+                REAL_DATETIME.fromisoformat(start_date)
+            except ValueError:
+                data["start_date"] = current_time.isoformat()
+        else:
+            data["start_date"] = current_time.isoformat()
+
+        stored_date = data.get("current_date")
+        normalized_date: Optional[str] = None
+        if isinstance(stored_date, str):
+            try:
+                normalized_date = REAL_DATETIME.fromisoformat(stored_date).date().isoformat()
+            except ValueError:
+                # Support legacy data that stored raw dates without full ISO format
+                if len(stored_date) >= ISO_DATE_PREFIX_LENGTH:
+                    candidate = stored_date[:ISO_DATE_PREFIX_LENGTH]
+                    try:
+                        normalized_date = REAL_DATETIME.fromisoformat(candidate).date().isoformat()
+                    except ValueError:
+                        normalized_date = None
+                else:
+                    normalized_date = None
+
+        if normalized_date is None:
+            try:
+                normalized_date = REAL_DATETIME.fromisoformat(data["start_date"]).date().isoformat()
+            except ValueError:
+                normalized_date = None
+
+        is_stale = normalized_date != today
+
+        if is_stale:
+            normalized_date = today
+            data["total_runs"] = 0
+            data["last_reset"] = current_time.isoformat()
+
+        data["current_date"] = normalized_date or today
+
+        raw_total = data.get("total_runs", 0)
+        try:
+            total_runs = int(raw_total)
+        except (TypeError, ValueError):
+            total_runs = 0
+
+        total_runs = max(total_runs, 0)
+
+        data["total_runs"] = total_runs
+
+        last_run = data.get("last_run")
+        if last_run is not None:
+            if not isinstance(last_run, str):
+                data.pop("last_run", None)
+            else:
+                try:
+                    REAL_DATETIME.fromisoformat(last_run)
+                except ValueError:
+                    data.pop("last_run", None)
+
+        last_reset = data.get("last_reset")
+        if last_reset is not None:
+            if not isinstance(last_reset, str):
+                data.pop("last_reset", None)
+            else:
+                try:
+                    REAL_DATETIME.fromisoformat(last_reset)
+                except ValueError:
+                    data.pop("last_reset", None)
+
+        if "last_reset" not in data:
+            data["last_reset"] = data["start_date"]
+
+        return data, total_runs, is_stale
+
+    def can_process_pr(self, pr_number: Union[int, str], repo: str = None, branch: str = None) -> bool:
+        """Check if PR can be processed (under attempt limit)"""
+        with self.lock:
+            raw_data = self._read_json_file(self.pr_attempts_file)
+            self._pr_attempts_cache = self._normalize_pr_attempt_keys(raw_data)
+
+            pr_key = self._make_pr_key(pr_number, repo, branch)
+            attempts = list(self._pr_attempts_cache.get(pr_key, []))
+
+            # Check total attempts limit first
+            if len(attempts) >= self.pr_limit:
+                return False
+
+            # Count consecutive failures from latest attempts
+            consecutive_failures = 0
+            for attempt in reversed(attempts):
+                if attempt.get("result") == "failure":
+                    consecutive_failures += 1
+                else:
+                    break
+
+            # Also block if too many consecutive failures (earlier than total limit)
+            return consecutive_failures < self.pr_limit
+
+    def try_process_pr(self, pr_number: Union[int, str], repo: str = None, branch: str = None) -> bool:
+        """Atomically reserve a processing slot for PR."""
+        with self.lock:
+            # Check consecutive failure limit first
+            if not self.can_process_pr(pr_number, repo, branch):
+                return False
+
+            pr_key = self._make_pr_key(pr_number, repo, branch)
+            inflight = self._pr_inflight_cache.get(pr_key, 0)
+
+            # Check if we're at the concurrent processing limit for this PR
+            if inflight >= self.pr_limit:
+                return False
+
+            # Reserve a processing slot
+            self._pr_inflight_cache[pr_key] = inflight + 1
+
+            # Persist immediately to prevent race conditions with concurrent cron jobs
+            self._write_json_file(self.inflight_file, self._pr_inflight_cache)
+
+            return True
+
+    def release_pr_slot(self, pr_number: Union[int, str], repo: str = None, branch: str = None):
+        """Release a processing slot for PR (call in finally block)"""
+        with self.lock:
+            pr_key = self._make_pr_key(pr_number, repo, branch)
+            inflight = self._pr_inflight_cache.get(pr_key, 0)
+            if inflight > 0:
+                self._pr_inflight_cache[pr_key] = inflight - 1
+                # Persist immediately to prevent race conditions
+                self._write_json_file(self.inflight_file, self._pr_inflight_cache)
+
+    def get_pr_attempts(self, pr_number: Union[int, str], repo: str = None, branch: str = None):
+        """Get count of consecutive failures for a specific PR."""
+        with self.lock:
+            pr_key = self._make_pr_key(pr_number, repo, branch)
+            attempts = list(self._pr_attempts_cache.get(pr_key, []))
+
+            failure_count = 0
+            for attempt in reversed(attempts):
+                if attempt.get("result") == "failure":
+                    failure_count += 1
+                else:
+                    break
+            return failure_count
+
+    def get_pr_attempt_list(self, pr_number: Union[int, str], repo: str = None, branch: str = None):
+        """Get list of attempts for a specific PR (for detailed analysis)"""
+        with self.lock:
+            # Reload from disk to ensure consistency across multiple managers
+            raw_data = self._read_json_file(self.pr_attempts_file)
+            self._pr_attempts_cache = self._normalize_pr_attempt_keys(raw_data)
+            pr_key = self._make_pr_key(pr_number, repo, branch)
+            return self._pr_attempts_cache.get(pr_key, [])
+
+    def record_pr_attempt(self, pr_number: Union[int, str], result: str, repo: str = None, branch: str = None):
+        """Record a PR attempt (success or failure)"""
+        with self.lock:
+            pr_key = self._make_pr_key(pr_number, repo, branch)
+
+            # Create attempt record
+            attempt_record = {
+                "result": result,
+                "timestamp": datetime.now().isoformat(),
+                "pr_number": pr_number,
+                "repo": repo,
+                "branch": branch
+            }
+
+            # Get existing attempts list and append new attempt
+            attempts = self._pr_attempts_cache.get(pr_key, [])
+            attempts.append(attempt_record)
+            self._pr_attempts_cache[pr_key] = attempts
+
+            # Update inflight cache
+            inflight = self._pr_inflight_cache.get(pr_key, 0)
+            if inflight > 0:
+                if inflight == 1:
+                    self._pr_inflight_cache.pop(pr_key, None)
+                else:
+                    self._pr_inflight_cache[pr_key] = inflight - 1
+
+            # Sync to file for persistence
+            self._sync_state_to_files()
+
+    def can_start_global_run(self) -> bool:
+        """Check if a global run can be started"""
+        with self.lock:
+            # Always refresh from file to detect external resets
+            runs = self.get_global_runs()
+
+            if runs < self.global_limit:
+                return True
+
+            # Manual override allows limited additional runs (max 2x limit)
+            # Never allow unlimited runs even with override
+            if self.has_manual_approval() and runs < (self.global_limit * 2):
+                return True
+
+            # Hard stop at 2x limit regardless of approval status
+            return False
+
+    def get_global_runs(self) -> int:
+        """Get total number of global runs (resets daily)"""
+        with self.lock:
+            normalized_total = 0
+
+            def _refresh(payload: Optional[dict]):
+                nonlocal normalized_total
+                normalized, total, _ = self._normalize_global_run_payload(payload)
+                normalized_total = normalized["total_runs"]
+                return normalized
+
+            if not json_manager.update_json(self.global_runs_file, _refresh):
+                self.logger.warning(
+                    "Falling back to manual refresh for global run counter"
+                )
+                payload = self._read_json_file(self.global_runs_file)
+                normalized, total, _ = self._normalize_global_run_payload(payload)
+                normalized_total = total
+                self._write_json_file(self.global_runs_file, normalized)
+
+            self._global_runs_cache = normalized_total
+            return normalized_total
+
+    def record_global_run(self):
+        """Record a global automation run atomically"""
+        with self.lock:
+            new_total = 0
+            current_time = datetime.now()
+
+            def _increment(payload: Optional[dict]):
+                nonlocal new_total
+                normalized, total, _ = self._normalize_global_run_payload(payload, now=current_time)
+                total += 1
+                normalized["total_runs"] = total
+                normalized["current_date"] = current_time.date().isoformat()
+                normalized["last_run"] = current_time.isoformat()
+                new_total = total
+                return normalized
+
+            if not json_manager.update_json(self.global_runs_file, _increment):
+                self.logger.warning(
+                    "Falling back to manual increment for global run counter"
+                )
+                payload = self._read_json_file(self.global_runs_file)
+                normalized, total, _ = self._normalize_global_run_payload(payload, now=current_time)
+                total += 1
+                normalized["total_runs"] = total
+                normalized["current_date"] = current_time.date().isoformat()
+                normalized["last_run"] = current_time.isoformat()
+                new_total = total
+                self._write_json_file(self.global_runs_file, normalized)
+
+            self._global_runs_cache = new_total
+
+    def requires_manual_approval(self) -> bool:
+        """Check if manual approval is required"""
+        return self.get_global_runs() >= self.global_limit
+
+    def has_manual_approval(self) -> bool:
+        """Check if valid manual approval exists"""
+        with self.lock:
+            data = self._read_json_file(self.approval_file)
+
+            if not data.get("approved", False):
+                return False
+
+            # Check if approval has expired (configurable hours)
+            approval_date_str = data.get("approval_date")
+            if not approval_date_str:
+                return False
+
+            try:
+                approval_date = REAL_DATETIME.fromisoformat(approval_date_str)
+            except (TypeError, ValueError):
+                return False
+            approval_hours = get_automation_limits()["approval_hours"]
+            expiry = approval_date + timedelta(hours=approval_hours)
+
+            return datetime.now() < expiry
+
+    def check_and_notify_limits(self):
+        """Check limits and send email notifications if thresholds are reached"""
+        notifications_sent = []
+
+        with self.lock:
+            # Check for PR limits reached
+            for pr_key, attempts in self._pr_attempts_cache.items():
+                if len(attempts) >= self.pr_limit:
+                    self._send_limit_notification(
+                        "PR Automation Limit Reached",
+                        f"PR {pr_key} has reached the maximum attempt limit of {self.pr_limit}."
+                    )
+                    notifications_sent.append(f"PR {pr_key}")
+
+            # Check for global limit reached
+            if self._global_runs_cache >= self.global_limit:
+                self._send_limit_notification(
+                    "Global Automation Limit Reached",
+                    f"Global automation runs have reached the maximum limit of {self.global_limit}."
+                )
+                notifications_sent.append("Global limit")
+
+        return notifications_sent
+
+    def _send_limit_notification(self, subject: str, message: str):
+        """Send email notification for limit reached"""
+        try:
+            # Try to use the more complete email notification method
+            self._send_notification(subject, message)
+        except Exception as e:
+            # If email fails, just log it - don't break automation
+            self.logger.error("Failed to send email notification: %s", e)
+            self.logger.debug("Notification subject: %s", subject)
+            self.logger.debug("Notification body: %s", message)
+
+    def grant_manual_approval(self, approver_email: str, approval_time: Optional[datetime] = None):
+        """Grant manual approval for continued automation"""
+        with self.lock:
+            approval_time = approval_time or datetime.now()
+
+            data = {
+                "approved": True,
+                "approval_date": approval_time.isoformat(),
+                "approver": approver_email
+            }
+
+            self._write_json_file(self.approval_file, data)
+
+    def _get_smtp_credentials(self):
+        """Get SMTP credentials securely from keyring or environment fallback"""
+        username = None
+        password = None
+
+        if HAS_KEYRING:
+            try:
+                username = keyring.get_password("worldarchitect-automation", "smtp_username")
+                password = keyring.get_password("worldarchitect-automation", "smtp_password")
+            except Exception:
+                self.logger.debug("Keyring lookup failed for SMTP credentials", exc_info=True)
+                username = None
+                password = None
+
+        if username is None:
+            username = os.environ.get("SMTP_USERNAME") or os.environ.get("EMAIL_USER")
+        if password is None:
+            password = os.environ.get("SMTP_PASSWORD") or os.environ.get("EMAIL_PASS")
+
+        return username, password
+
+    def _send_notification(self, subject: str, message: str) -> bool:
+        """Send email notification with secure credential handling"""
+        try:
+            # Load email configuration
+            smtp_server = os.environ.get("SMTP_SERVER", "smtp.gmail.com")
+            smtp_port = int(os.environ.get("SMTP_PORT", "587"))
+            username, password = self._get_smtp_credentials()
+            to_email = os.environ.get("EMAIL_TO")
+            from_email = os.environ.get("EMAIL_FROM") or username
+
+            if not (username and password and to_email and from_email):
+                self.logger.info("Email configuration incomplete - skipping notification")
+                return False
+
+            msg = MIMEMultipart()
+            msg["From"] = from_email
+            msg["To"] = to_email
+            msg["Subject"] = f"[WorldArchitect Automation] {subject}"
+
+            body = f"""
+{message}
+
+Time: {datetime.now().isoformat()}
+System: PR Automation Safety Manager
+
+This is an automated notification from the Your Project automation system.
+"""
+
+            msg.attach(MIMEText(body, "plain"))
+
+            # Connect and send email
+            server = smtplib.SMTP(smtp_server, smtp_port)
+            try:
+                server.ehlo()
+                server.starttls()
+                server.ehlo()
+                if username and password:
+                    server.login(username, password)
+                server.send_message(msg)
+            finally:
+                server.quit()
+                self.logger.info("Email notification sent successfully: %s", subject)
+            return True
+
+        except smtplib.SMTPAuthenticationError as e:
+            self.logger.error(f"SMTP authentication failed - check credentials: {e}")
+            return False
+        except smtplib.SMTPRecipientsRefused as e:
+            self.logger.error(f"Email recipients refused: {e}")
+            return False
+        except smtplib.SMTPException as e:
+            self.logger.error(f"SMTP error sending notification: {e}")
+            return False
+        except OSError as e:
+            self.logger.error(f"Network error sending notification: {e}")
+            return False
+        except Exception as e:
+            # Log error but don't fail automation
+            self.logger.error(f"Unexpected error sending notification: {e}")
+            return False
+
+    def _clear_global_runs(self):
+        """Clear global runs counter (for testing)"""
+        with self.lock:
+            self._global_runs_cache = 0
+            data = self._read_json_file(self.global_runs_file)
+            data["total_runs"] = 0
+            data["last_run"] = None
+            now = datetime.now()
+            data["current_date"] = now.date().isoformat()
+            data["last_reset"] = now.isoformat()
+            self._write_json_file(self.global_runs_file, data)
+
+    def _clear_pr_attempts(self):
+        """Clear PR attempts cache (for testing)"""
+        with self.lock:
+            self._pr_attempts_cache.clear()
+            self._write_json_file(self.pr_attempts_file, {})
+
+    def load_config(self, config_file: str) -> dict:
+        """Load configuration from file"""
+        try:
+            with open(config_file) as f:
+                config = json.load(f)
+                # Update limits from config
+                if "pr_limit" in config:
+                    self.pr_limit = config["pr_limit"]
+                if "global_limit" in config:
+                    self.global_limit = config["global_limit"]
+                return config
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+
+    def save_config(self, config_file: str, config: dict):
+        """Save configuration to file"""
+        self._write_json_file(config_file, config)
+
+    def has_email_config(self) -> bool:
+        """Check if email configuration is available"""
+        try:
+            smtp_server = os.environ.get("SMTP_SERVER")
+            username, password = self._get_smtp_credentials()
+            return bool(smtp_server and username and password)
+        except Exception:
+            return False
+
+    def send_notification(self, subject: str, message: str) -> bool:
+        """Send email notification - wrapper for _send_notification"""
+        try:
+            return self._send_notification(subject, message)
+        except Exception:
+            return False
+
+    def _is_email_configured(self) -> bool:
+        """Check if email configuration is complete"""
+        try:
+            smtp_server = os.environ.get("SMTP_SERVER")
+            smtp_port = os.environ.get("SMTP_PORT")
+            email_to = os.environ.get("EMAIL_TO")
+            username, password = self._get_smtp_credentials()
+            return bool(smtp_server and smtp_port and email_to and username and password)
+        except Exception:
+            return False
+
+
+def main():
+    """CLI interface for safety manager"""
+
+    parser = argparse.ArgumentParser(description="Automation Safety Manager")
+    parser.add_argument("--data-dir", default="/tmp/automation_safety",
+                        help="Directory for safety data files")
+    parser.add_argument("--check-pr", type=int, metavar="PR_NUMBER",
+                        help="Check if PR can be processed")
+    parser.add_argument("--record-pr", nargs=2, metavar=("PR_NUMBER", "RESULT"),
+                        help="Record PR attempt (result: success|failure)")
+    parser.add_argument("--repo", type=str,
+                        help="Repository name (owner/repo) for PR attempt operations")
+    parser.add_argument("--branch", type=str,
+                        help="Branch name for PR attempt tracking")
+    parser.add_argument("--check-global", action="store_true",
+                        help="Check if global run can start")
+    parser.add_argument("--record-global", action="store_true",
+                        help="Record global run")
+    parser.add_argument("--manual_override", type=str, metavar="EMAIL",
+                        help="Grant manual override (emergency use only)")
+    parser.add_argument("--status", action="store_true",
+                        help="Show current status")
+
+    args = parser.parse_args()
+
+    # Ensure data directory exists
+    os.makedirs(args.data_dir, exist_ok=True)
+
+    manager = AutomationSafetyManager(args.data_dir)
+
+    if args.check_pr:
+        can_process = manager.can_process_pr(args.check_pr, repo=args.repo, branch=args.branch)
+        attempts = manager.get_pr_attempts(args.check_pr, repo=args.repo, branch=args.branch)
+        repo_label = f" ({args.repo})" if args.repo else ""
+        branch_label = f" [{args.branch}]" if args.branch else ""
+        print(
+            f"PR #{args.check_pr}{repo_label}{branch_label}: "
+            f"{'ALLOWED' if can_process else 'BLOCKED'} ({attempts}/{manager.pr_limit} attempts)"
+        )
+        sys.exit(0 if can_process else 1)
+
+    elif args.record_pr:
+        pr_number, result = args.record_pr
+        manager.record_pr_attempt(int(pr_number), result, repo=args.repo, branch=args.branch)
+        print(
+            f"Recorded {result} for PR #{pr_number}"
+            f"{' in ' + args.repo if args.repo else ''}"
+            f"{' [' + args.branch + ']' if args.branch else ''}"
+        )
+
+    elif args.check_global:
+        can_start = manager.can_start_global_run()
+        runs = manager.get_global_runs()
+        print(f"Global runs: {'ALLOWED' if can_start else 'BLOCKED'} ({runs}/{manager.global_limit} runs)")
+        sys.exit(0 if can_start else 1)
+
+    elif args.record_global:
+        manager.record_global_run()
+        runs = manager.get_global_runs()
+        print(f"Recorded global run #{runs}")
+
+    elif args.manual_override:
+        manager.grant_manual_approval(args.manual_override)
+        print(f"Manual override granted by {args.manual_override}")
+
+    elif args.status:
+        runs = manager.get_global_runs()
+        has_approval = manager.has_manual_approval()
+        requires_approval = manager.requires_manual_approval()
+
+        print(f"Global runs: {runs}/{manager.global_limit}")
+        print(f"Requires approval: {requires_approval}")
+        print(f"Has approval: {has_approval}")
+
+        pr_data = manager._read_json_file(manager.pr_attempts_file)
+
+        if pr_data:
+            print("PR attempts:")
+            for pr_key, attempts in pr_data.items():
+                count = len(attempts) if isinstance(attempts, list) else int(attempts or 0)
+                status = "BLOCKED" if count >= manager.pr_limit else "OK"
+
+                repo_label = ""
+                branch_label = ""
+                pr_label = pr_key
+
+                if "||" in pr_key:
+                    segments = {}
+                    for segment in pr_key.split("||"):
+                        if "=" in segment:
+                            k, v = segment.split("=", 1)
+                            segments[k] = v
+                    repo_label = segments.get("r", "")
+                    pr_label = segments.get("p", pr_label)
+                    branch_label = segments.get("b", "")
+
+                display = f"PR #{pr_label}"
+                if repo_label:
+                    display += f" ({repo_label})"
+                if branch_label:
+                    display += f" [{branch_label}]"
+
+                print(f"  {display}: {count}/{manager.pr_limit} ({status})")
+        else:
+            print("No PR attempts recorded")
+
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/automation/jleechanorg_pr_automation/automation_safety_manager.py
+++ b/automation/jleechanorg_pr_automation/automation_safety_manager.py
@@ -22,6 +22,13 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from typing import Dict, Optional, Union
 
+# Import shared utilities
+from .utils import (
+    get_automation_limits,
+    json_manager,
+    setup_logging,
+)
+
 REAL_DATETIME = datetime
 
 # Number of characters in the ISO 8601 date prefix ("YYYY-MM-DD").
@@ -35,13 +42,6 @@ if _keyring_spec:
 else:
     keyring = None  # type: ignore
     HAS_KEYRING = False
-
-# Import shared utilities
-from .utils import (
-    get_automation_limits,
-    json_manager,
-    setup_logging,
-)
 
 
 class AutomationSafetyManager:
@@ -711,8 +711,10 @@ def main():
     """CLI interface for safety manager"""
 
     parser = argparse.ArgumentParser(description="Automation Safety Manager")
-    parser.add_argument("--data-dir", default="/tmp/automation_safety",
-                        help="Directory for safety data files")
+    parser.add_argument(
+        "--data-dir",
+        default=os.path.join(os.path.expanduser("~"), ".automation_safety"),
+        help="Directory for safety data files")
     parser.add_argument("--check-pr", type=int, metavar="PR_NUMBER",
                         help="Check if PR can be processed")
     parser.add_argument("--record-pr", nargs=2, metavar=("PR_NUMBER", "RESULT"),

--- a/automation/jleechanorg_pr_automation/automation_safety_wrapper.py
+++ b/automation/jleechanorg_pr_automation/automation_safety_wrapper.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+Automation Safety Wrapper for launchd
+
+This wrapper enforces safety limits before running PR automation:
+- Max 5 attempts per PR
+- Max 50 total automation runs before requiring manual approval
+- Email notifications when limits are reached
+"""
+
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from .automation_safety_manager import AutomationSafetyManager
+
+
+def setup_logging() -> logging.Logger:
+    """Set up logging for automation wrapper"""
+    log_dir = Path.home() / "Library" / "Logs" / "worldarchitect-automation"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[
+            logging.FileHandler(log_dir / "automation_safety.log"),
+            logging.StreamHandler()
+        ]
+    )
+    return logging.getLogger(__name__)
+
+
+def main() -> int:
+    """Main wrapper function with safety checks"""
+    logger = setup_logging()
+    logger.info("🛡️  Starting automation safety wrapper")
+
+    # Data directory for safety tracking
+    data_dir = Path.home() / "Library" / "Application Support" / "worldarchitect-automation"
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    # Initialize safety manager
+    manager = AutomationSafetyManager(str(data_dir))
+
+    try:
+        # Check global run limits
+        if not manager.can_start_global_run():
+            logger.warning(f"🚫 Global automation limit reached ({manager.get_global_runs()}/{manager.global_limit} runs)")
+
+            if manager.requires_manual_approval() and not manager.has_manual_approval():
+                logger.error("❌ Manual approval required to continue automation")
+                logger.info("💡 To grant approval: automation-safety-cli --manual_override user@example.com")
+
+                # Send notification
+                manager.check_and_notify_limits()
+                return 1
+
+        logger.info(
+            f"📊 Global runs before execution: {manager.get_global_runs()}"
+            f"/{manager.global_limit}"
+        )
+
+        logger.info("🚀 Executing PR automation monitor: jleechanorg_pr_automation.jleechanorg_pr_monitor")
+
+        # Execute with environment variables for safety integration
+        env = os.environ.copy()
+        env["AUTOMATION_SAFETY_DATA_DIR"] = str(data_dir)
+        env["AUTOMATION_SAFETY_WRAPPER"] = "1"
+
+        # Record the global run *before* launching the monitor so the attempt
+        # is counted even if the subprocess fails to start or exits early.
+        manager.record_global_run()
+        logger.info(
+            f"📊 Recorded global run {manager.get_global_runs()}/"
+            f"{manager.global_limit} prior to monitor execution"
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-m", "jleechanorg_pr_automation.jleechanorg_pr_monitor"],
+            check=False, env=env,
+            capture_output=True,
+            text=True,
+            timeout=3600,
+            shell=False,
+        )  # 1 hour timeout
+
+        global_runs_after = manager.get_global_runs()
+        logger.info(f"📊 Global runs after execution: {global_runs_after}/{manager.global_limit}")
+
+        # Log results
+        if result.returncode == 0:
+            logger.info("✅ Automation completed successfully")
+            if result.stdout:
+                logger.info(f"Output: {result.stdout.strip()}")
+        else:
+            logger.error(f"❌ Automation failed with exit code {result.returncode}")
+            if result.stderr:
+                logger.error(f"Error: {result.stderr.strip()}")
+
+        return result.returncode
+
+    except subprocess.TimeoutExpired:
+        logger.error("⏰ Automation timed out after 1 hour")
+        return 124
+    except Exception as e:
+        logger.error(f"💥 Unexpected error in safety wrapper: {e}")
+        return 1
+    finally:
+        # Check and notify about any limit violations
+        manager.check_and_notify_limits()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/automation/jleechanorg_pr_automation/automation_utils.py
+++ b/automation/jleechanorg_pr_automation/automation_utils.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""
+Shared Automation Utilities Module
+
+Consolidates common functionality used across automation components:
+- Logging setup and configuration
+- Configuration management (SMTP, paths, environment)
+- Email notification system
+- Subprocess execution with timeout and error handling
+- File and directory management utilities
+"""
+
+import fcntl
+import json
+import logging
+import os
+import smtplib
+import subprocess
+import tempfile
+from datetime import datetime
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+try:
+    import keyring
+    KEYRING_AVAILABLE = True
+except ImportError:
+    KEYRING_AVAILABLE = False
+
+
+class AutomationUtils:
+    """Shared utilities for automation components"""
+
+    # Default configuration
+    DEFAULT_CONFIG = {
+        "SMTP_SERVER": "smtp.gmail.com",
+        "SMTP_PORT": 587,
+        "LOG_DIR": "~/Library/Logs/worldarchitect-automation",
+        "DATA_DIR": "~/Library/Application Support/worldarchitect-automation",
+        "MAX_SUBPROCESS_TIMEOUT": int(os.getenv("AUTOMATION_SUBPROCESS_TIMEOUT", "300")),  # 5 minutes (configurable)
+        "EMAIL_SUBJECT_PREFIX": "[WorldArchitect Automation]"
+    }
+
+    @classmethod
+    def setup_logging(cls, name: str, log_filename: str = None) -> logging.Logger:
+        """Unified logging setup for all automation components
+
+        Args:
+            name: Logger name (typically __name__)
+            log_filename: Optional specific log filename, defaults to component name
+
+        Returns:
+            Configured logger instance
+        """
+        if log_filename is None:
+            log_filename = f"{name.split('.')[-1]}.log"
+
+        # Create log directory
+        log_dir = Path(cls.DEFAULT_CONFIG["LOG_DIR"]).expanduser()
+        log_dir.mkdir(parents=True, exist_ok=True)
+
+        # Set up logging with consistent format
+        logging.basicConfig(
+            level=logging.INFO,
+            format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+            handlers=[
+                logging.FileHandler(log_dir / log_filename),
+                logging.StreamHandler()
+            ]
+        )
+
+        logger = logging.getLogger(name)
+        logger.info(f"🛠️  Logging initialized - logs: {log_dir / log_filename}")
+        return logger
+
+    @classmethod
+    def get_config_value(cls, key: str, default: Any = None) -> Any:
+        """Get configuration value from environment or defaults"""
+        env_value = os.environ.get(key)
+        if env_value is not None:
+            # Try to convert to appropriate type
+            if isinstance(default, bool):
+                return env_value.lower() in ("true", "1", "yes", "on")
+            if isinstance(default, int):
+                try:
+                    return int(env_value)
+                except ValueError:
+                    pass
+            return env_value
+        return cls.DEFAULT_CONFIG.get(key, default)
+
+    @classmethod
+    def get_data_directory(cls, subdir: str = None) -> Path:
+        """Get standardized data directory path"""
+        data_dir = Path(cls.DEFAULT_CONFIG["DATA_DIR"]).expanduser()
+        if subdir:
+            data_dir = data_dir / subdir
+        data_dir.mkdir(parents=True, exist_ok=True)
+        return data_dir
+
+    @classmethod
+    def get_smtp_credentials(cls) -> Tuple[Optional[str], Optional[str]]:
+        """Securely get SMTP credentials from keyring or environment"""
+        username = None
+        password = None
+
+        if KEYRING_AVAILABLE:
+            try:
+                username = keyring.get_password("worldarchitect-automation", "smtp_username")
+                password = keyring.get_password("worldarchitect-automation", "smtp_password")
+            except Exception:
+                pass  # Fall back to environment variables
+
+        # Fallback to environment variables if keyring fails or unavailable
+        if not username:
+            username = os.environ.get("SMTP_USERNAME")
+        if not password:
+            password = os.environ.get("SMTP_PASSWORD")
+
+        return username, password
+
+    @classmethod
+    def send_email_notification(cls, subject: str, message: str,
+                              to_email: str = None, from_email: str = None) -> bool:
+        """Send email notification with unified error handling
+
+        Args:
+            subject: Email subject line
+            message: Email body content
+            to_email: Override recipient email
+            from_email: Override sender email
+
+        Returns:
+            True if email sent successfully, False otherwise
+        """
+        try:
+            # Get SMTP configuration
+            smtp_server = cls.get_config_value("SMTP_SERVER")
+            smtp_port = cls.get_config_value("SMTP_PORT")
+            username, password = cls.get_smtp_credentials()
+
+            # Get email addresses
+            from_email = from_email or os.environ.get("MEMORY_EMAIL_FROM")
+            to_email = to_email or os.environ.get("MEMORY_EMAIL_TO")
+
+            if not all([username, password, from_email, to_email]):
+                print("Email configuration incomplete - skipping notification")
+                return False
+
+            # Build email message
+            msg = MIMEMultipart()
+            msg["From"] = from_email
+            msg["To"] = to_email
+            msg["Subject"] = f"{cls.DEFAULT_CONFIG['EMAIL_SUBJECT_PREFIX']} {subject}"
+
+            # Add timestamp to message
+            full_message = f"""{message}
+
+Time: {datetime.now().isoformat()}
+System: WorldArchitect Automation
+
+This is an automated notification from the Your Project automation system."""
+
+            msg.attach(MIMEText(full_message, "plain"))
+
+            # Send email with timeout and proper error handling
+            with smtplib.SMTP(smtp_server, smtp_port, timeout=30) as server:
+                server.starttls()
+                server.login(username, password)
+                server.send_message(msg)
+
+            print(f"✅ Email notification sent: {subject}")
+            return True
+
+        except smtplib.SMTPAuthenticationError as e:
+            print(f"❌ SMTP authentication failed: {e}")
+        except smtplib.SMTPRecipientsRefused as e:
+            print(f"❌ Email recipients refused: {e}")
+        except smtplib.SMTPException as e:
+            print(f"❌ SMTP error: {e}")
+        except OSError as e:
+            print(f"❌ Network error: {e}")
+        except Exception as e:
+            print(f"❌ Unexpected email error: {e}")
+
+        return False
+
+    @classmethod
+    def execute_subprocess_with_timeout(cls, command: list, timeout: int = None,
+                                      cwd: str = None, capture_output: bool = True,
+                                      check: bool = True) -> subprocess.CompletedProcess:
+        """Execute subprocess with standardized timeout and error handling
+
+        Args:
+            command: Command to execute as list
+            timeout: Timeout in seconds (uses default if None)
+            cwd: Working directory
+            capture_output: Whether to capture stdout/stderr
+            check: Whether to raise CalledProcessError on non-zero exit (default True)
+
+        Returns:
+            CompletedProcess instance
+
+        Raises:
+            subprocess.TimeoutExpired: If command times out
+            subprocess.CalledProcessError: If command fails and check=True
+        """
+        if timeout is None:
+            timeout = cls.get_config_value("MAX_SUBPROCESS_TIMEOUT")
+
+        # Ensure shell=False for security, check parameter controls error handling
+        result = subprocess.run(
+            command,
+            timeout=timeout,
+            cwd=cwd,
+            capture_output=capture_output,
+            text=True,
+            shell=False,
+            check=check
+        )
+
+        return result
+
+    @classmethod
+    def safe_read_json(cls, file_path: Path) -> dict:
+        """Safely read JSON file with file locking"""
+        try:
+            with open(file_path) as f:
+                fcntl.flock(f.fileno(), fcntl.LOCK_SH)  # Shared lock for reading
+                data = json.load(f)
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)  # Unlock
+                return data
+        except (FileNotFoundError, json.JSONDecodeError):
+            return {}
+
+    @classmethod
+    def safe_write_json(cls, file_path: Path, data: dict):
+        """Atomically write JSON file with file locking"""
+        # Use system temp directory for better security
+        temp_path = None
+        try:
+            # Create temporary file securely
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".tmp",
+                delete=False
+            ) as temp_file:
+                fcntl.flock(temp_file.fileno(), fcntl.LOCK_EX)  # Exclusive lock for writing
+                json.dump(data, temp_file, indent=2)
+                temp_file.flush()
+                os.fsync(temp_file.fileno())  # Force write to disk
+                fcntl.flock(temp_file.fileno(), fcntl.LOCK_UN)  # Unlock
+                temp_path = temp_file.name
+
+            # Set restrictive permissions before moving
+            os.chmod(temp_path, 0o600)  # Owner read/write only
+
+            # Atomic rename - this operation is atomic on POSIX systems
+            os.rename(temp_path, file_path)
+            temp_path = None  # Successful, don't clean up
+
+        except (OSError, TypeError, ValueError) as e:
+            # Clean up temp file on error
+            if temp_path and os.path.exists(temp_path):
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass  # Best effort cleanup
+            raise RuntimeError(f"Failed to write JSON file {file_path}: {e}") from e
+
+    @classmethod
+    def get_memory_config(cls) -> Dict[str, str]:
+        """Load memory email configuration (for backward compatibility)"""
+        config = {}
+        config_file = Path.home() / ".memory_email_config"
+
+        if config_file.exists():
+            try:
+                # Source the bash config file by running it and capturing environment
+                result = cls.execute_subprocess_with_timeout(
+                    ["bash", "-c", f"source {config_file} && env"],
+                    timeout=10
+                )
+
+                for line in result.stdout.splitlines():
+                    if "=" in line:
+                        key, value = line.split("=", 1)
+                        config[key] = value
+
+            except Exception as e:
+                print(f"Warning: Could not load memory config: {e}")
+
+        return config
+
+
+# Convenience functions for backward compatibility
+def setup_logging(name: str, log_filename: str = None) -> logging.Logger:
+    """Convenience function for setup_logging"""
+    return AutomationUtils.setup_logging(name, log_filename)
+
+
+def send_email_notification(subject: str, message: str, to_email: str = None, from_email: str = None) -> bool:
+    """Convenience function for send_email_notification"""
+    return AutomationUtils.send_email_notification(subject, message, to_email, from_email)
+
+
+def execute_subprocess_with_timeout(command: list, timeout: int = None,
+                                  cwd: str = None, capture_output: bool = True) -> subprocess.CompletedProcess:
+    """Convenience function for execute_subprocess_with_timeout"""
+    return AutomationUtils.execute_subprocess_with_timeout(command, timeout, cwd, capture_output)

--- a/automation/jleechanorg_pr_automation/check_codex_comment.py
+++ b/automation/jleechanorg_pr_automation/check_codex_comment.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Determine whether a Codex instruction comment should be posted."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Tuple
+
+# Safety limits for JSON parsing to prevent memory exhaustion
+MAX_JSON_SIZE = 10 * 1024 * 1024  # 10MB limit for PR data
+
+
+def decide(marker_prefix: str, marker_suffix: str) -> Tuple[str, str]:
+    try:
+        # Read stdin with size limit to prevent memory exhaustion
+        stdin_data = sys.stdin.read(MAX_JSON_SIZE)
+        if len(stdin_data) >= MAX_JSON_SIZE:
+            sys.stderr.write("ERROR: PR data exceeds maximum size limit\n")
+            return "post", ""
+
+        pr_data = json.loads(stdin_data)
+    except json.JSONDecodeError:
+        return "post", ""
+
+    head_sha = pr_data.get("headRefOid") or ""
+
+    # Handle GitHub API comments structure variations
+    comments_data = pr_data.get("comments", [])
+    if isinstance(comments_data, dict):
+        # GraphQL format: {"nodes": [...]}
+        comments = comments_data.get("nodes", [])
+    elif isinstance(comments_data, list):
+        # REST API format: [...]
+        comments = comments_data
+    else:
+        comments = []
+
+    if not head_sha:
+        return "post", ""
+
+    for comment in comments:
+        # Safely handle comment data that may not be a dictionary
+        if isinstance(comment, dict):
+            body = comment.get("body", "")
+        else:
+            # Skip malformed comment data
+            continue
+        prefix_index = body.find(marker_prefix)
+        if prefix_index == -1:
+            continue
+
+        start_index = prefix_index + len(marker_prefix)
+        end_index = body.find(marker_suffix, start_index)
+        if end_index == -1:
+            continue
+
+        marker_sha = body[start_index:end_index].strip()
+        if marker_sha == head_sha:
+            return "skip", head_sha
+
+    return "post", head_sha
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        sys.stderr.write("Usage: check_codex_comment.py <marker_prefix> <marker_suffix>\n")
+        return 2
+
+    action, sha = decide(sys.argv[1], sys.argv[2])
+    sys.stdout.write(f"{action}:{sha}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/automation/jleechanorg_pr_automation/check_codex_comment.py
+++ b/automation/jleechanorg_pr_automation/check_codex_comment.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Tuple
 
 # Safety limits for JSON parsing to prevent memory exhaustion
 MAX_JSON_SIZE = 10 * 1024 * 1024  # 10MB limit for PR data
+EXPECTED_ARGC = 3
 
 
-def decide(marker_prefix: str, marker_suffix: str) -> Tuple[str, str]:
+def decide(marker_prefix: str, marker_suffix: str) -> tuple[str, str]:
     try:
         # Read stdin with size limit to prevent memory exhaustion
-        stdin_data = sys.stdin.read(MAX_JSON_SIZE)
+        stdin_data = sys.stdin.read(MAX_JSON_SIZE + 1)
         if len(stdin_data) > MAX_JSON_SIZE:
             sys.stderr.write("ERROR: PR data exceeds maximum size limit\n")
             return "post", ""
@@ -63,7 +63,7 @@ def decide(marker_prefix: str, marker_suffix: str) -> Tuple[str, str]:
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
+    if len(sys.argv) != EXPECTED_ARGC:
         sys.stderr.write("Usage: check_codex_comment.py <marker_prefix> <marker_suffix>\n")
         return 2
 

--- a/automation/jleechanorg_pr_automation/check_codex_comment.py
+++ b/automation/jleechanorg_pr_automation/check_codex_comment.py
@@ -15,7 +15,7 @@ def decide(marker_prefix: str, marker_suffix: str) -> Tuple[str, str]:
     try:
         # Read stdin with size limit to prevent memory exhaustion
         stdin_data = sys.stdin.read(MAX_JSON_SIZE)
-        if len(stdin_data) >= MAX_JSON_SIZE:
+        if len(stdin_data) > MAX_JSON_SIZE:
             sys.stderr.write("ERROR: PR data exceeds maximum size limit\n")
             return "post", ""
 

--- a/automation/jleechanorg_pr_automation/codex_branch_updater.py
+++ b/automation/jleechanorg_pr_automation/codex_branch_updater.py
@@ -1,0 +1,277 @@
+"""Playwright automation for managing Codex tasks on ChatGPT."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import random
+from getpass import getpass
+from pathlib import Path
+from typing import Dict, Tuple
+
+from playwright.async_api import (
+    Browser,
+    BrowserContext,
+    Page,
+    async_playwright,
+)
+from playwright.async_api import (
+    Error as PlaywrightError,
+)
+from playwright.async_api import (
+    TimeoutError as PlaywrightTimeoutError,
+)
+
+CHATGPT_CODEX_URL = "https://chatgpt.com/codex"
+CREDENTIALS_PATH = Path.home() / ".chatgpt_codex_credentials.json"
+AUTH_STATE_PATH = Path.home() / ".chatgpt_codex_auth_state.json"
+TASK_CARD_SELECTOR = '[data-testid="codex-task-card"]'
+UPDATE_BRANCH_BUTTON_SELECTOR = 'button:has-text("Update Branch")'
+TASK_TITLE_SELECTOR = '[data-testid="codex-task-title"]'
+
+
+def _save_credentials(credentials: Dict[str, str]) -> None:
+    """Persist credentials to disk with restrictive permissions."""
+
+    CREDENTIALS_PATH.write_text(json.dumps(credentials, indent=2))
+    os.chmod(CREDENTIALS_PATH, 0o600)
+
+
+def _load_credentials() -> Dict[str, str] | None:
+    """Return stored credentials if available and well formed."""
+
+    if not CREDENTIALS_PATH.exists():
+        return None
+
+    try:
+        data = json.loads(CREDENTIALS_PATH.read_text())
+    except json.JSONDecodeError:
+        return None
+
+    email = data.get("email")
+    password = data.get("password")
+    if not email or not password:
+        return None
+
+    return {"email": email, "password": password}
+
+
+def prompt_for_credentials() -> Dict[str, str]:
+    """Prompt the user for credentials and persist them."""
+
+    print("🔐 ChatGPT Codex credentials not found. They will be stored locally at")
+    print(f"    {CREDENTIALS_PATH}")
+    email = input("ChatGPT email: ").strip()
+    password = getpass("ChatGPT password: ")
+
+    credentials = {"email": email, "password": password}
+    _save_credentials(credentials)
+    print("✅ Credentials saved locally (chmod 600).")
+    return credentials
+
+
+def get_credentials() -> Dict[str, str]:
+    """Load stored credentials or prompt the user."""
+
+    credentials = _load_credentials()
+    if credentials is None:
+        credentials = prompt_for_credentials()
+    return credentials
+
+
+async def ensure_logged_in(page: Page, credentials: Dict[str, str] | None = None) -> None:
+    """Log into ChatGPT Codex if required."""
+
+    await page.goto(CHATGPT_CODEX_URL, wait_until="domcontentloaded")
+
+    if await is_task_list_visible(page):
+        return
+
+    if credentials is None:
+        credentials = get_credentials()
+
+    login_trigger = page.get_by_role("link", name="Log in")
+    if await login_trigger.count() == 0:
+        login_trigger = page.get_by_role("button", name="Log in")
+    if await login_trigger.count():
+        await login_trigger.first().click()
+
+    await _complete_login_flow(page, credentials)
+
+
+async def _complete_login_flow(page: Page, credentials: Dict[str, str]) -> None:
+    """Fill in the login flow using the provided credentials."""
+
+    email_field = page.locator("input[type='email']")
+    await email_field.first().wait_for(timeout=30000)
+    await email_field.first().fill(credentials["email"])
+
+    next_button = page.get_by_role("button", name="Continue")
+    if await next_button.count():
+        await next_button.first().click()
+    else:
+        await page.keyboard.press("Enter")
+
+    password_field = page.locator("input[type='password']")
+    await password_field.first().wait_for(timeout=30000)
+    await password_field.first().fill(credentials["password"])
+
+    signin_button = page.get_by_role("button", name="Continue")
+    if await signin_button.count() == 0:
+        signin_button = page.get_by_role("button", name="Sign in")
+    if await signin_button.count() == 0:
+        signin_button = page.get_by_role("button", name="Log in")
+
+    if await signin_button.count():
+        await signin_button.first().click()
+    else:
+        await page.keyboard.press("Enter")
+
+    await page.wait_for_url("**/codex**", timeout=60000)
+    await wait_for_task_list(page)
+
+
+async def is_task_list_visible(page: Page) -> bool:
+    """Return True if the Codex task list is visible."""
+
+    task_cards = page.locator(TASK_CARD_SELECTOR)
+    try:
+        await task_cards.first().wait_for(timeout=5000)
+    except PlaywrightTimeoutError:
+        return False
+    return await task_cards.count() > 0
+
+
+async def wait_for_task_list(page: Page) -> None:
+    """Wait until task cards are available."""
+
+    await page.wait_for_selector(TASK_CARD_SELECTOR, timeout=60000)
+
+
+async def collect_task_metadata(page: Page, index: int) -> Tuple[str, str]:
+    """Return the title and status text for a given task card."""
+
+    task_card = page.locator(TASK_CARD_SELECTOR).nth(index)
+    title_locator = task_card.locator(TASK_TITLE_SELECTOR)
+    title = await title_locator.inner_text() if await title_locator.count() else f"Task #{index + 1}"
+    status_locator = task_card.locator("[data-testid='codex-task-status']")
+    status = await status_locator.inner_text() if await status_locator.count() else ""
+    return title.strip(), status.strip()
+
+
+async def process_tasks(page: Page) -> None:
+    """Iterate through all Codex tasks and click Update Branch when present."""
+
+    processed_indices: set[int] = set()
+
+    while True:
+        task_cards = page.locator(TASK_CARD_SELECTOR)
+        total_tasks = await task_cards.count()
+        if total_tasks == 0:
+            print("ℹ️  No tasks detected on Codex dashboard.")
+            return
+
+        pending_indices = [idx for idx in range(total_tasks) if idx not in processed_indices]
+        if not pending_indices:
+            print("🏁 Completed processing available tasks.")
+            return
+
+        for index in pending_indices:
+            task_card = task_cards.nth(index)
+            await task_card.scroll_into_view_if_needed()
+
+            title, status = await collect_task_metadata(page, index)
+            print(f"🔍 Inspecting {title} ({status or 'no status'})")
+
+            update_button = task_card.locator(UPDATE_BRANCH_BUTTON_SELECTOR)
+            button_count = await update_button.count()
+            if button_count:
+                try:
+                    await update_button.first().click()
+                    print("✅ Clicked Update Branch directly from task card.")
+                    processed_indices.add(index)
+                    await _post_action_delay(page)
+                    continue
+                except PlaywrightError as exc:
+                    print(f"⚠️  Failed to click Update Branch on card: {exc}")
+
+            await task_card.click()
+            await page.wait_for_timeout(1000)
+
+            modal_update_button = page.locator(UPDATE_BRANCH_BUTTON_SELECTOR)
+            try:
+                await modal_update_button.first().wait_for(timeout=5000)
+                await modal_update_button.first().click()
+                print("✅ Clicked Update Branch inside task detail.")
+            except PlaywrightTimeoutError:
+                print("➡️  No Update Branch button found for this task. Skipping.")
+            except PlaywrightError as exc:
+                print(f"⚠️  Error clicking Update Branch in detail view: {exc}")
+
+            await _close_task_detail(page)
+            processed_indices.add(index)
+            await _post_action_delay(page)
+
+
+async def _close_task_detail(page: Page) -> None:
+    """Attempt to close a task detail view or navigate back."""
+
+    for name in ("Close", "Back", "Done"):
+        button = page.get_by_role("button", name=name)
+        if await button.count():
+            await button.first().click()
+            await page.wait_for_timeout(500)
+            return
+
+    try:
+        await page.go_back(wait_until="domcontentloaded")
+        await wait_for_task_list(page)
+    except PlaywrightError:
+        # Navigation back is optional - if it fails, continue with workflow
+        pass
+
+
+async def _post_action_delay(page: Page) -> None:
+    """Add a small randomized delay to appear human-like."""
+
+    delay_ms = random.randint(1000, 2500)
+    await page.wait_for_timeout(delay_ms)
+
+
+async def run() -> None:
+    """Entry point for running the Playwright automation."""
+
+    playwright = await async_playwright().start()
+    browser: Browser | None = None
+    context: BrowserContext | None = None
+    try:
+        browser = await playwright.chromium.launch(headless=False)
+        context_kwargs = {}
+        if AUTH_STATE_PATH.exists():
+            context_kwargs["storage_state"] = str(AUTH_STATE_PATH)
+        context = await browser.new_context(**context_kwargs)
+        page = await context.new_page()
+
+        await ensure_logged_in(page)
+        await wait_for_task_list(page)
+        await process_tasks(page)
+
+        await context.storage_state(path=str(AUTH_STATE_PATH))
+        print(f"💾 Authentication state saved to {AUTH_STATE_PATH}.")
+    finally:
+        if context is not None:
+            await context.close()
+        if browser is not None:
+            await browser.close()
+        await playwright.stop()
+
+
+def main() -> None:
+    """Synchronous wrapper for asyncio entry point."""
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/automation/jleechanorg_pr_automation/codex_config.py
+++ b/automation/jleechanorg_pr_automation/codex_config.py
@@ -1,0 +1,122 @@
+"""Shared configuration for Codex automation workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+DEFAULT_ASSISTANT_HANDLE = "coderabbitai"
+
+
+def compose_assistant_mentions(assistant_handle: str) -> str:
+    """Return the canonical mention list for the supplied assistant handle."""
+
+    return f"@codex @{assistant_handle} @copilot @cursor"
+
+
+DEFAULT_ASSISTANT_MENTIONS = compose_assistant_mentions(DEFAULT_ASSISTANT_HANDLE)
+
+CODEX_COMMENT_INTRO_BODY = (
+    "[AI automation] Codex will implement the code updates while {review_assistants_clause} "
+    "review support. Please make the following changes to this PR."
+)
+
+# Core instruction template with shared AI assistant intro text
+CODEX_COMMENT_TEMPLATE = (
+    "{comment_intro}\n\n"
+    "Use your judgment to fix comments from everyone or explain why it should not be fixed. "
+    'Follow binary response protocol - every comment needs "DONE" or "NOT DONE" classification '
+    "explicitly with an explanation. Address all comments on this PR. Fix any failing tests and "
+    "resolve merge conflicts. Push any commits needed to remote so the PR is updated."
+)
+
+CODEX_COMMIT_MARKER_PREFIX = "<!-- codex-automation-commit:"
+CODEX_COMMIT_MARKER_SUFFIX = "-->"
+
+
+def normalise_handle(assistant_handle: str | None) -> str:
+    """Return a sanitized assistant handle without a leading '@'."""
+
+    if assistant_handle is None:
+        return DEFAULT_ASSISTANT_HANDLE
+
+    # Treat an empty string as "unspecified" so we fall back to the default
+    # handle rather than emitting a bare "@" mention in comments.
+    cleaned = assistant_handle.lstrip("@")
+    return cleaned or DEFAULT_ASSISTANT_HANDLE
+
+
+def _extract_review_assistants(assistant_mentions: str) -> list[str]:
+    """Return the assistant mentions that participate in review support."""
+
+    tokens = assistant_mentions.split()
+    return [
+        token
+        for token in tokens
+        if token.startswith("@") and token.lower() != "@codex"
+    ]
+
+
+def _format_review_assistants(review_assistants: list[str]) -> str:
+    """Return a human readable list of review assistants for prose usage."""
+
+    if not review_assistants:
+        return "the review assistants"
+
+    # Strip leading "@" handles so we don't ping reviewers twice inside the prose.
+    prose_names = [assistant.lstrip("@") or assistant for assistant in review_assistants]
+
+    if len(prose_names) == 1:
+        return prose_names[0]
+
+    if len(prose_names) == 2:
+        return f"{prose_names[0]} and {prose_names[1]}"
+
+    return ", ".join(prose_names[:-1]) + f", and {prose_names[-1]}"
+
+
+def build_comment_intro(
+    assistant_mentions: str | None = None,
+    assistant_handle: str | None = None,
+) -> str:
+    """Return the shared Codex automation intro text for comment bodies."""
+
+    mentions = assistant_mentions
+    if mentions is None:
+        mentions = compose_assistant_mentions(normalise_handle(assistant_handle))
+    review_assistants = _extract_review_assistants(mentions)
+    assistants_text = _format_review_assistants(review_assistants)
+    if len(review_assistants) == 1:
+        clause = f"{assistants_text} focuses on"
+    else:
+        clause = f"{assistants_text} focus on"
+    intro_body = CODEX_COMMENT_INTRO_BODY.format(
+        review_assistants_clause=clause
+    )
+    intro_prefix = f"{mentions} " if mentions else ""
+    return f"{intro_prefix}{intro_body}"
+
+
+def build_default_comment(assistant_handle: str | None = None) -> str:
+    """Return the default Codex instruction text for the given handle."""
+
+    return CODEX_COMMENT_TEMPLATE.format(
+        comment_intro=build_comment_intro(assistant_handle=assistant_handle)
+    )
+
+
+@dataclass(frozen=True)
+class CodexConfig:
+    """Convenience container for sharing Codex automation constants."""
+
+    assistant_handle: str
+    comment_text: str
+    commit_marker_prefix: str = CODEX_COMMIT_MARKER_PREFIX
+    commit_marker_suffix: str = CODEX_COMMIT_MARKER_SUFFIX
+
+    @classmethod
+    def from_env(cls, assistant_handle: str | None) -> CodexConfig:
+        handle = normalise_handle(assistant_handle)
+        return cls(
+            assistant_handle=handle,
+            comment_text=build_default_comment(handle),
+        )

--- a/automation/jleechanorg_pr_automation/jleechanorg_pr_monitor.py
+++ b/automation/jleechanorg_pr_automation/jleechanorg_pr_monitor.py
@@ -1,0 +1,1216 @@
+#!/usr/bin/env python3
+"""
+jleechanorg PR Monitor - Cross-Organization Automation
+
+Discovers and processes open PRs across the jleechanorg organization by
+posting configurable automation comments with safety limits integration.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import traceback
+from collections import Counter
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from .automation_safety_manager import AutomationSafetyManager
+from .automation_utils import AutomationUtils
+from .codex_config import (
+    CODEX_COMMIT_MARKER_PREFIX as SHARED_MARKER_PREFIX,
+)
+from .codex_config import (
+    CODEX_COMMIT_MARKER_SUFFIX as SHARED_MARKER_SUFFIX,
+)
+from .codex_config import (
+    build_comment_intro,
+)
+from .utils import json_manager, setup_logging
+
+
+class JleechanorgPRMonitor:
+    """Cross-organization PR monitoring with Codex automation comments"""
+
+    @staticmethod
+    def _redact_email(email: Optional[str]) -> Optional[str]:
+        """Redact email for logging while preserving domain for debugging"""
+        if not email or "@" not in email:
+            return email
+        user, domain = email.rsplit("@", 1)
+        if len(user) <= 2:
+            return f"***@{domain}"
+        return f"{user[:2]}***@{domain}"
+
+    CODEX_COMMIT_MARKER_PREFIX = SHARED_MARKER_PREFIX
+    CODEX_COMMIT_MARKER_SUFFIX = SHARED_MARKER_SUFFIX
+    CODEX_COMMIT_MESSAGE_MARKER = "[codex-automation-commit]"
+    CODEX_BOT_IDENTIFIER = "codex"
+    # GitHub short SHAs display with a minimum of 7 characters, while full SHAs are 40 characters.
+    CODEX_COMMIT_SHA_LENGTH_RANGE: Tuple[int, int] = (7, 40)
+    CODEX_SUMMARY_COMMIT_PATTERNS = [
+        re.compile(
+            rf"/blob/([0-9a-fA-F]{{{CODEX_COMMIT_SHA_LENGTH_RANGE[0]},{CODEX_COMMIT_SHA_LENGTH_RANGE[1]}}})/"
+        ),
+        re.compile(
+            rf"/commit/([0-9a-fA-F]{{{CODEX_COMMIT_SHA_LENGTH_RANGE[0]},{CODEX_COMMIT_SHA_LENGTH_RANGE[1]}}})"
+        ),
+        # Cursor Bugbot summaries reference the pending Codex commit in prose, e.g.
+        # "Written by Cursor Bugbot for commit c279655."
+        re.compile(
+            rf"\bcommit\b[^0-9a-fA-F]{{0,5}}([0-9a-fA-F]{{{CODEX_COMMIT_SHA_LENGTH_RANGE[0]},{CODEX_COMMIT_SHA_LENGTH_RANGE[1]}}})",
+            re.IGNORECASE,
+        ),
+    ]
+
+    _HEAD_COMMIT_DETAILS_QUERY = """
+        query($owner: String!, $name: String!, $prNumber: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $prNumber) {
+              headRefOid
+              commits(last: 1) {
+                nodes {
+                  commit {
+                    oid
+                    messageHeadline
+                    message
+                    author {
+                      email
+                      name
+                      user { login }
+                    }
+                    committer {
+                      email
+                      name
+                      user { login }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+
+    _codex_actor_keywords = [
+        "codex",
+        "coderabbitai",
+        "coderabbit",
+        "copilot",
+        "cursor",
+    ]
+    _codex_actor_patterns = [
+        re.compile(rf"\b{keyword}\b", re.IGNORECASE)
+        for keyword in _codex_actor_keywords
+    ]
+    _codex_commit_message_pattern_str = (
+        r"\[(?:" + "|".join(_codex_actor_keywords) + r")-automation-commit\]"
+    )
+    _codex_commit_message_pattern = re.compile(
+        _codex_commit_message_pattern_str,
+        re.IGNORECASE,
+    )
+
+    @staticmethod
+    def _extract_actor_fields(
+        actor: Optional[Dict],
+    ) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        if not isinstance(actor, dict):
+            return (None, None, None)
+
+        user_info = actor.get("user")
+        login = user_info.get("login") if isinstance(user_info, dict) else None
+        email = actor.get("email")
+        name = actor.get("name")
+        return (login, email, name)
+
+    def __init__(self):
+        self.logger = setup_logging(__name__)
+
+        self.assistant_mentions = os.environ.get(
+            "AI_ASSISTANT_MENTIONS",
+            "@codex @coderabbitai @copilot @cursor",
+        )
+
+        self.wrapper_managed = os.environ.get("AUTOMATION_SAFETY_WRAPPER") == "1"
+
+        # Processing history persisted to permanent location
+        self.history_base_dir = Path.home() / "Library" / "Logs" / "worldarchitect-automation" / "pr_history"
+        self.history_base_dir.mkdir(parents=True, exist_ok=True)
+
+        # Organization settings
+        self.organization = "jleechanorg"
+        self.base_project_dir = Path.home() / "projects"
+
+        safety_data_dir = os.environ.get("AUTOMATION_SAFETY_DATA_DIR")
+        if not safety_data_dir:
+            default_dir = Path.home() / "Library" / "Application Support" / "worldarchitect-automation"
+            default_dir.mkdir(parents=True, exist_ok=True)
+            safety_data_dir = str(default_dir)
+
+        self.safety_manager = AutomationSafetyManager(safety_data_dir)
+
+        self.logger.info("🏢 Initialized jleechanorg PR monitor")
+        self.logger.info(f"📁 History storage: {self.history_base_dir}")
+        self.logger.info("💬 Comment-only automation mode")
+    def _get_history_file(self, repo_name: str, branch_name: str) -> Path:
+        """Get history file path for specific repo/branch"""
+        repo_dir = self.history_base_dir / repo_name
+        repo_dir.mkdir(parents=True, exist_ok=True)
+
+        # Replace slashes in branch names to avoid creating nested directories
+        safe_branch_name = branch_name.replace("/", "_")
+        return repo_dir / f"{safe_branch_name}.json"
+
+    def _load_branch_history(self, repo_name: str, branch_name: str) -> Dict[str, str]:
+        """Load processed PRs for a specific repo/branch"""
+        history_file = self._get_history_file(repo_name, branch_name)
+        return json_manager.read_json(str(history_file), {})
+
+    def _save_branch_history(self, repo_name: str, branch_name: str, history: Dict[str, str]) -> None:
+        """Save processed PRs for a specific repo/branch"""
+        history_file = self._get_history_file(repo_name, branch_name)
+        if not json_manager.write_json(str(history_file), history):
+            self.logger.error(f"❌ Error saving history for {repo_name}/{branch_name}: write failed")
+
+    def _should_skip_pr(self, repo_name: str, branch_name: str, pr_number: int, current_commit: str) -> bool:
+        """Check if PR should be skipped based on recent processing"""
+        history = self._load_branch_history(repo_name, branch_name)
+        pr_key = str(pr_number)
+
+        # If we haven't processed this PR before, don't skip
+        if pr_key not in history:
+            return False
+
+        # If commit has changed since we processed it, don't skip
+        last_processed_commit = history[pr_key]
+        if last_processed_commit != current_commit:
+            self.logger.info(f"🔄 PR {repo_name}/{branch_name}#{pr_number} has new commit ({current_commit[:8]} vs {last_processed_commit[:8]})")
+            return False
+
+        # We processed this PR with this exact commit, skip it
+        self.logger.info(f"⏭️ Skipping PR {repo_name}/{branch_name}#{pr_number} - already processed commit {current_commit[:8]}")
+        return True
+
+    def _record_processed_pr(self, repo_name: str, branch_name: str, pr_number: int, commit_sha: str) -> None:
+        """Record that we've processed a PR with a specific commit"""
+        history = self._load_branch_history(repo_name, branch_name)
+        pr_key = str(pr_number)
+        history[pr_key] = commit_sha
+        self._save_branch_history(repo_name, branch_name, history)
+        self.logger.debug(f"📝 Recorded processing of PR {repo_name}/{branch_name}#{pr_number} with commit {commit_sha[:8]}")
+
+    # TDD GREEN: Implement methods for PR filtering and actionable counting
+    def _record_pr_processing(self, repo_name: str, branch_name: str, pr_number: int, commit_sha: str) -> None:
+        """Record that a PR has been processed (alias for compatibility)"""
+        self._record_processed_pr(repo_name, branch_name, pr_number, commit_sha)
+
+    def _normalize_repository_name(self, repository: str) -> str:
+        """Return full owner/repo identifier for GitHub CLI operations."""
+
+        if not repository:
+            return repository
+
+        if "/" in repository:
+            return repository
+
+        return f"{self.organization}/{repository}"
+
+    def is_pr_actionable(self, pr_data: Dict) -> bool:
+        """Determine if a PR is actionable (should be processed)"""
+        # Closed PRs are not actionable
+        if pr_data.get("state", "").lower() != "open":
+            return False
+
+        # PRs with no commits are not actionable
+        head_ref_oid = pr_data.get("headRefOid")
+        if not head_ref_oid:
+            return False
+
+        # Check if already processed with this commit
+        repo_name = pr_data.get("repository", "")
+        branch_name = pr_data.get("headRefName", "")
+        pr_number = pr_data.get("number", 0)
+
+        if self._should_skip_pr(repo_name, branch_name, pr_number, head_ref_oid):
+            return False
+
+        # Open PRs (including drafts) with new commits are actionable
+        return True
+
+    def filter_eligible_prs(self, pr_list: List[Dict]) -> List[Dict]:
+        """Filter list to return only actionable PRs"""
+        eligible = []
+        for pr in pr_list:
+            if self.is_pr_actionable(pr):
+                eligible.append(pr)
+        return eligible
+
+    def process_actionable_prs(self, pr_list: List[Dict], target_count: int) -> int:
+        """Process up to target_count actionable PRs, returning count processed"""
+        processed = 0
+        for pr in pr_list:
+            if processed >= target_count:
+                break
+            if self.is_pr_actionable(pr):
+                # Simulate processing (for testing)
+                processed += 1
+        return processed
+
+    def filter_and_process_prs(self, pr_list: List[Dict], target_actionable_count: int) -> int:
+        """Filter PRs to actionable ones and process up to target count"""
+        eligible_prs = self.filter_eligible_prs(pr_list)
+        return self.process_actionable_prs(eligible_prs, target_actionable_count)
+
+    def find_eligible_prs(self, limit: int = 10) -> List[Dict]:
+        """Find eligible PRs from live GitHub data"""
+        all_prs = self.discover_open_prs()
+        eligible_prs = self.filter_eligible_prs(all_prs)
+        return eligible_prs[:limit]
+
+    def run_monitoring_cycle_with_actionable_count(self, target_actionable_count: int = 20) -> Dict:
+        """Enhanced monitoring cycle that processes exactly target actionable PRs"""
+        all_prs = self.discover_open_prs()
+
+        # Sort by most recently updated first
+        all_prs.sort(key=lambda pr: pr.get("updatedAt", ""), reverse=True)
+
+        actionable_processed = 0
+        skipped_count = 0
+        processing_failures = 0
+
+        # Count ALL non-actionable PRs as skipped, not just those we encounter before target
+        for pr in all_prs:
+            if not self.is_pr_actionable(pr):
+                skipped_count += 1
+
+        # Process actionable PRs up to target
+        for pr in all_prs:
+            if actionable_processed >= target_actionable_count:
+                break
+
+            if not self.is_pr_actionable(pr):
+                continue  # Already counted in skipped above
+
+            # Attempt to process the PR
+            repo_name = pr.get("repository", "")
+            pr_number = pr.get("number", 0)
+            repo_full = pr.get("repositoryFullName", f"jleechanorg/{repo_name}")
+
+            # Reserve a processing slot for this PR
+            if not self.safety_manager.try_process_pr(pr_number, repo=repo_full):
+                self.logger.info(f"⚠️ PR {repo_full}#{pr_number} blocked by safety manager - consecutive failures or rate limit")
+                processing_failures += 1
+                continue
+
+            try:
+                success = self._process_pr_comment(repo_name, pr_number, pr)
+                if success:
+                    actionable_processed += 1
+                else:
+                    processing_failures += 1
+            except Exception as e:
+                self.logger.error(f"Error processing PR {repo_name}#{pr_number}: {e}")
+                processing_failures += 1
+            finally:
+                # Always release the processing slot
+                self.safety_manager.release_pr_slot(pr_number, repo=repo_full)
+
+        return {
+            "actionable_processed": actionable_processed,
+            "total_discovered": len(all_prs),
+            "skipped_count": skipped_count,
+            "processing_failures": processing_failures
+        }
+
+    def _process_pr_comment(self, repo_name: str, pr_number: int, pr_data: Dict) -> bool:
+        """Process a PR by posting a comment (used by tests and enhanced monitoring)"""
+        try:
+            # Use the existing comment posting method
+            repo_full_name = pr_data.get("repositoryFullName", f"jleechanorg/{repo_name}")
+            result = self.post_codex_instruction_simple(repo_full_name, pr_number, pr_data)
+            # Return True only if comment was actually posted
+            return result == "posted"
+        except Exception as e:
+            self.logger.error(f"Error processing comment for PR {repo_name}#{pr_number}: {e}")
+            return False
+
+    def discover_open_prs(self) -> List[Dict]:
+        """Discover open PRs updated in the last 24 hours across the organization."""
+
+        self.logger.info(f"🔍 Discovering open PRs in {self.organization} organization (last 24 hours)")
+
+        now = datetime.utcnow()
+        one_day_ago = now - timedelta(hours=24)
+        self.logger.info("📅 Filtering PRs updated since: %s UTC", one_day_ago.strftime("%Y-%m-%d %H:%M:%S"))
+
+        graphql_query = """
+        query($searchQuery: String!, $cursor: String) {
+          search(type: ISSUE, query: $searchQuery, first: 100, after: $cursor) {
+            nodes {
+              __typename
+              ... on PullRequest {
+                number
+                title
+                headRefName
+                baseRefName
+                updatedAt
+                url
+                author { login resourcePath url }
+                headRefOid
+                state
+                isDraft
+                repository { name nameWithOwner }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+        """
+
+        search_query = f"org:{self.organization} is:pr is:open"
+        cursor: Optional[str] = None
+        recent_prs: List[Dict] = []
+
+        while True:
+            gh_api_cmd = [
+                "gh",
+                "api",
+                "graphql",
+                "-f",
+                f"query={graphql_query}",
+                "-f",
+                f"searchQuery={search_query}",
+            ]
+            if cursor:
+                gh_api_cmd.extend(["-f", f"cursor={cursor}"])
+
+            api_result = AutomationUtils.execute_subprocess_with_timeout(gh_api_cmd, timeout=60, check=False)
+            if api_result.returncode != 0:
+                raise RuntimeError(f"GraphQL search failed: {api_result.stderr.strip()}")
+
+            try:
+                api_data = json.loads(api_result.stdout)
+            except json.JSONDecodeError as exc:
+                self.logger.error("❌ Failed to parse GraphQL response: %s", exc)
+                raise
+
+            search_data = api_data.get("data", {}).get("search")
+            if not search_data:
+                break
+
+            nodes = search_data.get("nodes", [])
+            for node in nodes:
+                if node.get("__typename") != "PullRequest":
+                    continue
+
+                updated_str = node.get("updatedAt")
+                if not updated_str:
+                    continue
+
+                try:
+                    updated_time = datetime.fromisoformat(updated_str.replace("Z", "+00:00")).replace(tzinfo=None)
+                except ValueError:
+                    self.logger.debug(
+                        "⚠️ Invalid date format for PR %s: %s", node.get("number"), updated_str
+                    )
+                    continue
+
+                if updated_time < one_day_ago:
+                    continue
+
+                repo_info = node.get("repository") or {}
+                author_info = node.get("author") or {}
+                if "login" not in author_info:
+                    author_info = {**author_info, "login": author_info.get("login")}
+
+                normalized = {
+                    "number": node.get("number"),
+                    "title": node.get("title"),
+                    "headRefName": node.get("headRefName"),
+                    "baseRefName": node.get("baseRefName"),
+                    "updatedAt": updated_str,
+                    "url": node.get("url"),
+                    "author": author_info,
+                    "headRefOid": node.get("headRefOid"),
+                    "state": node.get("state"),
+                    "isDraft": node.get("isDraft"),
+                    "repository": repo_info.get("name"),
+                    "repositoryFullName": repo_info.get("nameWithOwner"),
+                    "updated_datetime": updated_time,
+                }
+                recent_prs.append(normalized)
+
+            page_info = search_data.get("pageInfo") or {}
+            if not page_info.get("hasNextPage"):
+                break
+
+            cursor = page_info.get("endCursor")
+            if not cursor:
+                break
+
+        if not recent_prs:
+            self.logger.info("📭 No recent open PRs discovered")
+            return []
+
+        recent_prs.sort(key=lambda x: x.get("updated_datetime", datetime.min), reverse=True)
+
+        repo_counter = Counter(pr.get("repository") for pr in recent_prs if pr.get("repository"))
+        for repo_name, count in repo_counter.items():
+            self.logger.info("📋 %s: %s recent PRs", repo_name, count)
+
+        self.logger.info("🎯 Total recent PRs discovered (last 24 hours): %s", len(recent_prs))
+
+        self.logger.info("📊 Most recently updated PRs:")
+        for i, pr in enumerate(recent_prs[:5], 1):
+            updated_str = pr["updated_datetime"].strftime("%Y-%m-%d %H:%M")
+            self.logger.info("  %s. %s #%s - %s", i, pr["repositoryFullName"], pr["number"], updated_str)
+
+        return recent_prs
+
+
+    def _find_local_repository(self, repo_name: str) -> Optional[Path]:
+        """Find local repository path for given repo name"""
+
+        def is_git_repository(path: Path) -> bool:
+            """Check if path is a git repository"""
+            git_path = path / ".git"
+            return git_path.exists()
+
+        # Check current working directory first
+        current_dir = Path.cwd()
+        if is_git_repository(current_dir):
+            # Check if this is related to the target repository
+            if repo_name.lower() in current_dir.name.lower() or "worldarchitect" in current_dir.name.lower():
+                self.logger.debug(f"🎯 Found local repo (current dir): {current_dir}")
+                return current_dir
+
+        # Common patterns for local repositories
+        search_paths = [
+            # Standard patterns in ~/projects/
+            self.base_project_dir / repo_name,
+            self.base_project_dir / f"{repo_name}_worker",
+            self.base_project_dir / f"{repo_name}_worker1",
+            self.base_project_dir / f"{repo_name}_worker2",
+            # Project patterns in home directory
+            Path.home() / f"project_{repo_name}",
+            Path.home() / f"project_{repo_name}" / repo_name,
+            # Nested repository patterns
+            Path.home() / f"project_{repo_name}_frontend" / f"{repo_name}_frontend",
+        ]
+
+        for path in search_paths:
+            if path.exists() and is_git_repository(path):
+                self.logger.debug(f"🎯 Found local repo: {path}")
+                return path
+
+        # Search for any directory containing the repo name in ~/projects/
+        if self.base_project_dir.exists():
+            for path in self.base_project_dir.iterdir():
+                if path.is_dir() and repo_name.lower() in path.name.lower():
+                    if is_git_repository(path):
+                        self.logger.debug(f"🎯 Found local repo (fuzzy): {path}")
+                        return path
+
+        # Search for project_* patterns in home directory
+        home_dir = Path.home()
+        for path in home_dir.iterdir():
+            if path.is_dir() and path.name.startswith(f"project_{repo_name}"):
+                # Check if it's a direct repo
+                if is_git_repository(path):
+                    self.logger.debug(f"🎯 Found local repo (home): {path}")
+                    return path
+                # Check if repo is nested inside
+                nested_repo = path / repo_name
+                if nested_repo.exists() and is_git_repository(nested_repo):
+                    self.logger.debug(f"🎯 Found local repo (nested): {nested_repo}")
+                    return nested_repo
+
+        return None
+
+    def post_codex_instruction_simple(self, repository: str, pr_number: int, pr_data: Dict) -> str:
+        """Post codex instruction comment to PR"""
+        repo_full = self._normalize_repository_name(repository)
+        self.logger.info(f"💬 Requesting Codex support for {repo_full} PR #{pr_number}")
+
+        # Extract repo name and branch from PR data
+        repo_name = repo_full.split("/")[-1]
+        branch_name = pr_data.get("headRefName", "unknown")
+
+        # Get current PR state including commit SHA
+        head_sha, comments = self._get_pr_comment_state(repo_full, pr_number)
+        head_commit_details = None
+        if head_sha:
+            head_commit_details = self._get_head_commit_details(repo_full, pr_number, head_sha)
+            if head_commit_details and self._is_head_commit_from_codex(head_commit_details):
+                self.logger.debug(
+                    "🆔 Head commit %s for %s#%s already attributed to Codex",
+                    head_sha[:8],
+                    repo_full,
+                    pr_number,
+                )
+                self._record_processed_pr(repo_name, branch_name, pr_number, head_sha)
+                return "skipped"
+
+        if not head_sha:
+            self.logger.warning(
+                f"⚠️ Could not determine commit SHA for PR #{pr_number}; proceeding without marker gating"
+            )
+        else:
+            # Check if we should skip this PR based on commit-based tracking
+            if self._should_skip_pr(repo_name, branch_name, pr_number, head_sha):
+                self.logger.info(f"⏭️ Skipping PR #{pr_number} - already processed this commit")
+                return "skipped"
+
+            if self._has_codex_comment_for_commit(comments, head_sha):
+                self.logger.info(
+                    f"♻️ Codex instruction already posted for commit {head_sha[:8]} on PR #{pr_number}, skipping"
+                )
+                self._record_processed_pr(repo_name, branch_name, pr_number, head_sha)
+                return "skipped"
+
+            if self._has_pending_codex_commit(comments, head_sha):
+                self.logger.info(
+                    f"⏳ Pending Codex automation commit {head_sha[:8]} detected on PR #{pr_number}; skipping re-run"
+                )
+                self._record_processed_pr(repo_name, branch_name, pr_number, head_sha)
+                return "skipped"
+
+        # Build comment body that tells Codex to fix PR comments and failing tests
+        comment_body = self._build_codex_comment_body_simple(
+            repo_full,
+            pr_number,
+            pr_data,
+            head_sha,
+        )
+
+        # Post the comment
+        try:
+            comment_cmd = [
+                "gh", "pr", "comment", str(pr_number),
+                "--repo", repo_full,
+                "--body", comment_body
+            ]
+
+            result = AutomationUtils.execute_subprocess_with_timeout(comment_cmd, timeout=30)
+
+            # Check if subprocess succeeded
+            if hasattr(result, "returncode") and result.returncode != 0:
+                self.logger.error(
+                    f"❌ Failed to post comment on PR #{pr_number}: Subprocess exited with code {result.returncode}. "
+                    f"Output: {getattr(result, 'stdout', '')} Error: {getattr(result, 'stderr', '')}"
+                )
+                return "failed"
+
+            self.logger.info(f"✅ Posted Codex instruction comment on PR #{pr_number} ({repo_full})")
+
+            # Record that we've processed this PR with this commit when available
+            if head_sha:
+                self._record_processed_pr(repo_name, branch_name, pr_number, head_sha)
+
+            return "posted"
+
+        except subprocess.CalledProcessError as e:
+            self.logger.error(f"❌ Failed to post comment on PR #{pr_number}: {e.stderr}")
+            return "failed"
+        except Exception as e:
+            self.logger.error(f"💥 Unexpected error posting comment: {e}")
+            return "failed"
+
+
+
+
+
+
+
+
+
+
+
+    def _are_tests_passing(self, repository: str, pr_number: int) -> bool:
+        """Check if tests are passing on the PR"""
+        try:
+            # Get PR status checks
+            result = AutomationUtils.execute_subprocess_with_timeout([
+                "gh", "pr", "view", str(pr_number),
+                "--repo", repository,
+                "--json", "statusCheckRollup"
+            ], timeout=30)
+
+            pr_status = json.loads(result.stdout)
+            status_checks = pr_status.get("statusCheckRollup", [])
+
+            # If no status checks are configured, assume tests are failing
+            if not status_checks:
+                self.logger.debug(f"⚠️ No status checks configured for PR #{pr_number}, assuming failing")
+                return False
+
+            # Check if all status checks are successful
+            for check in status_checks:
+                if check.get("state") not in ["SUCCESS", "NEUTRAL"]:
+                    self.logger.debug(f"❌ Status check failed: {check.get('name')} - {check.get('state')}")
+                    return False
+
+            self.logger.debug(f"✅ All {len(status_checks)} status checks passing for PR #{pr_number}")
+            return True
+
+        except Exception as e:
+            self.logger.warning(f"⚠️ Could not check test status for PR #{pr_number}: {e}")
+            return False  # Assume tests are failing if we can't check
+
+    def _build_codex_comment_body_simple(
+        self,
+        repository: str,
+        pr_number: int,
+        pr_data: Dict,
+        head_sha: str,
+    ) -> str:
+        """Build comment body that tells all AI assistants to fix PR comments, tests, and merge conflicts"""
+
+        intro_line = build_comment_intro(assistant_mentions=self.assistant_mentions)
+        comment_body = f"""{intro_line}
+
+**Summary (Execution Flow):**
+1. Review every outstanding PR comment to understand required fixes and clarifications.
+2. Implement code or configuration updates that address each comment, then reply with explicit DONE/NOT DONE outcomes plus context.
+3. Run the relevant test suites locally and in CI, repairing any failures until the checks report success.
+4. Rebase or merge with the base branch to clear conflicts, then push the updated commits to this PR.
+5. Perform a final self-review to confirm linting, formatting, and documentation standards are met before handoff.
+
+**PR Details:**
+- Title: {pr_data.get('title', 'Unknown')}
+- Author: {pr_data.get('author', {}).get('login', 'unknown')}
+- Branch: {pr_data.get('headRefName', 'unknown')}
+- Commit: {head_sha[:8] if head_sha else 'unknown'} ({head_sha or 'unknown'})
+
+**Instructions:**
+Use your judgment to fix comments from everyone or explain why it should not be fixed. Follow binary response protocol - every comment needs "DONE" or "NOT DONE" classification explicitly with an explanation. Address all comments on this PR. Fix any failing tests and resolve merge conflicts. Push any commits needed to remote so the PR is updated.
+
+**Tasks:**
+1. **Address all comments** - Review and implement ALL feedback from reviewers
+2. **Fix failing tests** - Review test failures and implement fixes
+3. **Resolve merge conflicts** - Handle any conflicts with the base branch
+4. **Ensure code quality** - Follow project standards and best practices
+
+**Automation Markers:**
+- Leave the hidden comment marker `<!-- codex-automation-commit:... -->` in this thread so we only re-ping you after new commits.
+- Include `{self.CODEX_COMMIT_MESSAGE_MARKER}` in the commit message of your next push so we can confirm Codex authored it (even if the author/committer metadata already shows Codex).
+"""
+
+        if head_sha:
+            comment_body += (
+                f"\n\n{self.CODEX_COMMIT_MARKER_PREFIX}{head_sha}"
+                f"{self.CODEX_COMMIT_MARKER_SUFFIX}"
+            )
+
+        return comment_body
+
+    def _get_pr_comment_state(self, repo_full_name: str, pr_number: int) -> Tuple[Optional[str], List[Dict]]:
+        """Fetch PR comment data needed for Codex comment gating"""
+        view_cmd = [
+            "gh",
+            "pr",
+            "view",
+            str(pr_number),
+            "--repo",
+            repo_full_name,
+            "--json",
+            "headRefOid,comments",
+        ]
+
+        try:
+            result = AutomationUtils.execute_subprocess_with_timeout(
+                view_cmd,
+                timeout=30
+            )
+            pr_data = json.loads(result.stdout or "{}")
+            head_sha = pr_data.get("headRefOid")
+
+            # Handle different comment structures from GitHub API
+            comments_data = pr_data.get("comments", [])
+            if isinstance(comments_data, dict):
+                comments = comments_data.get("nodes", [])
+            elif isinstance(comments_data, list):
+                comments = comments_data
+            else:
+                comments = []
+
+            # Ensure comments are sorted by creation time (oldest first)
+            # GitHub API should return them sorted, but let's be explicit
+            comments.sort(
+                key=lambda c: (c.get("createdAt") or c.get("updatedAt") or "")
+            )
+
+            return head_sha, comments
+        except subprocess.CalledProcessError as e:
+            error_message = e.stderr.strip() if e.stderr else str(e)
+            self.logger.warning(
+                f"⚠️ Failed to fetch PR comment state for PR #{pr_number}: {error_message}"
+            )
+        except json.JSONDecodeError as e:
+            self.logger.warning(
+                f"⚠️ Failed to parse PR comment state for PR #{pr_number}: {e}"
+            )
+
+        return None, []
+
+    def _get_head_commit_details(
+        self,
+        repo_full_name: str,
+        pr_number: int,
+        expected_sha: Optional[str] = None,
+    ) -> Optional[Dict[str, Optional[str]]]:
+        """Fetch metadata for the PR head commit using the GitHub GraphQL API."""
+
+        if "/" not in repo_full_name:
+            self.logger.debug(
+                "⚠️ Cannot fetch commit details for %s - invalid repo format",
+                repo_full_name,
+            )
+            return None
+
+        owner, name = repo_full_name.split("/", 1)
+
+        # Validate GitHub naming constraints (alphanumeric, hyphens, periods, underscores, max 100 chars)
+        github_name_pattern = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9\-\._]{0,98}[a-zA-Z0-9])?$")
+        if not github_name_pattern.match(owner) or not github_name_pattern.match(name):
+            self.logger.warning(
+                "⚠️ Invalid GitHub identifiers: owner='%s', name='%s'",
+                owner,
+                name,
+            )
+            return None
+
+        # Validate PR number is positive integer
+        if not isinstance(pr_number, int) or pr_number <= 0:
+            self.logger.warning("⚠️ Invalid PR number: %s", pr_number)
+            return None
+
+        cmd = [
+            "gh",
+            "api",
+            "graphql",
+            "-f",
+            f"query={self._HEAD_COMMIT_DETAILS_QUERY}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"prNumber={pr_number}",
+        ]
+
+        try:
+            result = AutomationUtils.execute_subprocess_with_timeout(cmd, timeout=30)
+        except subprocess.CalledProcessError as exc:
+            self.logger.debug(
+                "⚠️ Failed to fetch head commit details for %s#%s: %s",
+                repo_full_name,
+                pr_number,
+                exc.stderr or exc,
+            )
+            return None
+        except Exception as exc:
+            self.logger.debug(
+                "⚠️ Error executing head commit lookup for %s#%s: %s",
+                repo_full_name,
+                pr_number,
+                exc,
+            )
+            return None
+
+        try:
+            data = json.loads(result.stdout or "{}")
+        except json.JSONDecodeError as exc:
+            self.logger.debug(
+                "⚠️ Failed to decode commit details for %s#%s: %s",
+                repo_full_name,
+                pr_number,
+                exc,
+            )
+            return None
+
+        pr_data = (
+            data.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+        )
+        commits_data = pr_data.get("commits") or {}
+        commit_nodes = commits_data.get("nodes") if isinstance(commits_data, dict) else None
+        if not commit_nodes or not isinstance(commit_nodes, list):
+            return None
+
+        commit_info = commit_nodes[-1].get("commit") if commit_nodes else None
+        if not commit_info:
+            return None
+
+        commit_sha = commit_info.get("oid")
+        if expected_sha and commit_sha and commit_sha != expected_sha:
+            # If GitHub served stale data, ignore it to avoid mismatched metadata.
+            return None
+
+        author_info = commit_info.get("author") or {}
+        committer_info = commit_info.get("committer") or {}
+
+        author_login, author_email, author_name = self._extract_actor_fields(author_info)
+        committer_login, committer_email, committer_name = self._extract_actor_fields(committer_info)
+
+        # Log commit detection with redacted emails for privacy
+        self.logger.debug(
+            "📧 Commit %s: author=%s (%s), committer=%s (%s)",
+            commit_sha[:8] if commit_sha else "unknown",
+            author_login or "unknown",
+            self._redact_email(author_email) if author_email else "no-email",
+            committer_login or "unknown",
+            self._redact_email(committer_email) if committer_email else "no-email",
+        )
+
+        return {
+            "sha": commit_sha,
+            "author_login": author_login,
+            "author_email": author_email,
+            "author_name": author_name,
+            "committer_login": committer_login,
+            "committer_email": committer_email,
+            "committer_name": committer_name,
+            "message_headline": commit_info.get("messageHeadline"),
+            "message": commit_info.get("message"),
+        }
+
+    def _extract_commit_marker(self, comment_body: str) -> Optional[str]:
+        """Extract commit marker from Codex automation comment"""
+        if not comment_body:
+            return None
+
+        prefix_index = comment_body.find(self.CODEX_COMMIT_MARKER_PREFIX)
+        if prefix_index == -1:
+            return None
+
+        start_index = prefix_index + len(self.CODEX_COMMIT_MARKER_PREFIX)
+        end_index = comment_body.find(self.CODEX_COMMIT_MARKER_SUFFIX, start_index)
+        if end_index == -1:
+            return None
+
+        return comment_body[start_index:end_index].strip()
+
+    def _has_codex_comment_for_commit(self, comments: List[Dict], head_sha: str) -> bool:
+        """Determine if Codex instruction already exists for the latest commit"""
+        if not head_sha:
+            return False
+
+        for comment in comments:
+            body = comment.get("body", "")
+            marker_sha = self._extract_commit_marker(body)
+            if marker_sha and marker_sha == head_sha:
+                return True
+
+        return False
+
+    def _is_head_commit_from_codex(
+        self, commit_details: Optional[Dict[str, Optional[str]]]
+    ) -> bool:
+        """Determine if the head commit was authored or marked by Codex."""
+
+        if not commit_details:
+            return False
+
+        actor_fields = [
+            commit_details.get("author_login"),
+            commit_details.get("author_email"),
+            commit_details.get("author_name"),
+            commit_details.get("committer_login"),
+            commit_details.get("committer_email"),
+            commit_details.get("committer_name"),
+        ]
+
+        for field in actor_fields:
+            if field and isinstance(field, str):
+                if any(pattern.search(field) for pattern in self._codex_actor_patterns):
+                    return True
+
+        message_values = [
+            commit_details.get("message_headline"),
+            commit_details.get("message"),
+        ]
+
+        for message in message_values:
+            if message and isinstance(message, str):
+                if self._codex_commit_message_pattern.search(message):
+                    return True
+
+        return False
+
+    def _get_comment_author_login(self, comment: Dict) -> str:
+        """Return normalized author login for a comment."""
+        author = comment.get("author") or comment.get("user") or {}
+        if isinstance(author, dict):
+            return (author.get("login") or author.get("name") or "").strip()
+        if isinstance(author, str):
+            return author.strip()
+        return ""
+
+    def _extract_codex_summary_commit(self, comment_body: str) -> Optional[str]:
+        """Extract commit SHA referenced in Codex summary comment."""
+        if not comment_body:
+            return None
+
+        for pattern in self.CODEX_SUMMARY_COMMIT_PATTERNS:
+            match = pattern.search(comment_body)
+            if match:
+                return match.group(1).lower()
+
+        return None
+
+    def _has_pending_codex_commit(self, comments: List[Dict], head_sha: str) -> bool:
+        """Detect if latest commit was generated by Codex automation and is still pending."""
+        if not head_sha:
+            return False
+
+        normalized_head = head_sha.lower()
+
+        for comment in comments:
+            author_login = self._get_comment_author_login(comment)
+            if not author_login or self.CODEX_BOT_IDENTIFIER not in author_login.lower():
+                continue
+
+            summary_commit = self._extract_codex_summary_commit(comment.get("body", ""))
+            if not summary_commit:
+                continue
+
+            if summary_commit == normalized_head or normalized_head.startswith(
+                summary_commit
+            ):
+                return True
+
+        return False
+
+    def process_single_pr_by_number(self, pr_number: int, repository: str) -> bool:
+        """Process a specific PR by number and repository"""
+        repo_full = self._normalize_repository_name(repository)
+        self.logger.info(f"🎯 Processing target PR: {repo_full} #{pr_number}")
+
+        # Check global automation limits
+        if not self.safety_manager.can_start_global_run():
+            self.logger.warning("🚫 Global automation limit reached - cannot process target PR")
+            return False
+
+        try:
+            # Check safety limits for this specific PR first
+            if not self.safety_manager.try_process_pr(pr_number, repo=repo_full):
+                self.logger.warning(f"🚫 Safety limits exceeded for PR {repo_full} #{pr_number}")
+                return False
+
+            # Only record global run AFTER confirming we can process the PR
+            if not self.wrapper_managed:
+                self.safety_manager.record_global_run()
+                current_runs = self.safety_manager.get_global_runs()
+                self.logger.info(
+                    "📊 Recorded global run %s/%s before processing target PR",
+                    current_runs,
+                    self.safety_manager.global_limit,
+                )
+
+            # Process PR with guaranteed cleanup
+            try:
+                # Get PR details using gh CLI
+                result = AutomationUtils.execute_subprocess_with_timeout(
+                    ["gh", "pr", "view", str(pr_number), "--repo", repo_full, "--json", "title,headRefName,baseRefName,url,author"],
+                    timeout=30
+                )
+                pr_data = json.loads(result.stdout)
+
+                self.logger.info(f"📝 Found PR: {pr_data['title']}")
+
+                # Post codex instruction comment
+                comment_result = self.post_codex_instruction_simple(repo_full, pr_number, pr_data)
+                success = comment_result == "posted"
+
+                # Record PR processing attempt with result
+                result = "success" if success else "failure"
+                self.safety_manager.record_pr_attempt(
+                    pr_number,
+                    result,
+                    repo=repo_full,
+                    branch=pr_data.get("headRefName"),
+                )
+
+                if success:
+                    self.logger.info(f"✅ Successfully processed target PR {repo_full} #{pr_number}")
+                else:
+                    self.logger.error(f"❌ Failed to process target PR {repo_full} #{pr_number}")
+
+                return success
+
+            except subprocess.CalledProcessError as e:
+                self.logger.error(f"❌ Failed to get PR details for {repo_full} #{pr_number}: {e.stderr}")
+                return False
+            except json.JSONDecodeError as e:
+                self.logger.error(f"❌ Failed to parse PR data for {repo_full} #{pr_number}: {e}")
+                return False
+            finally:
+                # Always release the processing slot
+                self.safety_manager.release_pr_slot(pr_number, repo=repo_full)
+
+        except Exception as e:
+            self.logger.error(f"❌ Unexpected error processing target PR {repo_full} #{pr_number}: {e}")
+            self.logger.debug("Traceback: %s", traceback.format_exc())
+            return False
+
+    def run_monitoring_cycle(self, single_repo=None, max_prs=10):
+        """Run a complete monitoring cycle with actionable PR counting"""
+        self.logger.info("🚀 Starting jleechanorg PR monitoring cycle")
+
+        if not self.safety_manager.can_start_global_run():
+            current_runs = self.safety_manager.get_global_runs()
+            self.logger.warning(
+                "🚫 Global automation limit reached %s/%s",
+                current_runs,
+                self.safety_manager.global_limit,
+            )
+            self.safety_manager.check_and_notify_limits()
+            return
+
+        global_run_recorded = self.wrapper_managed
+
+        try:
+            open_prs = self.discover_open_prs()
+        except Exception as exc:
+            self.logger.error("❌ Failed to discover PRs: %s", exc)
+            self.logger.debug("Traceback: %s", traceback.format_exc())
+            self.safety_manager.check_and_notify_limits()
+            return
+
+        # Apply single repo filter if specified
+        if single_repo:
+            open_prs = [pr for pr in open_prs if pr["repository"] == single_repo]
+            self.logger.info(f"🎯 Filtering to repository: {single_repo}")
+
+        if not open_prs:
+            self.logger.info("📭 No open PRs found")
+            return
+
+        # Use enhanced actionable counting instead of simple max_prs limit
+        target_actionable_count = max_prs  # Convert max_prs to actionable target
+        actionable_processed = 0
+        skipped_count = 0
+
+        for pr in open_prs:
+            if actionable_processed >= target_actionable_count:
+                break
+
+            repo_name = pr["repository"]
+            repo_full_name = self._normalize_repository_name(
+                pr.get("repositoryFullName") or repo_name
+            )
+            pr_number = pr["number"]
+
+            # Check if this PR is actionable (skip if not)
+            if not self.is_pr_actionable(pr):
+                skipped_count += 1
+                continue
+
+            branch_name = pr.get("headRefName", "unknown")
+
+            if not self.safety_manager.try_process_pr(pr_number, repo=repo_full_name, branch=branch_name):
+                self.logger.info(
+                    f"🚫 Safety limits exceeded for PR {repo_full_name} #{pr_number}; skipping"
+                )
+                skipped_count += 1
+                continue
+
+            self.logger.info(f"🎯 Processing PR: {repo_full_name} #{pr_number} - {pr['title']}")
+
+            attempt_recorded = False
+            try:
+                if not global_run_recorded:
+                    self.safety_manager.record_global_run()
+                    global_run_recorded = True
+                    current_runs = self.safety_manager.get_global_runs()
+                    self.logger.info(
+                        "📊 Recorded global run %s/%s before processing PRs",
+                        current_runs,
+                        self.safety_manager.global_limit,
+                    )
+
+                # Post codex instruction comment directly (comment-only approach)
+                comment_result = self.post_codex_instruction_simple(repo_full_name, pr_number, pr)
+                success = comment_result == "posted"
+
+                result = "success" if success else "failure"
+                self.safety_manager.record_pr_attempt(
+                    pr_number,
+                    result,
+                    repo=repo_full_name,
+                    branch=branch_name,
+                )
+                attempt_recorded = True
+
+                if success:
+                    self.logger.info(f"✅ Successfully processed PR {repo_full_name} #{pr_number}")
+                    actionable_processed += 1
+                else:
+                    self.logger.error(f"❌ Failed to process PR {repo_full_name} #{pr_number}")
+            except Exception as e:
+                self.logger.error(f"❌ Exception processing PR {repo_full_name} #{pr_number}: {e}")
+                self.logger.debug("Traceback: %s", traceback.format_exc())
+                # Record failure for safety manager
+                self.safety_manager.record_pr_attempt(pr_number, "failure", repo=repo_full_name, branch=branch_name)
+                attempt_recorded = True
+            finally:
+                # Always release the processing slot if record_pr_attempt didn't do it
+                if not attempt_recorded:
+                    self.safety_manager.release_pr_slot(pr_number, repo=repo_full_name, branch=branch_name)
+
+        self.logger.info(f"🏁 Monitoring cycle complete: {actionable_processed} actionable PRs processed, {skipped_count} skipped")
+
+
+def main():
+    """CLI interface for jleechanorg PR monitor"""
+
+    parser = argparse.ArgumentParser(description="jleechanorg PR Monitor")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Discover PRs but do not process them")
+    parser.add_argument("--single-repo",
+                        help="Process only specific repository")
+    parser.add_argument("--max-prs", type=int, default=5,
+                        help="Maximum PRs to process per cycle")
+    parser.add_argument("--target-pr", type=int,
+                        help="Process specific PR number")
+    parser.add_argument("--target-repo",
+                        help="Repository for target PR (required with --target-pr)")
+
+    args = parser.parse_args()
+
+    # Validate target PR arguments
+    if args.target_pr and not args.target_repo:
+        parser.error("--target-repo is required when using --target-pr")
+    if args.target_repo and not args.target_pr:
+        parser.error("--target-pr is required when using --target-repo")
+
+    monitor = JleechanorgPRMonitor()
+
+    # Handle target PR processing
+    if args.target_pr and args.target_repo:
+        print(f"🎯 Processing target PR: {args.target_repo} #{args.target_pr}")
+        success = monitor.process_single_pr_by_number(args.target_pr, args.target_repo)
+        sys.exit(0 if success else 1)
+
+    if args.dry_run:
+        print("🔍 DRY RUN: Discovering PRs only")
+        prs = monitor.discover_open_prs()
+
+        if args.single_repo:
+            prs = [pr for pr in prs if pr["repository"] == args.single_repo]
+
+        print(f"📋 Found {len(prs)} open PRs:")
+        for pr in prs[:args.max_prs]:
+            print(f"  • {pr['repository']} PR #{pr['number']}: {pr['title']}")
+    else:
+        monitor.run_monitoring_cycle(single_repo=args.single_repo, max_prs=args.max_prs)
+
+
+if __name__ == "__main__":
+    main()

--- a/automation/jleechanorg_pr_automation/tests/conftest.py
+++ b/automation/jleechanorg_pr_automation/tests/conftest.py
@@ -1,0 +1,12 @@
+"""
+Pytest configuration for jleechanorg_pr_automation tests.
+Sets up proper Python path for package imports.
+"""
+import sys
+from pathlib import Path
+
+# Add project root to sys.path so package imports work without editable install
+package_dir = Path(__file__).parent.parent
+project_root = package_dir.parent
+if str(project_root) not in sys.path:
+    sys.path.insert(0, str(project_root))

--- a/automation/jleechanorg_pr_automation/tests/test_actionable_counting_matrix.py
+++ b/automation/jleechanorg_pr_automation/tests/test_actionable_counting_matrix.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+RED Phase: Matrix tests for actionable PR counting logic
+
+Test Matrix: Actionable PR counting should exclude skipped PRs and only count
+PRs that actually get processed with comments.
+"""
+
+import shutil
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from jleechanorg_pr_automation.jleechanorg_pr_monitor import JleechanorgPRMonitor
+
+
+class TestActionableCountingMatrix(unittest.TestCase):
+    """Matrix testing for actionable PR counting with skip exclusion"""
+
+    def setUp(self):
+        """Set up test environment"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.monitor = JleechanorgPRMonitor()
+        self.monitor.history_storage_path = self.temp_dir
+
+    def tearDown(self):
+        """Clean up test files"""
+        shutil.rmtree(self.temp_dir)
+
+    def test_run_monitoring_cycle_should_process_exactly_target_actionable_prs(self):
+        """RED: run_monitoring_cycle should process exactly target actionable PRs, not counting skipped"""
+
+        # Create a mix of PRs - some actionable, some should be skipped
+        mock_prs = [
+            # 3 actionable PRs (new commits)
+            {"number": 1001, "state": "open", "isDraft": False, "headRefOid": "new001",
+             "repository": "repo1", "headRefName": "feature1", "repositoryFullName": "org/repo1",
+             "title": "Actionable PR 1", "updatedAt": "2025-09-28T21:00:00Z"},
+            {"number": 1002, "state": "open", "isDraft": False, "headRefOid": "new002",
+             "repository": "repo2", "headRefName": "feature2", "repositoryFullName": "org/repo2",
+             "title": "Actionable PR 2", "updatedAt": "2025-09-28T20:59:00Z"},
+            {"number": 1003, "state": "open", "isDraft": False, "headRefOid": "new003",
+             "repository": "repo3", "headRefName": "feature3", "repositoryFullName": "org/repo3",
+             "title": "Actionable PR 3", "updatedAt": "2025-09-28T20:58:00Z"},
+
+            # 2 PRs that should be skipped (already processed)
+            {"number": 2001, "state": "open", "isDraft": False, "headRefOid": "old001",
+             "repository": "repo4", "headRefName": "processed1", "repositoryFullName": "org/repo4",
+             "title": "Already Processed PR 1", "updatedAt": "2025-09-28T20:57:00Z"},
+            {"number": 2002, "state": "open", "isDraft": False, "headRefOid": "old002",
+             "repository": "repo5", "headRefName": "processed2", "repositoryFullName": "org/repo5",
+             "title": "Already Processed PR 2", "updatedAt": "2025-09-28T20:56:00Z"}
+        ]
+
+        # Pre-record the "processed" PRs as already handled
+        self.monitor._record_pr_processing("repo4", "processed1", 2001, "old001")
+        self.monitor._record_pr_processing("repo5", "processed2", 2002, "old002")
+
+        # Mock the PR discovery to return our test data
+        with patch.object(self.monitor, "discover_open_prs", return_value=mock_prs):
+            with patch.object(self.monitor, "_process_pr_comment", return_value=True) as mock_process:
+
+                # RED: This should fail - current implementation counts all PRs, not just actionable ones
+                result = self.monitor.run_monitoring_cycle_with_actionable_count(target_actionable_count=3)
+
+                # Should process exactly 3 actionable PRs, not counting the 2 skipped ones
+                self.assertEqual(result["actionable_processed"], 3)
+                self.assertEqual(result["total_discovered"], 5)
+                self.assertEqual(result["skipped_count"], 2)
+
+                # Verify that _process_pr_comment was called exactly 3 times (only for actionable PRs)
+                self.assertEqual(mock_process.call_count, 3)
+
+    def test_monitoring_cycle_with_insufficient_actionable_prs_should_process_all_available(self):
+        """RED: When fewer actionable PRs than target, should process all available actionable PRs"""
+
+        # Create only 2 actionable PRs, but set target to 5
+        mock_prs = [
+            {"number": 1001, "state": "open", "isDraft": False, "headRefOid": "new001",
+             "repository": "repo1", "headRefName": "feature1", "repositoryFullName": "org/repo1",
+             "title": "Actionable PR 1", "updatedAt": "2025-09-28T21:00:00Z"},
+            {"number": 1002, "state": "open", "isDraft": False, "headRefOid": "new002",
+             "repository": "repo2", "headRefName": "feature2", "repositoryFullName": "org/repo2",
+             "title": "Actionable PR 2", "updatedAt": "2025-09-28T20:59:00Z"},
+
+            # 3 closed/processed PRs (not actionable)
+            {"number": 2001, "state": "closed", "isDraft": False, "headRefOid": "any001",
+             "repository": "repo3", "headRefName": "closed1", "repositoryFullName": "org/repo3",
+             "title": "Closed PR", "updatedAt": "2025-09-28T20:58:00Z"},
+            {"number": 2002, "state": "open", "isDraft": False, "headRefOid": "old002",
+             "repository": "repo4", "headRefName": "processed2", "repositoryFullName": "org/repo4",
+             "title": "Processed PR", "updatedAt": "2025-09-28T20:57:00Z"}
+        ]
+
+        # Pre-record one as processed
+        self.monitor._record_pr_processing("repo4", "processed2", 2002, "old002")
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=mock_prs):
+            with patch.object(self.monitor, "_process_pr_comment", return_value=True) as mock_process:
+
+                # RED: This should fail - method doesn't exist yet
+                result = self.monitor.run_monitoring_cycle_with_actionable_count(target_actionable_count=5)
+
+                # Should process only the 2 available actionable PRs
+                self.assertEqual(result["actionable_processed"], 2)
+                self.assertEqual(result["total_discovered"], 4)
+                self.assertEqual(result["skipped_count"], 2)  # 1 closed + 1 processed
+
+                # Verify processing was called only for actionable PRs
+                self.assertEqual(mock_process.call_count, 2)
+
+    def test_monitoring_cycle_with_zero_actionable_prs_should_process_none(self):
+        """RED: When no actionable PRs available, should process 0"""
+
+        # Create only non-actionable PRs
+        mock_prs = [
+            # All closed or already processed
+            {"number": 2001, "state": "closed", "isDraft": False, "headRefOid": "any001",
+             "repository": "repo1", "headRefName": "closed1", "repositoryFullName": "org/repo1",
+             "title": "Closed PR 1", "updatedAt": "2025-09-28T21:00:00Z"},
+            {"number": 2002, "state": "closed", "isDraft": False, "headRefOid": "any002",
+             "repository": "repo2", "headRefName": "closed2", "repositoryFullName": "org/repo2",
+             "title": "Closed PR 2", "updatedAt": "2025-09-28T20:59:00Z"},
+            {"number": 2003, "state": "open", "isDraft": False, "headRefOid": "old003",
+             "repository": "repo3", "headRefName": "processed3", "repositoryFullName": "org/repo3",
+             "title": "Processed PR", "updatedAt": "2025-09-28T20:58:00Z"}
+        ]
+
+        # Mark the open one as already processed
+        self.monitor._record_pr_processing("repo3", "processed3", 2003, "old003")
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=mock_prs):
+            with patch.object(self.monitor, "_process_pr_comment", return_value=True) as mock_process:
+
+                # RED: This should fail - method doesn't exist yet
+                result = self.monitor.run_monitoring_cycle_with_actionable_count(target_actionable_count=10)
+
+                # Should process 0 PRs
+                self.assertEqual(result["actionable_processed"], 0)
+                self.assertEqual(result["total_discovered"], 3)
+                self.assertEqual(result["skipped_count"], 3)  # All skipped
+
+                # Verify no processing was attempted
+                self.assertEqual(mock_process.call_count, 0)
+
+    def test_actionable_counter_should_track_actual_successful_processing(self):
+        """RED: Actionable counter should only count PRs that successfully get processed"""
+
+        mock_prs = [
+            {"number": 1001, "state": "open", "isDraft": False, "headRefOid": "new001",
+             "repository": "repo1", "headRefName": "feature1", "repositoryFullName": "org/repo1",
+             "title": "Success PR", "updatedAt": "2025-09-28T21:00:00Z"},
+            {"number": 1002, "state": "open", "isDraft": False, "headRefOid": "new002",
+             "repository": "repo2", "headRefName": "feature2", "repositoryFullName": "org/repo2",
+             "title": "Failure PR", "updatedAt": "2025-09-28T20:59:00Z"},
+            {"number": 1003, "state": "open", "isDraft": False, "headRefOid": "new003",
+             "repository": "repo3", "headRefName": "feature3", "repositoryFullName": "org/repo3",
+             "title": "Success PR 2", "updatedAt": "2025-09-28T20:58:00Z"}
+        ]
+
+        def mock_process_side_effect(repo_name, pr_number, pr_data):
+            # Simulate: First PR succeeds, second fails, third succeeds
+            if pr_number == 1002:
+                return False  # Processing failed
+            return True  # Processing succeeded
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=mock_prs):
+            with patch.object(self.monitor, "_process_pr_comment", side_effect=mock_process_side_effect) as mock_process:
+
+                # RED: This should fail - method doesn't exist yet
+                result = self.monitor.run_monitoring_cycle_with_actionable_count(target_actionable_count=10)
+
+                # Should count only successful processing (2 out of 3 attempts)
+                self.assertEqual(result["actionable_processed"], 2)
+                self.assertEqual(result["total_discovered"], 3)
+                self.assertEqual(result["processing_failures"], 1)
+
+                # Verify all 3 were attempted
+                self.assertEqual(mock_process.call_count, 3)
+
+    def test_enhanced_run_monitoring_cycle_should_replace_old_max_prs_logic(self):
+        """RED: Enhanced monitoring cycle should replace old max_prs with actionable counting"""
+
+        mock_prs = [
+            # Create 15 total PRs, but only 8 should be actionable
+            *[
+                {"number": 1000 + i, "state": "open", "isDraft": False, "headRefOid": f"new{i:03d}",
+                 "repository": f"repo{i}", "headRefName": f"feature{i}", "repositoryFullName": f"org/repo{i}",
+                 "title": f"Actionable PR {i}", "updatedAt": f"2025-09-28T{21-i//10}:{59-(i%10)*5}:00Z"}
+                for i in range(8)  # 8 actionable PRs
+            ],
+            *[
+                {"number": 2000 + i, "state": "closed", "isDraft": False, "headRefOid": f"any{i:03d}",
+                 "repository": f"closed_repo{i}", "headRefName": f"closed{i}", "repositoryFullName": f"org/closed_repo{i}",
+                 "title": f"Closed PR {i}", "updatedAt": f"2025-09-28T20:{50-i}:00Z"}
+                for i in range(7)  # 7 closed PRs (not actionable)
+            ]
+        ]
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=mock_prs):
+            with patch.object(self.monitor, "_process_pr_comment", return_value=True) as mock_process:
+
+                # RED: This should fail - enhanced method doesn't exist
+                # Should process exactly 5 actionable PRs, ignoring the 7 closed ones
+                result = self.monitor.run_monitoring_cycle_with_actionable_count(target_actionable_count=5)
+
+                self.assertEqual(result["actionable_processed"], 5)
+                self.assertEqual(result["total_discovered"], 15)
+                self.assertEqual(result["skipped_count"], 7)  # Closed PRs
+
+                # Should have attempted processing exactly 5 times
+                self.assertEqual(mock_process.call_count, 5)
+
+
+if __name__ == "__main__":
+    # RED Phase: Run tests to confirm they FAIL
+    print("🔴 RED Phase: Running failing tests for actionable PR counting")
+    print("Expected: ALL TESTS SHOULD FAIL (no implementation exists)")
+    unittest.main(verbosity=2)

--- a/automation/jleechanorg_pr_automation/tests/test_automation_over_running_reproduction.py
+++ b/automation/jleechanorg_pr_automation/tests/test_automation_over_running_reproduction.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""
+RED TEST: Reproduce automation over-running issue
+
+This test reproduces the exact issue discovered:
+- 346 runs in 20 hours (should be max 50)
+- Manual approval allowing unlimited runs (should be limited)
+- No default manual override (should require explicit --manual_override)
+"""
+
+import argparse
+import shutil
+import tempfile
+import unittest
+from datetime import datetime
+
+from jleechanorg_pr_automation.automation_safety_manager import AutomationSafetyManager
+
+
+class TestAutomationOverRunningReproduction(unittest.TestCase):
+    """Reproduce the critical automation over-running issue"""
+
+    def setUp(self):
+        """Set up test environment"""
+        self.test_dir = tempfile.mkdtemp()
+        self.manager = AutomationSafetyManager(self.test_dir)
+
+    def tearDown(self):
+        """Clean up test environment"""
+        shutil.rmtree(self.test_dir)
+
+    def test_automation_blocks_unlimited_runs_with_manual_override(self):
+        """
+        GREEN TEST: Manual override now has limits
+
+        Manual override allows up to 2x the normal limit (100 runs) but no more.
+        """
+        # Set up scenario: we're at the 2x limit + 1 (101 runs)
+        # We need to write to the file since get_global_runs() reads from file
+        today = datetime.now().date().isoformat()
+        data = {
+            "total_runs": 101,
+            "start_date": datetime.now().isoformat(),
+            "current_date": today
+        }
+        self.manager._write_json_file(self.manager.global_runs_file, data)
+
+        # Manual approval should NOT allow unlimited runs
+        self.manager.grant_manual_approval("test@example.com")
+
+        # This should be FALSE after 2x the limit (100 runs)
+        result = self.manager.can_start_global_run()
+
+        # FIXED: This should now be FALSE (blocked) at 101 runs
+        self.assertFalse(result,
+                        "Manual override should NOT allow unlimited runs beyond 2x limit")
+
+    def test_FAIL_manual_approval_enabled_by_default(self):
+        """
+        RED TEST: This should FAIL to demonstrate manual approval defaults
+
+        Manual approval should never be granted by default.
+        """
+        # Fresh manager should have NO approval
+        fresh_manager = AutomationSafetyManager(tempfile.mkdtemp())
+
+        # This should be FALSE by default
+        result = fresh_manager.has_manual_approval()
+
+        self.assertFalse(result,
+                        "Manual approval should NEVER be granted by default")
+
+    def test_command_line_uses_manual_override_not_approve(self):
+        """
+        GREEN TEST: Command line interface now uses --manual_override
+
+        Verify the CLI command has been properly renamed.
+        """
+        # Test that we can use --manual_override
+        # Parse the new arguments
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--manual_override", type=str, help="Correct command")
+
+        # The --manual_override command should work
+        args = parser.parse_args(["--manual_override", "test@example.com"])
+        self.assertIsNotNone(args.manual_override, "--manual_override command works")
+        self.assertEqual(args.manual_override, "test@example.com")
+
+        # Test that --approve should no longer exist in the real CLI
+        # (This test verifies our refactoring was successful)
+
+    def test_blocks_346_runs_scenario(self):
+        """
+        GREEN TEST: 346 runs scenario now properly blocked
+
+        The system now blocks excessive runs even with manual override.
+        """
+        # Grant approval (simulating what happened Sept 27)
+        self.manager.grant_manual_approval("$USER@anthropic.com")
+
+        # Simulate running 346 times (what actually happened)
+        # We need to write to the file since get_global_runs() reads from file
+        today = datetime.now().date().isoformat()
+        data = {
+            "total_runs": 346,
+            "start_date": datetime.now().isoformat(),
+            "current_date": today
+        }
+        self.manager._write_json_file(self.manager.global_runs_file, data)
+
+        # This should now be FALSE (blocked) with fixed logic
+        result = self.manager.can_start_global_run()
+
+        self.assertFalse(result,
+                        "346 runs should be BLOCKED even with manual override")
+
+    def test_automation_rate_documentation(self):
+        """
+        DOCUMENTATION TEST: Rate limiting considerations
+
+        Documents the excessive rate that was observed and suggests future improvements.
+        This test documents the issue but doesn't enforce rate limiting yet.
+        """
+        # Document that rate limiting doesn't exist (future enhancement)
+        self.assertFalse(hasattr(self.manager, "check_rate_limit"),
+                        "Rate limiting could be added as future enhancement")
+
+        # Document the excessive rate that occurred (historical reference)
+        runs_in_20_hours = 346
+        hours = 20.3
+        rate_per_hour = runs_in_20_hours / hours
+
+        # Document the observed rate for future reference
+        # 17 runs/hour was too much, but our new limits (50 max, 100 with override) prevent this
+        self.assertGreater(rate_per_hour, 10.0,
+                          f"Historical rate was {rate_per_hour:.1f} runs/hour (now prevented by run limits)")
+
+        # Verify our new limits would have prevented the issue
+        max_runs_with_override = self.manager.global_limit * 2  # 100 runs
+        self.assertLess(max_runs_with_override, runs_in_20_hours,
+                       "New limits (100 max) would have prevented 346 runs")
+
+
+if __name__ == "__main__":
+    print("🟢 GREEN PHASE: Running tests that now PASS after fixes")
+    print("✅ Automation over-running issue RESOLVED")
+    print("")
+    print("FIXES IMPLEMENTED:")
+    print("1. Manual override now limited to 2x normal limit (100 runs max)")
+    print("2. CLI command renamed from --approve to --manual_override")
+    print("3. Manual override defaults to FALSE (never enabled by default)")
+    print("4. Hard stop at 2x limit regardless of override status")
+    print("5. 346 runs scenario now properly blocked")
+    print("")
+    unittest.main()

--- a/automation/jleechanorg_pr_automation/tests/test_automation_safety_limits.py
+++ b/automation/jleechanorg_pr_automation/tests/test_automation_safety_limits.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""
+Test-Driven Development for PR Automation Safety Limits
+
+RED Phase: All tests should FAIL initially
+- PR attempt limits (max 5 per PR)
+- Global run limits (max 50 total)
+- Manual approval requirement
+"""
+
+import json
+import os
+import shutil
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from jleechanorg_pr_automation.automation_safety_manager import AutomationSafetyManager
+
+
+class TestAutomationSafetyLimits(unittest.TestCase):
+    """Matrix testing for automation safety limits"""
+
+    def setUp(self):
+        """Set up test environment with temporary files"""
+        self.test_dir = tempfile.mkdtemp()
+        self.pr_attempts_file = os.path.join(self.test_dir, "pr_attempts.json")
+        self.global_runs_file = os.path.join(self.test_dir, "global_runs.json")
+        self.approval_file = os.path.join(self.test_dir, "manual_approval.json")
+
+        if hasattr(self, "_automation_manager"):
+            del self._automation_manager
+
+        # Initialize empty tracking files
+        with open(self.pr_attempts_file, "w") as f:
+            json.dump({}, f)
+        with open(self.global_runs_file, "w") as f:
+            json.dump({"total_runs": 0, "start_date": datetime.now().isoformat()}, f)
+        with open(self.approval_file, "w") as f:
+            json.dump({"approved": False, "approval_date": None}, f)
+
+    def tearDown(self):
+        """Clean up test files"""
+        shutil.rmtree(self.test_dir)
+
+    # Matrix 1: PR Attempt Limits (5 attempts per PR)
+    def test_pr_attempt_limit_1_should_allow(self):
+        """RED: First attempt on PR #1001 should be allowed"""
+        # This test will FAIL initially - no implementation exists
+        result = self.automation_manager.can_process_pr(1001)
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_pr_attempts(1001), 0)
+
+    def test_pr_attempt_limit_5_should_allow(self):
+        """RED: 5th attempt on PR #1001 should be allowed"""
+        # Set up 4 previous attempts
+        self.automation_manager.record_pr_attempt(1001, "failure")
+        self.automation_manager.record_pr_attempt(1001, "failure")
+        self.automation_manager.record_pr_attempt(1001, "failure")
+        self.automation_manager.record_pr_attempt(1001, "failure")
+
+        result = self.automation_manager.can_process_pr(1001)
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_pr_attempts(1001), 4)
+
+    def test_pr_attempt_limit_6_should_block(self):
+        """RED: 6th attempt on PR #1001 should be blocked"""
+        # Set up 5 previous attempts (max limit reached)
+        for _ in range(5):
+            self.automation_manager.record_pr_attempt(1001, "failure")
+
+        result = self.automation_manager.can_process_pr(1001)
+        self.assertFalse(result)
+        self.assertEqual(self.automation_manager.get_pr_attempts(1001), 5)
+
+    def test_pr_attempt_success_resets_counter(self):
+        """RED: Successful PR attempt should reset counter"""
+        # Set up 3 failures then 1 success
+        self.automation_manager.record_pr_attempt(1001, "failure")
+        self.automation_manager.record_pr_attempt(1001, "failure")
+        self.automation_manager.record_pr_attempt(1001, "failure")
+        self.automation_manager.record_pr_attempt(1001, "success")
+
+        # Counter should reset, allowing new attempts
+        result = self.automation_manager.can_process_pr(1001)
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_pr_attempts(1001), 0)
+
+    # Matrix 2: Global Run Limits (50 total runs)
+    def test_global_run_limit_1_should_allow(self):
+        """RED: First global run should be allowed"""
+        result = self.automation_manager.can_start_global_run()
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 0)
+
+    def test_global_run_limit_50_should_allow(self):
+        """RED: 50th global run should be allowed"""
+        # Set up 49 previous runs
+        for i in range(49):
+            self.automation_manager.record_global_run()
+
+        result = self.automation_manager.can_start_global_run()
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 49)
+
+    def test_global_run_limit_51_should_block(self):
+        """RED: 51st global run should be blocked without approval"""
+        # Set up 50 previous runs (max limit reached)
+        for i in range(50):
+            self.automation_manager.record_global_run()
+
+        result = self.automation_manager.can_start_global_run()
+        self.assertFalse(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 50)
+
+    # Matrix 3: Manual Approval System
+    def test_manual_approval_required_after_50_runs(self):
+        """RED: Manual approval should be required after 50 runs"""
+        # Set up 50 runs to trigger approval requirement
+        for i in range(50):
+            self.automation_manager.record_global_run()
+
+        # Should require approval
+        self.assertTrue(self.automation_manager.requires_manual_approval())
+        self.assertFalse(self.automation_manager.has_manual_approval())
+
+    def test_manual_approval_grants_additional_runs(self):
+        """RED: Manual approval should allow continuation beyond 50 runs"""
+        # Set up 50 runs
+        for i in range(50):
+            self.automation_manager.record_global_run()
+
+        # Grant manual approval
+        self.automation_manager.grant_manual_approval("user@example.com")
+
+        # Should now allow additional runs
+        self.assertTrue(self.automation_manager.can_start_global_run())
+        self.assertTrue(self.automation_manager.has_manual_approval())
+
+    def test_approval_expires_after_24_hours(self):
+        """RED: Manual approval should expire after 24 hours"""
+        # Set up approval 25 hours ago
+        old_time = datetime.now() - timedelta(hours=25)
+        self.automation_manager.grant_manual_approval("user@example.com", old_time)
+
+        # Approval should be expired
+        self.assertFalse(self.automation_manager.has_manual_approval())
+
+    # Matrix 4: Email Notification System
+    @patch.dict(os.environ, {
+        "SMTP_SERVER": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "EMAIL_USER": "test@example.com",
+        "EMAIL_PASS": "testpass",
+        "EMAIL_TO": "admin@example.com"
+    })
+    @patch("smtplib.SMTP")
+    def test_email_sent_when_pr_limit_reached(self, mock_smtp):
+        """RED: Email should be sent when PR reaches 5 attempts"""
+        # Set up 5 attempts to trigger notification
+        for _ in range(5):
+            self.automation_manager.record_pr_attempt(1001, "failure")
+
+        # Should trigger email
+        self.automation_manager.check_and_notify_limits()
+
+        # Verify email was sent
+        mock_smtp.assert_called_once()
+
+    @patch.dict(os.environ, {
+        "SMTP_SERVER": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "EMAIL_USER": "test@example.com",
+        "EMAIL_PASS": "testpass",
+        "EMAIL_TO": "admin@example.com"
+    })
+    @patch("smtplib.SMTP")
+    def test_email_sent_when_global_limit_reached(self, mock_smtp):
+        """RED: Email should be sent when global limit of 50 is reached"""
+        # Set up 50 runs to trigger notification
+        for i in range(50):
+            self.automation_manager.record_global_run()
+
+        # Should trigger email
+        self.automation_manager.check_and_notify_limits()
+
+        # Verify email was sent
+        mock_smtp.assert_called_once()
+
+    # Matrix 5: State Persistence
+    def test_pr_attempts_persist_across_restarts(self):
+        """RED: PR attempt counts should persist across automation restarts"""
+        # Record attempts
+        self.automation_manager.record_pr_attempt(1001, "failure")
+        self.automation_manager.record_pr_attempt(1001, "failure")
+
+        # Simulate restart by creating new manager instance
+        new_manager = AutomationSafetyManager(self.test_dir)
+
+        # Should maintain attempt count
+        self.assertEqual(new_manager.get_pr_attempts(1001), 2)
+
+    def test_global_runs_persist_across_restarts(self):
+        """RED: Global run count should persist across automation restarts"""
+        # Record runs
+        for i in range(10):
+            self.automation_manager.record_global_run()
+
+        # Simulate restart
+        new_manager = AutomationSafetyManager(self.test_dir)
+
+        # Should maintain run count
+        self.assertEqual(new_manager.get_global_runs(), 10)
+
+    # Matrix 6: Concurrent Access Safety
+    def test_concurrent_pr_attempts_thread_safe(self):
+        """RED: Concurrent PR attempts should be thread-safe"""
+        # Create a single manager instance explicitly for this test
+        manager = AutomationSafetyManager(self.test_dir)
+        results = []
+
+        def attempt_pr():
+            result = manager.try_process_pr(1001)
+            results.append(result)
+
+        # Start 10 concurrent threads
+        threads = []
+        for _ in range(10):
+            t = threading.Thread(target=attempt_pr)
+            threads.append(t)
+            t.start()
+
+        # Wait for all threads
+        for t in threads:
+            t.join()
+
+        # Should have exactly 5 successful attempts (limit)
+        successful_attempts = sum(results)
+        self.assertEqual(successful_attempts, 5)
+
+    # Matrix 7: Configuration Management
+    def test_limits_configurable_via_environment(self):
+        """RED: Safety limits should be configurable via environment variables"""
+        with patch.dict(os.environ, {
+            "AUTOMATION_PR_LIMIT": "3",
+            "AUTOMATION_GLOBAL_LIMIT": "25"
+        }):
+            manager = AutomationSafetyManager(self.test_dir)
+
+            # Should use custom limits
+            self.assertEqual(manager.pr_limit, 3)
+            self.assertEqual(manager.global_limit, 25)
+
+    def test_default_limits_when_no_config(self):
+        """RED: Should use default limits when no configuration provided"""
+        manager = AutomationSafetyManager(self.test_dir)
+
+        # Should use defaults
+        self.assertEqual(manager.pr_limit, 5)
+        self.assertEqual(manager.global_limit, 50)
+
+    # Matrix 8: Daily Reset Functionality (50 runs per day)
+    def test_daily_reset_first_run_of_day(self):
+        """RED: First run of the day should be allowed with counter at 0"""
+        result = self.automation_manager.can_start_global_run()
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 0)
+
+    def test_daily_reset_49th_run_same_day(self):
+        """RED: 49th run on same day should be allowed"""
+        # Record 48 runs on same day
+        for _ in range(48):
+            self.automation_manager.record_global_run()
+
+        result = self.automation_manager.can_start_global_run()
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 48)
+
+    def test_daily_reset_50th_run_same_day(self):
+        """RED: 50th run on same day should be allowed (at limit)"""
+        # Record 49 runs on same day
+        for _ in range(49):
+            self.automation_manager.record_global_run()
+
+        result = self.automation_manager.can_start_global_run()
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 49)
+
+    def test_daily_reset_51st_run_same_day_blocked(self):
+        """RED: 51st run on same day should be blocked"""
+        # Record 50 runs on same day (hit daily limit)
+        for _ in range(50):
+            self.automation_manager.record_global_run()
+
+        result = self.automation_manager.can_start_global_run()
+        self.assertFalse(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 50)
+
+    def test_daily_reset_missing_current_date_resets_counter(self):
+        """Legacy counters without current_date should reset after upgrade"""
+        legacy_data = {
+            "total_runs": 50,
+            "start_date": datetime(2025, 9, 30, 12, 0, 0).isoformat()
+        }
+        with open(self.global_runs_file, "w") as f:
+            json.dump(legacy_data, f)
+
+        if hasattr(self, "_automation_manager"):
+            del self._automation_manager
+
+        # First run after upgrade should reset the stale counter
+        self.assertTrue(self.automation_manager.can_start_global_run())
+        self.assertEqual(self.automation_manager.get_global_runs(), 0)
+
+    @patch("jleechanorg_pr_automation.automation_safety_manager.datetime")
+    def test_daily_reset_new_day_resets_counter(self, mock_datetime):
+        """RED: Counter should reset to 0 when a new day starts"""
+        # Day 1: Record 50 runs
+        day1 = datetime(2025, 10, 1, 10, 0, 0)
+        mock_datetime.now.return_value = day1
+        mock_datetime.side_effect = datetime
+
+        for _ in range(50):
+            self.automation_manager.record_global_run()
+
+        # Should be at limit on Day 1
+        self.assertEqual(self.automation_manager.get_global_runs(), 50)
+        self.assertFalse(self.automation_manager.can_start_global_run())
+
+        # Day 2: Counter should reset
+        day2 = datetime(2025, 10, 2, 10, 0, 0)
+        mock_datetime.now.return_value = day2
+
+        # Should allow runs again with reset counter
+        result = self.automation_manager.can_start_global_run()
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 0)
+
+    @patch("jleechanorg_pr_automation.automation_safety_manager.datetime")
+    def test_daily_reset_multiple_days(self, mock_datetime):
+        """RED: Counter should reset each day for multiple days"""
+        mock_datetime.side_effect = datetime
+
+        # Day 1: 50 runs
+        day1 = datetime(2025, 10, 1, 10, 0, 0)
+        mock_datetime.now.return_value = day1
+        for _ in range(50):
+            self.automation_manager.record_global_run()
+        self.assertEqual(self.automation_manager.get_global_runs(), 50)
+
+        # Day 2: Reset to 0, then 30 runs
+        day2 = datetime(2025, 10, 2, 10, 0, 0)
+        mock_datetime.now.return_value = day2
+        self.assertEqual(self.automation_manager.get_global_runs(), 0)
+        for _ in range(30):
+            self.automation_manager.record_global_run()
+        self.assertEqual(self.automation_manager.get_global_runs(), 30)
+
+        # Day 3: Reset to 0 again
+        day3 = datetime(2025, 10, 3, 10, 0, 0)
+        mock_datetime.now.return_value = day3
+        self.assertEqual(self.automation_manager.get_global_runs(), 0)
+
+    @patch("jleechanorg_pr_automation.automation_safety_manager.datetime")
+    def test_daily_reset_midnight_transition(self, mock_datetime):
+        """RED: Counter should reset at midnight transition"""
+        mock_datetime.side_effect = datetime
+
+        # 23:59:59 on Day 1 - at limit
+        before_midnight = datetime(2025, 10, 1, 23, 59, 59)
+        mock_datetime.now.return_value = before_midnight
+        for _ in range(50):
+            self.automation_manager.record_global_run()
+        self.assertFalse(self.automation_manager.can_start_global_run())
+
+        # 00:00:01 on Day 2 - should reset
+        after_midnight = datetime(2025, 10, 2, 0, 0, 1)
+        mock_datetime.now.return_value = after_midnight
+
+        result = self.automation_manager.can_start_global_run()
+        self.assertTrue(result)
+        self.assertEqual(self.automation_manager.get_global_runs(), 0)
+
+    @property
+    def automation_manager(self):
+        """RED: This property will fail - no AutomationSafetyManager exists yet"""
+        # This will fail until we implement the class in GREEN phase
+        if not hasattr(self, "_automation_manager"):
+            self._automation_manager = AutomationSafetyManager(self.test_dir)
+        return self._automation_manager
+
+
+# Matrix 9: Integration with Existing Automation
+class TestAutomationIntegration(unittest.TestCase):
+    """Integration tests with existing simple_pr_batch.sh script"""
+
+    def setUp(self):
+        self.launchd_root = Path(tempfile.mkdtemp(prefix="launchd-plist-"))
+        self.plist_path = self.launchd_root / "com.worldarchitect.pr-automation.plist"
+        plist_dir = self.plist_path.parent
+        plist_dir.mkdir(parents=True, exist_ok=True)
+        plist_dir.chmod(0o755)
+        plist_content = """<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>/Users/$USER/projects/your-project.com/automation/automation_safety_wrapper.py</string>
+    </array>
+</dict>
+</plist>
+"""
+        with open(self.plist_path, "w", encoding="utf-8") as plist_file:
+            plist_file.write(plist_content)
+
+    def tearDown(self):
+        shutil.rmtree(self.launchd_root, ignore_errors=True)
+
+    def test_shell_script_respects_safety_limits(self):
+        """RED: Shell script should check safety limits before processing"""
+        # This test will fail - existing script doesn't have safety checks
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 1  # Safety limit hit
+
+            result = self.run_automation_script()
+
+            # Should exit early due to safety limits
+            self.assertEqual(result.returncode, 1)
+
+    def test_launchd_plist_includes_safety_wrapper(self):
+        """RED: launchd plist should call safety wrapper, not direct script"""
+        plist_content = self.read_launchd_plist()
+
+        # Should call safety wrapper, not direct automation
+        self.assertIn("automation_safety_wrapper.py", plist_content)
+        self.assertNotIn("simple_pr_batch.sh", plist_content)
+
+    def run_automation_script(self):
+        """Helper to run automation script"""
+        import subprocess
+        return subprocess.run([
+            "/Users/$USER/projects/worktree_worker2/automation/simple_pr_batch.sh"
+        ], check=False, capture_output=True, text=True)
+
+    def read_launchd_plist(self):
+        """Helper to read launchd plist file"""
+        # This will fail - plist doesn't exist yet
+        with open(self.plist_path, encoding="utf-8") as f:
+            return f.read()
+
+
+if __name__ == "__main__":
+    # RED Phase: Run tests to confirm they FAIL
+    print("🔴 RED Phase: Running failing tests for automation safety limits")
+    print("Expected: ALL TESTS SHOULD FAIL (no implementation exists)")
+    unittest.main(verbosity=2)

--- a/automation/jleechanorg_pr_automation/tests/test_automation_safety_limits.py
+++ b/automation/jleechanorg_pr_automation/tests/test_automation_safety_limits.py
@@ -11,6 +11,7 @@ RED Phase: All tests should FAIL initially
 import json
 import os
 import shutil
+import subprocess
 import tempfile
 import threading
 import unittest
@@ -441,10 +442,8 @@ class TestAutomationIntegration(unittest.TestCase):
 
     def run_automation_script(self):
         """Helper to run automation script"""
-        import subprocess
-        return subprocess.run([
-            "/Users/$USER/projects/worktree_worker2/automation/simple_pr_batch.sh"
-        ], check=False, capture_output=True, text=True)
+        script_path = Path.home() / "projects" / "worktree_worker2" / "automation" / "simple_pr_batch.sh"
+        return subprocess.run([str(script_path)], check=False, capture_output=True, text=True)
 
     def read_launchd_plist(self):
         """Helper to read launchd plist file"""

--- a/automation/jleechanorg_pr_automation/tests/test_automation_safety_manager_comprehensive.py
+++ b/automation/jleechanorg_pr_automation/tests/test_automation_safety_manager_comprehensive.py
@@ -1,0 +1,658 @@
+#!/usr/bin/env python3
+"""
+Comprehensive test suite for AutomationSafetyManager
+Using TDD methodology with 150+ test cases covering all safety logic
+"""
+
+import json
+import os
+import tempfile
+import threading
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+
+# Import the automation safety manager using proper Python module path
+from jleechanorg_pr_automation.automation_safety_manager import AutomationSafetyManager
+from jleechanorg_pr_automation.utils import json_manager
+
+
+class TestAutomationSafetyManagerInit:
+    """Test suite for AutomationSafetyManager initialization"""
+
+    def test_init_with_data_dir(self):
+        """Test initialization with provided data directory"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manager = AutomationSafetyManager(temp_dir)
+            assert manager.data_dir == temp_dir
+            assert manager.global_limit > 0
+            assert manager.pr_limit > 0
+
+    def test_init_creates_data_dir(self):
+        """Test that initialization creates data directory if it doesn't exist"""
+        with tempfile.TemporaryDirectory() as parent_dir:
+            data_dir = os.path.join(parent_dir, "new_safety_dir")
+            manager = AutomationSafetyManager(data_dir)
+            assert os.path.exists(data_dir)
+
+    def test_init_reads_config_file(self):
+        """Test that initialization reads existing config file"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create config file
+            config_file = os.path.join(temp_dir, "automation_safety_config.json")
+            config_data = {
+                "global_limit": 50,
+                "pr_limit": 3,
+                "daily_limit": 100
+            }
+            with open(config_file, "w") as f:
+                json.dump(config_data, f)
+
+            manager = AutomationSafetyManager(temp_dir)
+            assert manager.global_limit == 50
+            assert manager.pr_limit == 3
+
+    def test_init_creates_default_config(self):
+        """Test that initialization creates default config if none exists"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manager = AutomationSafetyManager(temp_dir)
+
+            config_file = os.path.join(temp_dir, "automation_safety_config.json")
+            assert os.path.exists(config_file)
+
+            with open(config_file) as f:
+                config = json.load(f)
+            assert "global_limit" in config
+            assert "pr_limit" in config
+
+    def test_init_invalid_config_uses_defaults(self):
+        """Test that invalid config file falls back to defaults"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Create invalid config file
+            config_file = os.path.join(temp_dir, "automation_safety_config.json")
+            with open(config_file, "w") as f:
+                f.write("{ invalid json")
+
+            manager = AutomationSafetyManager(temp_dir)
+            assert manager.global_limit > 0  # Should use defaults
+
+
+class TestGlobalLimits:
+    """Test suite for global automation limits"""
+
+    @pytest.fixture
+    def manager(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield AutomationSafetyManager(temp_dir)
+
+    def test_can_start_global_run_under_limit(self, manager):
+        """Test global run allowed when under limit"""
+        # Clear any existing runs
+        manager._clear_global_runs()
+        assert manager.can_start_global_run() == True
+
+    def test_can_start_global_run_at_limit(self, manager):
+        """Test global run denied when at limit"""
+        # Fill up to limit
+        for _ in range(manager.global_limit):
+            manager.record_global_run()
+
+        assert manager.can_start_global_run() == False
+
+    def test_record_global_run_increments_count(self, manager):
+        """Test that recording global run increments counter"""
+        initial_count = manager.get_global_runs()
+        manager.record_global_run()
+        assert manager.get_global_runs() == initial_count + 1
+
+    def test_get_global_runs_returns_count(self, manager):
+        """Test that get_global_runs returns correct count"""
+        manager._clear_global_runs()
+        assert manager.get_global_runs() == 0
+
+        manager.record_global_run()
+        assert manager.get_global_runs() == 1
+
+    def test_global_runs_file_persistence(self, manager):
+        """Test that global runs are persisted to file"""
+        manager._clear_global_runs()
+        manager.record_global_run()
+        manager.record_global_run()
+
+        # Create new manager with same data dir
+        new_manager = AutomationSafetyManager(manager.data_dir)
+        assert new_manager.get_global_runs() == 2
+
+    def test_global_runs_thread_safety(self, manager):
+        """Test that global runs are thread-safe"""
+        manager._clear_global_runs()
+
+        def record_runs():
+            for _ in range(10):
+                manager.record_global_run()
+
+        threads = [threading.Thread(target=record_runs) for _ in range(5)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        # Should have exactly 50 runs (5 threads × 10 runs each)
+        assert manager.get_global_runs() == 50
+
+    def test_clear_global_runs(self, manager):
+        """Test clearing global runs"""
+        manager.record_global_run()
+        manager.record_global_run()
+        assert manager.get_global_runs() > 0
+
+        manager._clear_global_runs()
+        assert manager.get_global_runs() == 0
+
+    def test_global_runs_auto_resets_daily(self, manager):
+        """Daily reset should clear the counter and allow automation without manual approval."""
+        manager._clear_global_runs()
+
+        # Simulate crossing the daily limit
+        for _ in range(manager.global_limit):
+            manager.record_global_run()
+
+        assert manager.requires_manual_approval() is True
+
+        now = datetime.now()
+        stale_payload = {
+            "total_runs": manager.global_limit,
+            "start_date": (now - timedelta(days=4)).isoformat(),
+            "current_date": (now - timedelta(days=1)).date().isoformat(),
+            "last_run": (now - timedelta(hours=2)).isoformat(),
+            "last_reset": (now - timedelta(days=2)).isoformat(),
+        }
+        json_manager.write_json(manager.global_runs_file, stale_payload)
+
+        refreshed_runs = manager.get_global_runs()
+        expected_today = datetime.now().date().isoformat()
+        assert refreshed_runs == 0
+        assert manager.requires_manual_approval() is False
+
+        normalized = manager._read_json_file(manager.global_runs_file)
+        assert normalized["current_date"] == expected_today
+        assert normalized["total_runs"] == 0
+
+        # Ensure the reset timestamp is updated and sane
+        last_reset = normalized.get("last_reset")
+        assert last_reset is not None
+        parsed_reset = datetime.fromisoformat(last_reset)
+        assert (
+            parsed_reset is not None
+        ), "last_reset should be a valid ISO datetime"
+
+        # Record another run and verify counters/log fields move forward
+        manager.record_global_run()
+        normalized = manager._read_json_file(manager.global_runs_file)
+        assert normalized["total_runs"] == 1
+        assert datetime.fromisoformat(normalized["last_run"])
+
+
+class TestPRLimits:
+    """Test suite for per-PR automation limits"""
+
+    @pytest.fixture
+    def manager(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield AutomationSafetyManager(temp_dir)
+
+    @pytest.mark.parametrize("pr_key,expected_can_process", [
+        ("repo-123", True),   # New PR
+        ("repo-456", True),   # Different PR
+        ("repo/with/slashes-789", True),  # PR with slashes in name
+    ])
+    def test_can_process_pr_new_prs(self, manager, pr_key, expected_can_process):
+        """Test that new PRs can be processed"""
+        result = manager.can_process_pr(pr_key)
+        assert result == expected_can_process
+
+    def test_can_process_pr_under_limit(self, manager):
+        """Test PR processing allowed when under limit"""
+        pr_key = "test-repo-123"
+
+        # Process PR up to limit - 1
+        for _ in range(manager.pr_limit - 1):
+            manager.record_pr_attempt(pr_key, "success")
+
+        assert manager.can_process_pr(pr_key) == True
+
+    def test_can_process_pr_at_limit(self, manager):
+        """Test PR processing denied when at limit"""
+        pr_key = "test-repo-123"
+
+        # Process PR up to limit
+        for _ in range(manager.pr_limit):
+            manager.record_pr_attempt(pr_key, "success")
+
+        assert manager.can_process_pr(pr_key) == False
+
+    def test_record_pr_attempt_success(self, manager):
+        """Test recording successful PR attempt"""
+        pr_key = "test-repo-123"
+
+        manager.record_pr_attempt(pr_key, "success")
+
+        # Should have one attempt recorded
+        attempts = manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) == 1
+        assert attempts[0]["result"] == "success"
+
+    def test_record_pr_attempt_failure(self, manager):
+        """Test recording failed PR attempt"""
+        pr_key = "test-repo-456"
+
+        manager.record_pr_attempt(pr_key, "failure")
+
+        attempts = manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) == 1
+        assert attempts[0]["result"] == "failure"
+
+    @pytest.mark.parametrize("result", ["success", "failure", "error", "timeout"])
+    def test_record_pr_attempt_various_results(self, manager, result):
+        """Test recording PR attempts with various result types"""
+        pr_key = f"test-repo-{result}"
+
+        manager.record_pr_attempt(pr_key, result)
+
+        attempts = manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) == 1
+        assert attempts[0]["result"] == result
+
+    def test_record_pr_attempt_includes_timestamp(self, manager):
+        """Test that PR attempts include timestamps"""
+        pr_key = "test-repo-timestamp"
+
+        before_time = datetime.now()
+        manager.record_pr_attempt(pr_key, "success")
+        after_time = datetime.now()
+
+        attempts = manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) == 1
+
+        timestamp_str = attempts[0]["timestamp"]
+        timestamp = datetime.fromisoformat(timestamp_str)
+        assert before_time <= timestamp <= after_time
+
+    def test_get_pr_attempts_empty(self, manager):
+        """Test getting attempts for PR with no history"""
+        attempts = manager.get_pr_attempt_list("nonexistent-pr")
+        assert attempts == []
+
+    def test_get_pr_attempts_multiple(self, manager):
+        """Test getting multiple attempts for same PR"""
+        pr_key = "test-repo-multiple"
+
+        manager.record_pr_attempt(pr_key, "failure")
+        manager.record_pr_attempt(pr_key, "success")
+        manager.record_pr_attempt(pr_key, "success")
+
+        attempts = manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) == 3
+        assert attempts[0]["result"] == "failure"
+        assert attempts[1]["result"] == "success"
+        assert attempts[2]["result"] == "success"
+
+    def test_pr_attempts_file_persistence(self, manager):
+        """Test that PR attempts are persisted to file"""
+        pr_key = "test-repo-persist"
+        manager.record_pr_attempt(pr_key, "success")
+
+        # Create new manager with same data dir
+        new_manager = AutomationSafetyManager(manager.data_dir)
+        attempts = new_manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) == 1
+        assert attempts[0]["result"] == "success"
+
+    def test_pr_attempts_thread_safety(self, manager):
+        """Test that PR attempt recording is thread-safe"""
+        pr_key = "test-repo-threading"
+
+        def record_attempts():
+            for i in range(5):
+                manager.record_pr_attempt(pr_key, f"attempt-{i}")
+
+        threads = [threading.Thread(target=record_attempts) for _ in range(3)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        attempts = manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) == 15  # 3 threads × 5 attempts each
+
+
+class TestEmailNotifications:
+    """Test suite for email notification functionality"""
+
+    @pytest.fixture
+    def manager(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield AutomationSafetyManager(temp_dir)
+
+    @patch.dict(os.environ, {
+        "SMTP_SERVER": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "EMAIL_USER": "test@example.com",
+        "EMAIL_PASS": "password",
+        "EMAIL_TO": "admin@example.com"
+    })
+    def test_email_config_complete(self, manager):
+        """Test email configuration detection when complete"""
+        assert manager._is_email_configured() == True
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_email_config_incomplete(self, manager):
+        """Test email configuration detection when incomplete"""
+        assert manager._is_email_configured() == False
+
+    @patch.dict(os.environ, {
+        "SMTP_SERVER": "smtp.example.com",
+        "EMAIL_USER": "test@example.com"
+        # Missing SMTP_PORT, EMAIL_PASS, EMAIL_TO
+    })
+    def test_email_config_partial(self, manager):
+        """Test email configuration detection when partially configured"""
+        assert manager._is_email_configured() == False
+
+    @patch.dict(os.environ, {
+        "SMTP_SERVER": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "EMAIL_USER": "test@example.com",
+        "EMAIL_PASS": "password",
+        "EMAIL_TO": "admin@example.com"
+    })
+    @patch("smtplib.SMTP")
+    def test_send_notification_success(self, mock_smtp, manager):
+        """Test successful email notification sending"""
+        mock_server = Mock()
+        mock_smtp.return_value = mock_server
+
+        result = manager.send_notification("Test Subject", "Test message")
+
+        assert result == True
+        mock_smtp.assert_called_once_with("smtp.example.com", 587)
+        mock_server.starttls.assert_called_once()
+        mock_server.login.assert_called_once_with("test@example.com", "password")
+        mock_server.send_message.assert_called_once()
+        mock_server.quit.assert_called_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_notification_no_config(self, manager):
+        """Test email notification when not configured"""
+        with patch.object(manager.logger, "info") as mock_info:
+            result = manager.send_notification("Test", "Message")
+
+            assert result == False
+            mock_info.assert_called_with("Email configuration incomplete - skipping notification")
+
+    @patch.dict(os.environ, {
+        "SMTP_SERVER": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "EMAIL_USER": "test@example.com",
+        "EMAIL_PASS": "password",
+        "EMAIL_TO": "admin@example.com"
+    })
+    @patch("smtplib.SMTP")
+    def test_send_notification_smtp_error(self, mock_smtp, manager):
+        """Test email notification with SMTP error"""
+        mock_smtp.side_effect = Exception("SMTP connection failed")
+
+        with patch.object(manager.logger, "error") as mock_error:
+            result = manager.send_notification("Test", "Message")
+
+            assert result == False
+            mock_error.assert_called()
+
+    @patch.dict(os.environ, {
+        "SMTP_SERVER": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "EMAIL_USER": "test@example.com",
+        "EMAIL_PASS": "password",
+        "EMAIL_TO": "admin@example.com"
+    })
+    @patch("smtplib.SMTP")
+    def test_send_notification_login_error(self, mock_smtp, manager):
+        """Test email notification with login error"""
+        mock_server = Mock()
+        mock_server.login.side_effect = Exception("Authentication failed")
+        mock_smtp.return_value = mock_server
+
+        with patch.object(manager.logger, "error") as mock_error:
+            result = manager.send_notification("Test", "Message")
+
+            assert result == False
+            mock_error.assert_called()
+
+
+class TestFileLocking:
+    """Test suite for file locking mechanisms"""
+
+    @pytest.fixture
+    def manager(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield AutomationSafetyManager(temp_dir)
+
+    def test_concurrent_global_run_recording(self, manager):
+        """Test that concurrent global run recording is thread-safe"""
+        manager._clear_global_runs()
+
+        results = []
+
+        def record_run_with_result():
+            try:
+                manager.record_global_run()
+                results.append("success")
+            except Exception as e:
+                results.append(f"error: {e}")
+
+        # Start many concurrent threads
+        threads = [threading.Thread(target=record_run_with_result) for _ in range(20)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        # All operations should succeed
+        assert all(result == "success" for result in results)
+        assert manager.get_global_runs() == 20
+
+    def test_concurrent_pr_attempt_recording(self, manager):
+        """Test that concurrent PR attempt recording is thread-safe"""
+        pr_key = "test-repo-concurrent"
+        results = []
+
+        def record_attempt_with_result(attempt_id):
+            try:
+                manager.record_pr_attempt(pr_key, f"attempt-{attempt_id}")
+                results.append("success")
+            except Exception as e:
+                results.append(f"error: {e}")
+
+        # Start many concurrent threads
+        threads = [threading.Thread(target=record_attempt_with_result, args=(i,)) for i in range(15)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        # All operations should succeed
+        assert all(result == "success" for result in results)
+        attempts = manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) == 15
+
+    def test_file_corruption_recovery(self, manager):
+        """Test recovery from corrupted data files"""
+        # Corrupt the global runs file
+        global_runs_file = os.path.join(manager.data_dir, "global_runs.json")
+        manager.record_global_run()  # Create the file first
+
+        with open(global_runs_file, "w") as f:
+            f.write("{ corrupted json")
+
+        # Should recover gracefully
+        manager.record_global_run()
+        assert manager.get_global_runs() >= 1
+
+    def test_permission_error_handling(self, manager):
+        """Test handling of file permission errors"""
+        with patch("jleechanorg_pr_automation.utils.json_manager.write_json", return_value=False):
+            with patch.object(manager.logger, "error") as mock_error:
+                # Should not raise exception
+                manager.record_global_run()
+                mock_error.assert_called()
+
+
+class TestConfigurationManagement:
+    """Test suite for configuration management"""
+
+    def test_load_config_with_all_settings(self):
+        """Test loading configuration with all settings"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "automation_safety_config.json")
+            config_data = {
+                "global_limit": 25,
+                "pr_limit": 5,
+                "daily_limit": 200,
+                "email_notifications": True,
+                "max_pr_size": 1000
+            }
+            with open(config_file, "w") as f:
+                json.dump(config_data, f)
+
+            manager = AutomationSafetyManager(temp_dir)
+            assert manager.global_limit == 25
+            assert manager.pr_limit == 5
+
+    def test_load_config_with_partial_settings(self):
+        """Test loading configuration with partial settings uses defaults"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = os.path.join(temp_dir, "automation_safety_config.json")
+            config_data = {
+                "global_limit": 15
+                # Missing other settings
+            }
+            with open(config_file, "w") as f:
+                json.dump(config_data, f)
+
+            manager = AutomationSafetyManager(temp_dir)
+            assert manager.global_limit == 15
+            assert manager.pr_limit > 0  # Should use default
+
+    def test_save_config_creates_file(self):
+        """Test that save_config creates configuration file"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manager = AutomationSafetyManager(temp_dir)
+
+            config_file = os.path.join(temp_dir, "automation_safety_config.json")
+            assert os.path.exists(config_file)
+
+            with open(config_file) as f:
+                config = json.load(f)
+            assert "global_limit" in config
+            assert "pr_limit" in config
+
+    def test_config_file_permissions(self):
+        """Test that config file has appropriate permissions"""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manager = AutomationSafetyManager(temp_dir)
+
+            config_file = os.path.join(temp_dir, "automation_safety_config.json")
+            stat_info = os.stat(config_file)
+
+            # Should be readable/writable by owner
+            assert stat_info.st_mode & 0o600
+
+
+class TestIntegrationScenarios:
+    """Test suite for integration scenarios"""
+
+    @pytest.fixture
+    def manager(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            yield AutomationSafetyManager(temp_dir)
+
+    def test_typical_automation_workflow(self, manager):
+        """Test typical automation workflow"""
+        # Start automation run
+        assert manager.can_start_global_run() == True
+        manager.record_global_run()
+
+        # Process multiple PRs
+        pr_keys = ["repo1-123", "repo2-456", "repo1-789"]
+
+        for pr_key in pr_keys:
+            assert manager.can_process_pr(pr_key) == True
+            manager.record_pr_attempt(pr_key, "success")
+
+        # Verify state
+        assert manager.get_global_runs() == 1
+        for pr_key in pr_keys:
+            attempts = manager.get_pr_attempt_list(pr_key)
+            assert len(attempts) == 1
+            assert attempts[0]["result"] == "success"
+
+    def test_hitting_pr_limits(self, manager):
+        """Test behavior when hitting PR limits"""
+        pr_key = "test-repo-limit"
+
+        # Process up to limit
+        for i in range(manager.pr_limit):
+            assert manager.can_process_pr(pr_key) == True
+            manager.record_pr_attempt(pr_key, "success")
+
+        # Should now be at limit
+        assert manager.can_process_pr(pr_key) == False
+
+    def test_hitting_global_limits(self, manager):
+        """Test behavior when hitting global limits"""
+        # Fill up to global limit
+        for i in range(manager.global_limit):
+            assert manager.can_start_global_run() == True
+            manager.record_global_run()
+
+        # Should now be at limit
+        assert manager.can_start_global_run() == False
+
+    def test_mixed_success_failure_attempts(self, manager):
+        """Test tracking mixed success/failure attempts"""
+        pr_key = "test-repo-mixed"
+
+        # Record mixed results
+        results = ["failure", "success", "error", "success", "timeout"]
+        for result in results:
+            if manager.can_process_pr(pr_key):
+                manager.record_pr_attempt(pr_key, result)
+
+        attempts = manager.get_pr_attempt_list(pr_key)
+        assert len(attempts) <= manager.pr_limit
+
+        # Verify results are recorded correctly
+        recorded_results = [attempt["result"] for attempt in attempts]
+        assert all(result in results for result in recorded_results)
+
+    def test_multiple_managers_same_data_dir(self, manager):
+        """Test multiple manager instances sharing same data directory"""
+        data_dir = manager.data_dir
+
+        # Create second manager with same data dir
+        manager2 = AutomationSafetyManager(data_dir)
+
+        # Record with first manager
+        manager.record_global_run()
+        manager.record_pr_attempt("test-pr", "success")
+
+        # Verify second manager sees the data
+        assert manager2.get_global_runs() == manager.get_global_runs()
+        attempts1 = manager.get_pr_attempt_list("test-pr")
+        attempts2 = manager2.get_pr_attempt_list("test-pr")
+        assert len(attempts1) == len(attempts2)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/automation/jleechanorg_pr_automation/tests/test_codex_actor_matching.py
+++ b/automation/jleechanorg_pr_automation/tests/test_codex_actor_matching.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for Codex actor detection heuristics."""
+
+import unittest
+
+from jleechanorg_pr_automation.jleechanorg_pr_monitor import JleechanorgPRMonitor
+
+
+class TestCodexActorMatching(unittest.TestCase):
+    """Validate detection of Codex-authored commits."""
+
+    def setUp(self) -> None:
+        self.monitor = JleechanorgPRMonitor()
+
+    def test_detects_codex_via_actor_fields(self) -> None:
+        commit_details = {
+            "author_login": "codex-bot",
+            "author_email": "codex@example.com",
+            "author_name": "Codex Bot",
+            "committer_login": None,
+            "committer_email": None,
+            "committer_name": None,
+            "message_headline": "Refactor subsystem",
+            "message": "Refactor subsystem",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected Codex detection when actor fields include Codex token",
+        )
+
+    def test_detects_codex_via_message_marker(self) -> None:
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "regular-user",
+            "committer_email": "dev@example.com",
+            "committer_name": "Regular User",
+            "message_headline": (
+                f"Address review feedback {self.monitor.CODEX_COMMIT_MESSAGE_MARKER}"
+            ),
+            "message": "Address review feedback and add tests",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected Codex detection from commit message marker",
+        )
+
+    def test_detects_codex_via_message_body_marker_case_insensitive(self) -> None:
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "regular-user",
+            "committer_email": "dev@example.com",
+            "committer_name": "Regular User",
+            "message_headline": "Address review feedback",
+            "message": "Add docs [CODEX-AUTOMATION-COMMIT] and clean up",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected Codex detection from commit body marker",
+        )
+
+    def test_returns_false_when_no_codex_tokens_found(self) -> None:
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "reviewer",
+            "committer_email": "reviewer@example.com",
+            "committer_name": "Helpful Reviewer",
+            "message_headline": "Refactor subsystem",
+            "message": "Improve code coverage",
+        }
+
+        self.assertFalse(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected no Codex detection when no markers are present",
+        )
+
+    def test_handles_non_string_actor_fields(self) -> None:
+        """Type safety: should not crash when actor fields contain non-string values"""
+        commit_details = {
+            "author_login": {"nested": "value"},  # Invalid type
+            "author_email": 12345,  # Invalid type
+            "author_name": None,
+            "committer_login": ["list", "value"],  # Invalid type
+            "committer_email": None,
+            "committer_name": None,
+            "message_headline": "Normal message",
+            "message": "Normal body",
+        }
+
+        # Should not raise TypeError and should return False
+        result = self.monitor._is_head_commit_from_codex(commit_details)
+        self.assertFalse(result, "Should handle non-string fields gracefully")
+
+    def test_handles_non_string_message_fields(self) -> None:
+        """Type safety: should not crash when message fields contain non-string values"""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": None,
+            "committer_email": None,
+            "committer_name": None,
+            "message_headline": {"nested": "object"},  # Invalid type
+            "message": 12345,  # Invalid type
+        }
+
+        # Should not raise TypeError and should return False
+        result = self.monitor._is_head_commit_from_codex(commit_details)
+        self.assertFalse(result, "Should handle non-string message fields gracefully")
+
+    def test_handles_empty_string_fields(self) -> None:
+        """Should handle empty strings correctly"""
+        commit_details = {
+            "author_login": "",
+            "author_email": "",
+            "author_name": "",
+            "committer_login": "",
+            "committer_email": "",
+            "committer_name": "",
+            "message_headline": "",
+            "message": "",
+        }
+
+        result = self.monitor._is_head_commit_from_codex(commit_details)
+        self.assertFalse(result, "Should treat empty strings as no Codex markers")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/automation/jleechanorg_pr_automation/tests/test_graphql_error_handling.py
+++ b/automation/jleechanorg_pr_automation/tests/test_graphql_error_handling.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Tests for GraphQL API error handling in head commit detection."""
+
+import json
+import subprocess
+import unittest
+from unittest.mock import MagicMock, patch
+
+from jleechanorg_pr_automation.jleechanorg_pr_monitor import JleechanorgPRMonitor
+
+
+class TestGraphQLErrorHandling(unittest.TestCase):
+    """Validate robust error handling for GraphQL API failures."""
+
+    def setUp(self) -> None:
+        self.monitor = JleechanorgPRMonitor()
+
+    @patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout")
+    def test_handles_api_timeout(self, mock_exec) -> None:
+        """Should return None when GraphQL API times out"""
+        mock_exec.side_effect = subprocess.TimeoutExpired(["gh"], 30)
+
+        result = self.monitor._get_head_commit_details("org/repo", 123)
+
+        self.assertIsNone(result, "Should return None on API timeout")
+
+    @patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout")
+    def test_handles_malformed_json(self, mock_exec) -> None:
+        """Should return None when GraphQL returns invalid JSON"""
+        mock_exec.return_value = MagicMock(
+            stdout='{"invalid": json, missing quotes}'
+        )
+
+        result = self.monitor._get_head_commit_details("org/repo", 123)
+
+        self.assertIsNone(result, "Should return None on malformed JSON")
+
+    @patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout")
+    def test_handles_missing_data_field(self, mock_exec) -> None:
+        """Should handle missing 'data' field in GraphQL response"""
+        mock_exec.return_value = MagicMock(
+            stdout='{"errors": [{"message": "Field error"}]}'
+        )
+
+        result = self.monitor._get_head_commit_details("org/repo", 123)
+
+        self.assertIsNone(result, "Should return None when data field missing")
+
+    @patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout")
+    def test_handles_missing_repository_field(self, mock_exec) -> None:
+        """Should handle missing 'repository' field gracefully"""
+        mock_exec.return_value = MagicMock(
+            stdout='{"data": {}}'
+        )
+
+        result = self.monitor._get_head_commit_details("org/repo", 123)
+
+        self.assertIsNone(result, "Should return None when repository field missing")
+
+    @patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout")
+    def test_handles_missing_commits(self, mock_exec) -> None:
+        """Should handle missing commits array gracefully"""
+        response = {
+            "data": {
+                "repository": {
+                    "pullRequest": {}
+                }
+            }
+        }
+        mock_exec.return_value = MagicMock(stdout=json.dumps(response))
+
+        result = self.monitor._get_head_commit_details("org/repo", 123)
+
+        self.assertIsNone(result, "Should return None when commits missing")
+
+    @patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout")
+    def test_handles_empty_commits_array(self, mock_exec) -> None:
+        """Should handle empty commits array gracefully"""
+        response = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "commits": {"nodes": []}
+                    }
+                }
+            }
+        }
+        mock_exec.return_value = MagicMock(stdout=json.dumps(response))
+
+        result = self.monitor._get_head_commit_details("org/repo", 123)
+
+        self.assertIsNone(result, "Should return None when commits array empty")
+
+    @patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout")
+    def test_handles_called_process_error(self, mock_exec) -> None:
+        """Should handle subprocess CalledProcessError gracefully"""
+        mock_exec.side_effect = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["gh", "api"],
+            stderr="API rate limit exceeded"
+        )
+
+        result = self.monitor._get_head_commit_details("org/repo", 123)
+
+        self.assertIsNone(result, "Should return None on CalledProcessError")
+
+    @patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout")
+    def test_handles_generic_exception(self, mock_exec) -> None:
+        """Should handle unexpected exceptions gracefully"""
+        mock_exec.side_effect = RuntimeError("Unexpected error")
+
+        result = self.monitor._get_head_commit_details("org/repo", 123)
+
+        self.assertIsNone(result, "Should return None on unexpected exception")
+
+    def test_validates_invalid_repo_format(self) -> None:
+        """Should return None for invalid repository format"""
+        result = self.monitor._get_head_commit_details("invalid-no-slash", 123)
+
+        self.assertIsNone(result, "Should reject repo without slash separator")
+
+    def test_validates_empty_repo_name(self) -> None:
+        """Should return None for empty repository parts"""
+        result = self.monitor._get_head_commit_details("/repo", 123)
+
+        self.assertIsNone(result, "Should reject empty owner")
+
+    def test_validates_invalid_github_owner_name(self) -> None:
+        """Should return None for invalid GitHub owner/repo names"""
+        # GitHub names cannot start with hyphen
+        result = self.monitor._get_head_commit_details("-invalid/repo", 123)
+
+        self.assertIsNone(result, "Should reject owner starting with hyphen")
+
+    def test_validates_invalid_pr_number_string(self) -> None:
+        """Should return None for non-integer PR number"""
+        result = self.monitor._get_head_commit_details("org/repo", "not-a-number")
+
+        self.assertIsNone(result, "Should reject string PR number")
+
+    def test_validates_negative_pr_number(self) -> None:
+        """Should return None for negative PR number"""
+        result = self.monitor._get_head_commit_details("org/repo", -1)
+
+        self.assertIsNone(result, "Should reject negative PR number")
+
+    def test_validates_zero_pr_number(self) -> None:
+        """Should return None for zero PR number"""
+        result = self.monitor._get_head_commit_details("org/repo", 0)
+
+        self.assertIsNone(result, "Should reject zero PR number")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/automation/jleechanorg_pr_automation/tests/test_pr_filtering_matrix.py
+++ b/automation/jleechanorg_pr_automation/tests/test_pr_filtering_matrix.py
@@ -1,0 +1,470 @@
+#!/usr/bin/env python3
+"""
+RED Phase: Matrix-driven TDD tests for PR filtering and actionable counting
+
+Test Matrix Coverage:
+- PR Status × Commit Changes × Processing History → Action + Count
+- Batch Processing Logic with Skip Exclusion
+- Eligible PR Detection and Filtering
+"""
+
+import shutil
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+from jleechanorg_pr_automation.jleechanorg_pr_monitor import JleechanorgPRMonitor
+
+
+class TestPRFilteringMatrix(unittest.TestCase):
+    """Matrix testing for PR filtering and actionable counting logic"""
+
+    def setUp(self):
+        """Set up test environment"""
+        self.temp_dir = tempfile.mkdtemp()
+        self.monitor = JleechanorgPRMonitor()
+        self.monitor.history_storage_path = self.temp_dir
+
+    def tearDown(self):
+        """Clean up test files"""
+        shutil.rmtree(self.temp_dir)
+
+    # Matrix 1: PR Status × Commit Changes × Processing History
+    def test_matrix_open_pr_new_commit_never_processed_should_be_actionable(self):
+        """RED: Open PR with new commit, never processed → Should be actionable"""
+        pr_data = {
+            "number": 1001,
+            "title": "Test PR",
+            "state": "open",
+            "isDraft": False,
+            "headRefName": "feature-branch",
+            "repository": "test-repo",
+            "repositoryFullName": "org/test-repo",
+            "headRefOid": "abc123new"
+        }
+
+        # RED: This will fail - no is_pr_actionable method exists
+        result = self.monitor.is_pr_actionable(pr_data)
+        self.assertTrue(result)
+
+    def test_matrix_open_pr_same_commit_already_processed_should_not_be_actionable(self):
+        """RED: Open PR with same commit, already processed → Should not be actionable"""
+        pr_data = {
+            "number": 1001,
+            "title": "Test PR",
+            "state": "open",
+            "isDraft": False,
+            "headRefName": "feature-branch",
+            "repository": "test-repo",
+            "repositoryFullName": "org/test-repo",
+            "headRefOid": "abc123same"
+        }
+
+        # Simulate previous processing
+        self.monitor._record_pr_processing("test-repo", "feature-branch", 1001, "abc123same")
+
+        # RED: This will fail - no is_pr_actionable method exists
+        result = self.monitor.is_pr_actionable(pr_data)
+        self.assertFalse(result)
+
+    def test_matrix_open_pr_new_commit_old_commit_processed_should_be_actionable(self):
+        """RED: Open PR with new commit, old commit processed → Should be actionable"""
+        pr_data = {
+            "number": 1001,
+            "title": "Test PR",
+            "state": "open",
+            "isDraft": False,
+            "headRefName": "feature-branch",
+            "repository": "test-repo",
+            "repositoryFullName": "org/test-repo",
+            "headRefOid": "abc123new"
+        }
+
+        # Simulate processing of old commit
+        self.monitor._record_pr_processing("test-repo", "feature-branch", 1001, "abc123old")
+
+        # RED: This will fail - no is_pr_actionable method exists
+        result = self.monitor.is_pr_actionable(pr_data)
+        self.assertTrue(result)
+
+    def test_matrix_closed_pr_any_commit_should_not_be_actionable(self):
+        """RED: Closed PR with any commit → Should not be actionable"""
+        pr_data = {
+            "number": 1001,
+            "title": "Test PR",
+            "state": "closed",
+            "isDraft": False,
+            "headRefName": "feature-branch",
+            "repository": "test-repo",
+            "repositoryFullName": "org/test-repo",
+            "headRefOid": "abc123new"
+        }
+
+        # RED: This will fail - no is_pr_actionable method exists
+        result = self.monitor.is_pr_actionable(pr_data)
+        self.assertFalse(result)
+
+    def test_matrix_draft_pr_new_commit_never_processed_should_be_actionable(self):
+        """RED: Draft PR with new commit, never processed → Should be actionable"""
+        pr_data = {
+            "number": 1001,
+            "title": "Test PR",
+            "state": "open",
+            "isDraft": True,
+            "headRefName": "feature-branch",
+            "repository": "test-repo",
+            "repositoryFullName": "org/test-repo",
+            "headRefOid": "abc123new"
+        }
+
+        # RED: This will fail - no is_pr_actionable method exists
+        result = self.monitor.is_pr_actionable(pr_data)
+        self.assertTrue(result)
+
+    def test_matrix_open_pr_no_commits_should_not_be_actionable(self):
+        """RED: Open PR with no commits → Should not be actionable"""
+        pr_data = {
+            "number": 1001,
+            "title": "Test PR",
+            "state": "open",
+            "isDraft": False,
+            "headRefName": "feature-branch",
+            "repository": "test-repo",
+            "repositoryFullName": "org/test-repo",
+            "headRefOid": None  # No commits
+        }
+
+        # RED: This will fail - no is_pr_actionable method exists
+        result = self.monitor.is_pr_actionable(pr_data)
+        self.assertFalse(result)
+
+    # Matrix 2: Batch Processing Logic with Skip Exclusion
+    def test_matrix_batch_processing_15_eligible_target_10_should_process_10(self):
+        """RED: 15 eligible PRs, target 10 → Should process exactly 10"""
+        # Create 15 eligible PRs
+        eligible_prs = []
+        for i in range(15):
+            pr = {
+                "number": 1000 + i,
+                "title": f"Test PR {i}",
+                "state": "open",
+                "isDraft": False,
+                "headRefName": f"feature-branch-{i}",
+                "repository": "test-repo",
+                "repositoryFullName": "org/test-repo",
+                "headRefOid": f"abc123{i:03d}"
+            }
+            eligible_prs.append(pr)
+
+        # RED: This will fail - no process_actionable_prs method exists
+        processed_count = self.monitor.process_actionable_prs(eligible_prs, target_count=10)
+        self.assertEqual(processed_count, 10)
+
+    def test_matrix_batch_processing_5_eligible_target_10_should_process_5(self):
+        """RED: 5 eligible PRs, target 10 → Should process all 5"""
+        # Create 5 eligible PRs
+        eligible_prs = []
+        for i in range(5):
+            pr = {
+                "number": 1000 + i,
+                "title": f"Test PR {i}",
+                "state": "open",
+                "isDraft": False,
+                "headRefName": f"feature-branch-{i}",
+                "repository": "test-repo",
+                "repositoryFullName": "org/test-repo",
+                "headRefOid": f"abc123{i:03d}"
+            }
+            eligible_prs.append(pr)
+
+        # RED: This will fail - no process_actionable_prs method exists
+        processed_count = self.monitor.process_actionable_prs(eligible_prs, target_count=10)
+        self.assertEqual(processed_count, 5)
+
+    def test_matrix_batch_processing_0_eligible_target_10_should_process_0(self):
+        """RED: 0 eligible PRs, target 10 → Should process 0"""
+        eligible_prs = []
+
+        # RED: This will fail - no process_actionable_prs method exists
+        processed_count = self.monitor.process_actionable_prs(eligible_prs, target_count=10)
+        self.assertEqual(processed_count, 0)
+
+    def test_matrix_batch_processing_mixed_actionable_and_skipped_should_exclude_skipped_from_count(self):
+        """RED: Mixed actionable and skipped PRs → Should exclude skipped from count"""
+        # Create mixed PRs - some actionable, some already processed
+        all_prs = []
+
+        # 5 actionable PRs
+        for i in range(5):
+            pr = {
+                "number": 1000 + i,
+                "title": f"Actionable PR {i}",
+                "state": "open",
+                "isDraft": False,
+                "headRefName": f"feature-branch-{i}",
+                "repository": "test-repo",
+                "repositoryFullName": "org/test-repo",
+                "headRefOid": f"abc123new{i:03d}"
+            }
+            all_prs.append(pr)
+
+        # 3 already processed PRs (should be skipped)
+        for i in range(3):
+            pr = {
+                "number": 2000 + i,
+                "title": f"Processed PR {i}",
+                "state": "open",
+                "isDraft": False,
+                "headRefName": f"processed-branch-{i}",
+                "repository": "test-repo",
+                "repositoryFullName": "org/test-repo",
+                "headRefOid": f"abc123old{i:03d}"
+            }
+            # Pre-record as processed
+            self.monitor._record_pr_processing("test-repo", f"processed-branch-{i}", 2000 + i, f"abc123old{i:03d}")
+            all_prs.append(pr)
+
+        # RED: This will fail - no filter_and_process_prs method exists
+        processed_count = self.monitor.filter_and_process_prs(all_prs, target_actionable_count=10)
+        self.assertEqual(processed_count, 5)  # Only actionable PRs counted
+
+    # Matrix 3: Eligible PR Detection
+    def test_matrix_filter_eligible_prs_from_mixed_list(self):
+        """RED: Filter eligible PRs from mixed list → Should return only actionable ones"""
+        mixed_prs = [
+            # Actionable: Open, new commit
+            {
+                "number": 1001, "state": "open", "isDraft": False,
+                "headRefOid": "new123", "repository": "repo1",
+                "headRefName": "branch1", "repositoryFullName": "org/repo1"
+            },
+            # Not actionable: Closed
+            {
+                "number": 1002, "state": "closed", "isDraft": False,
+                "headRefOid": "new456", "repository": "repo2",
+                "headRefName": "branch2", "repositoryFullName": "org/repo2"
+            },
+            # Not actionable: Already processed
+            {
+                "number": 1003, "state": "open", "isDraft": False,
+                "headRefOid": "old789", "repository": "repo3",
+                "headRefName": "branch3", "repositoryFullName": "org/repo3"
+            },
+            # Actionable: Draft but new commit
+            {
+                "number": 1004, "state": "open", "isDraft": True,
+                "headRefOid": "new999", "repository": "repo4",
+                "headRefName": "branch4", "repositoryFullName": "org/repo4"
+            }
+        ]
+
+        # Mark one as already processed
+        self.monitor._record_pr_processing("repo3", "branch3", 1003, "old789")
+
+        # RED: This will fail - no filter_eligible_prs method exists
+        eligible_prs = self.monitor.filter_eligible_prs(mixed_prs)
+
+        # Should return only the 2 actionable PRs
+        self.assertEqual(len(eligible_prs), 2)
+        actionable_numbers = [pr["number"] for pr in eligible_prs]
+        self.assertIn(1001, actionable_numbers)
+        self.assertIn(1004, actionable_numbers)
+        self.assertNotIn(1002, actionable_numbers)  # Closed
+        self.assertNotIn(1003, actionable_numbers)  # Already processed
+
+    def test_matrix_find_5_eligible_prs_from_live_data(self):
+        """RED: Find 5 eligible PRs from live GitHub data → Should return 5 actionable PRs"""
+        # Mock discover_open_prs to return test data instead of calling GitHub API
+        mock_prs = [
+            {"number": 1, "state": "open", "isDraft": False, "headRefOid": "abc123", "repository": "repo1", "headRefName": "feature1"},
+            {"number": 2, "state": "closed", "isDraft": False, "headRefOid": "def456", "repository": "repo2", "headRefName": "feature2"},
+            {"number": 3, "state": "open", "isDraft": False, "headRefOid": "ghi789", "repository": "repo3", "headRefName": "feature3"},
+            {"number": 4, "state": "open", "isDraft": True, "headRefOid": "jkl012", "repository": "repo4", "headRefName": "feature4"},
+            {"number": 5, "state": "open", "isDraft": False, "headRefOid": "mno345", "repository": "repo5", "headRefName": "feature5"},
+            {"number": 6, "state": "open", "isDraft": False, "headRefOid": "pqr678", "repository": "repo6", "headRefName": "feature6"},
+            {"number": 7, "state": "open", "isDraft": False, "headRefOid": "stu901", "repository": "repo7", "headRefName": "feature7"}
+        ]
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=mock_prs):
+            eligible_prs = self.monitor.find_eligible_prs(limit=5)
+            self.assertEqual(len(eligible_prs), 5)
+            # All returned PRs should be actionable
+            for pr in eligible_prs:
+                self.assertTrue(self.monitor.is_pr_actionable(pr))
+
+    # Matrix 5: Comment Posting Return Values (Bug Fix Tests)
+    def test_comment_posting_returns_posted_on_success(self):
+        """GREEN: Comment posting should return 'posted' when successful"""
+        with patch.object(self.monitor, "_get_pr_comment_state") as mock_state, \
+             patch.object(self.monitor, "_should_skip_pr") as mock_skip, \
+             patch.object(self.monitor, "_has_codex_comment_for_commit") as mock_has_comment, \
+             patch.object(self.monitor, "_build_codex_comment_body_simple") as mock_build_body, \
+             patch.object(self.monitor, "_record_processed_pr") as mock_record, \
+             patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout") as mock_subprocess:
+
+            # Setup: PR not skipped, no existing comment, successful command
+            mock_state.return_value = ("sha123", [])
+            mock_skip.return_value = False
+            mock_has_comment.return_value = False
+            mock_build_body.return_value = "Test comment body"
+            mock_subprocess.return_value = Mock(returncode=0, stdout="success", stderr="")
+
+            pr_data = {
+                "repositoryFullName": "org/repo",
+                "headRefName": "feature"
+            }
+
+            result = self.monitor.post_codex_instruction_simple("org/repo", 123, pr_data)
+            self.assertEqual(result, "posted")
+            mock_record.assert_called_once()
+
+    def test_comment_posting_returns_skipped_when_already_processed(self):
+        """GREEN: Comment posting should return 'skipped' when PR already processed"""
+        with patch.object(self.monitor, "_get_pr_comment_state") as mock_state, \
+             patch.object(self.monitor, "_should_skip_pr") as mock_skip:
+
+            # Setup: PR should be skipped
+            mock_state.return_value = ("sha123", [])
+            mock_skip.return_value = True
+
+            pr_data = {
+                "repositoryFullName": "org/repo",
+                "headRefName": "feature"
+            }
+
+            result = self.monitor.post_codex_instruction_simple("org/repo", 123, pr_data)
+            self.assertEqual(result, "skipped")
+
+    def test_comment_posting_returns_skipped_when_comment_exists(self):
+        """GREEN: Comment posting should return 'skipped' when comment already exists for commit"""
+        with patch.object(self.monitor, "_get_pr_comment_state") as mock_state, \
+             patch.object(self.monitor, "_should_skip_pr") as mock_skip, \
+             patch.object(self.monitor, "_has_codex_comment_for_commit") as mock_has_comment:
+
+            # Setup: PR not skipped but has existing comment
+            mock_state.return_value = ("sha123", [])
+            mock_skip.return_value = False
+            mock_has_comment.return_value = True
+
+            pr_data = {
+                "repositoryFullName": "org/repo",
+                "headRefName": "feature"
+            }
+
+            result = self.monitor.post_codex_instruction_simple("org/repo", 123, pr_data)
+            self.assertEqual(result, "skipped")
+
+    def test_comment_posting_returns_failed_on_subprocess_error(self):
+        """GREEN: Comment posting should return 'failed' when subprocess fails"""
+        with patch.object(self.monitor, "_get_pr_comment_state") as mock_state, \
+             patch.object(self.monitor, "_should_skip_pr") as mock_skip, \
+             patch.object(self.monitor, "_has_codex_comment_for_commit") as mock_has_comment, \
+             patch.object(self.monitor, "_build_codex_comment_body_simple") as mock_build_body, \
+             patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout") as mock_subprocess:
+
+            # Setup: PR not skipped, no existing comment, but command fails
+            mock_state.return_value = ("sha123", [])
+            mock_skip.return_value = False
+            mock_has_comment.return_value = False
+            mock_build_body.return_value = "Test comment body"
+            mock_subprocess.side_effect = Exception("Command failed")
+
+            pr_data = {
+                "repositoryFullName": "org/repo",
+                "headRefName": "feature"
+            }
+
+            result = self.monitor.post_codex_instruction_simple("org/repo", 123, pr_data)
+            self.assertEqual(result, "failed")
+
+    def test_comment_posting_skips_when_head_commit_from_codex(self):
+        """GREEN: post_codex_instruction_simple should skip when head commit is Codex-attributed"""
+        with patch.object(self.monitor, "_get_pr_comment_state") as mock_state, \
+             patch.object(self.monitor, "_get_head_commit_details") as mock_head_details, \
+             patch.object(self.monitor, "_is_head_commit_from_codex") as mock_is_codex, \
+             patch.object(self.monitor, "_should_skip_pr") as mock_should_skip, \
+             patch.object(self.monitor, "_has_codex_comment_for_commit") as mock_has_comment, \
+             patch.object(self.monitor, "_record_processed_pr") as mock_record_processed, \
+             patch.object(self.monitor, "_build_codex_comment_body_simple") as mock_build_body, \
+             patch("jleechanorg_pr_automation.automation_utils.AutomationUtils.execute_subprocess_with_timeout") as mock_subprocess:
+
+            mock_state.return_value = ("sha123", [])
+            mock_head_details.return_value = {"sha": "sha123"}
+            mock_is_codex.return_value = True
+
+            pr_data = {
+                "repositoryFullName": "org/repo",
+                "headRefName": "feature",
+            }
+
+            result = self.monitor.post_codex_instruction_simple("org/repo", 456, pr_data)
+
+            self.assertEqual(result, "skipped")
+            mock_is_codex.assert_called_once_with({"sha": "sha123"})
+            mock_should_skip.assert_not_called()
+            mock_has_comment.assert_not_called()
+            mock_build_body.assert_not_called()
+            mock_subprocess.assert_not_called()
+            mock_record_processed.assert_called_once_with("repo", "feature", 456, "sha123")
+
+    def test_process_pr_comment_only_returns_true_for_posted(self):
+        """GREEN: _process_pr_comment should only return True when comment actually posted"""
+        with patch.object(self.monitor, "post_codex_instruction_simple") as mock_post:
+
+            pr_data = {"repositoryFullName": "org/repo"}
+
+            # Test: Returns True only for 'posted'
+            mock_post.return_value = "posted"
+            self.assertTrue(self.monitor._process_pr_comment("repo", 123, pr_data))
+
+            # Test: Returns False for 'skipped'
+            mock_post.return_value = "skipped"
+            self.assertFalse(self.monitor._process_pr_comment("repo", 123, pr_data))
+
+            # Test: Returns False for 'failed'
+            mock_post.return_value = "failed"
+            self.assertFalse(self.monitor._process_pr_comment("repo", 123, pr_data))
+
+    def test_comment_template_contains_all_ai_assistants(self):
+        """GREEN: Comment template should mention all 4 AI assistants"""
+        pr_data = {
+            "title": "Test PR",
+            "author": {"login": "testuser"},
+            "headRefName": "test-branch"
+        }
+
+        comment_body = self.monitor._build_codex_comment_body_simple(
+            "test/repo", 123, pr_data, "abc12345"
+        )
+
+        # Verify all 4 AI assistant mentions are present
+        self.assertIn("@codex", comment_body, "Comment should mention @codex")
+        self.assertIn("@coderabbitai", comment_body, "Comment should mention @coderabbitai")
+        self.assertIn("@copilot", comment_body, "Comment should mention @copilot")
+        self.assertIn("@cursor", comment_body, "Comment should mention @cursor")
+
+        # Verify they appear at the beginning of the comment
+        first_line = comment_body.split("\n")[0]
+        self.assertIn("@codex", first_line, "@codex should be in first line")
+        self.assertIn("@coderabbitai", first_line, "@coderabbitai should be in first line")
+        self.assertIn("@copilot", first_line, "@copilot should be in first line")
+        self.assertIn("@cursor", first_line, "@cursor should be in first line")
+
+        # Verify automation marker instructions are documented
+        self.assertIn(
+            self.monitor.CODEX_COMMIT_MESSAGE_MARKER,
+            comment_body,
+            "Comment should instruct Codex to include the commit message marker",
+        )
+        self.assertIn(
+            "<!-- codex-automation-commit:",
+            comment_body,
+            "Comment should remind Codex about the hidden commit marker",
+        )
+
+
+if __name__ == "__main__":
+    # RED Phase: Run tests to confirm they FAIL
+    print("🔴 RED Phase: Running failing tests for PR filtering matrix")
+    print("Expected: ALL TESTS SHOULD FAIL (no implementation exists)")
+    unittest.main(verbosity=2)

--- a/automation/jleechanorg_pr_automation/tests/test_pr_targeting.py
+++ b/automation/jleechanorg_pr_automation/tests/test_pr_targeting.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Test PR targeting functionality for jleechanorg_pr_monitor - Codex Strategy Tests Only
+"""
+
+import unittest
+
+from jleechanorg_pr_automation.codex_config import build_comment_intro
+from jleechanorg_pr_automation.jleechanorg_pr_monitor import JleechanorgPRMonitor
+
+
+class TestPRTargeting(unittest.TestCase):
+    """Test PR targeting functionality - Codex Strategy Only"""
+
+    def test_extract_commit_marker(self):
+        """Commit markers can be parsed from Codex comments"""
+        monitor = JleechanorgPRMonitor()
+        intro_line = build_comment_intro(
+            assistant_mentions=monitor.assistant_mentions
+        )
+        test_comment = (
+            f"{intro_line} Test comment\n\n"
+            f"{monitor.CODEX_COMMIT_MARKER_PREFIX}abc123{monitor.CODEX_COMMIT_MARKER_SUFFIX}"
+        )
+        marker = monitor._extract_commit_marker(test_comment)
+        self.assertEqual(marker, "abc123")
+
+    def test_intro_prose_avoids_duplicate_mentions(self):
+        """Review assistants should not retain '@' prefixes in prose text."""
+
+        intro_line = build_comment_intro(
+            assistant_mentions="@codex @coderabbitai @copilot @cursor"
+        )
+        _, _, intro_body = intro_line.partition("] ")
+        self.assertIn("coderabbitai", intro_body)
+        self.assertNotIn("@coderabbitai", intro_body)
+
+    def test_intro_without_mentions_has_no_leading_space(self):
+        """Explicitly blank mention lists should not add stray whitespace."""
+
+        intro_line = build_comment_intro(assistant_mentions="")
+        self.assertTrue(intro_line.startswith("[AI automation]"))
+
+    def test_detect_pending_codex_commit(self):
+        """Codex bot summary comments referencing head commit trigger pending detection."""
+        monitor = JleechanorgPRMonitor()
+        head_sha = "abcdef1234567890"
+        comments = [
+            {
+                "body": "**Summary**\nlink https://github.com/org/repo/blob/abcdef1234567890/path/file.py\n",
+                "author": {"login": "chatgpt-codex-connector[bot]"},
+            }
+        ]
+
+        self.assertTrue(monitor._has_pending_codex_commit(comments, head_sha))
+
+    def test_pending_codex_commit_detects_short_sha_references(self):
+        """Cursor Bugbot short SHA references should still count as pending commits."""
+        monitor = JleechanorgPRMonitor()
+        full_head_sha = "c279655d00dfcab5ac1a2fd9b0f6205ce5cbba12"
+        comments = [
+            {
+                "body": "Written by Cursor Bugbot for commit c279655. This will update automatically on new commits.",
+                "author": {"login": "chatgpt-codex-connector[bot]"},
+            }
+        ]
+
+        self.assertTrue(monitor._has_pending_codex_commit(comments, full_head_sha))
+
+    def test_pending_codex_commit_ignores_short_head_sha(self):
+        """Short head SHAs should not match longer Codex summary hashes."""
+        monitor = JleechanorgPRMonitor()
+        short_head_sha = "c279655"
+        comments = [
+            {
+                "body": "Written by Cursor Bugbot for commit c279655d00dfcab5ac1a2fd9b0f6205ce5cbba12.",
+                "author": {"login": "chatgpt-codex-connector[bot]"},
+            }
+        ]
+
+        self.assertFalse(monitor._has_pending_codex_commit(comments, short_head_sha))
+
+    def test_pending_codex_commit_requires_codex_author(self):
+        """Pending detection ignores non-Codex authors even if commit appears in comment."""
+        monitor = JleechanorgPRMonitor()
+        head_sha = "abcdef1234567890"
+        comments = [
+            {
+                "body": "Please review commit https://github.com/org/repo/commit/abcdef1234567890",
+                "author": {"login": "reviewer"},
+            }
+        ]
+
+        self.assertFalse(monitor._has_pending_codex_commit(comments, head_sha))
+
+    def test_codex_comment_includes_detailed_execution_flow(self):
+        """Automation comment should summarize the enforced execution flow with numbered steps."""
+        monitor = JleechanorgPRMonitor()
+        pr_data = {
+            "title": "Improve automation summary",
+            "author": {"login": "developer"},
+            "headRefName": "feature/automation-flow",
+        }
+
+        comment_body = monitor._build_codex_comment_body_simple(
+            "jleechanorg/your-project.com",
+            42,
+            pr_data,
+            "abcdef1234567890",
+        )
+
+        self.assertIn("**Summary (Execution Flow):**", comment_body)
+        self.assertIn("1. Review every outstanding PR comment", comment_body)
+        self.assertIn("5. Perform a final self-review", comment_body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/automation/jleechanorg_pr_automation/utils.py
+++ b/automation/jleechanorg_pr_automation/utils.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+Shared utilities for automation system
+
+Consolidates common patterns:
+- JSON file operations with thread safety
+- Logging configuration setup
+- Environment variable handling
+- Email configuration management
+"""
+
+import fcntl
+import json
+import logging
+import os
+import tempfile
+import threading
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+class SafeJSONManager:
+    """Thread-safe and cross-process safe JSON file operations with file locking"""
+
+    def __init__(self):
+        self._locks = {}
+        self._locks_lock = threading.Lock()
+
+    def _get_lock(self, file_path: str) -> threading.RLock:
+        """Get or create a lock for a specific file"""
+        # Normalize path to prevent duplicate locks for same file
+        norm_path = os.path.abspath(file_path)
+        with self._locks_lock:
+            if norm_path not in self._locks:
+                self._locks[norm_path] = threading.RLock()
+            return self._locks[norm_path]
+
+    def _get_file_lock_path(self, file_path: str) -> str:
+        """Get file lock path for cross-process safety"""
+        return f"{file_path}.lock"
+
+    def read_json(self, file_path: str, default: Any = None) -> Any:
+        """Cross-process safe JSON file reading with default fallback"""
+        lock = self._get_lock(file_path)
+        with lock:
+            try:
+                if os.path.exists(file_path):
+                    with open(file_path) as f:
+                        # Add file lock for cross-process safety
+                        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+                        try:
+                            return json.load(f)
+                        finally:
+                            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+                else:
+                    return default if default is not None else {}
+            except (OSError, json.JSONDecodeError) as e:
+                logging.warning(f"Failed to read JSON from {file_path}: {e}")
+                return default if default is not None else {}
+
+    def write_json(self, file_path: str, data: Any) -> bool:
+        """Cross-process safe JSON file writing with atomic operations"""
+        lock = self._get_lock(file_path)
+        with lock:
+            try:
+                # Ensure directory exists (guard against empty dirname for root files)
+                directory = os.path.dirname(file_path)
+                if directory:
+                    os.makedirs(directory, exist_ok=True)
+
+                # Create temp file in same directory for atomic replace
+                dir_path = directory or "."
+                fd, temp_path = tempfile.mkstemp(
+                    dir=dir_path,
+                    prefix=os.path.basename(file_path),
+                    suffix=".tmp"
+                )
+
+                try:
+                    with os.fdopen(fd, "w") as f:
+                        # Add exclusive file lock for cross-process safety
+                        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+                        try:
+                            json.dump(data, f, indent=2, default=str)
+                            f.flush()
+                            os.fsync(f.fileno())
+                        finally:
+                            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+                    # Atomic replace
+                    os.replace(temp_path, file_path)
+                    return True
+                finally:
+                    # Clean up temp file if replace failed
+                    if os.path.exists(temp_path):
+                        try:
+                            os.remove(temp_path)
+                        except OSError:
+                            # Ignore errors during temp file cleanup (file may already be deleted)
+                            pass
+
+            except OSError as e:
+                logging.exception(f"Failed to write JSON to {file_path}: {e}")
+                return False
+
+    def update_json(self, file_path: str, update_func, lock_timeout: int = 10) -> bool:
+        """Cross-process safe JSON file update with callback function"""
+        lock = self._get_lock(file_path)
+        with lock:
+            try:
+                data = self.read_json(file_path, {})
+                updated_data = update_func(data)
+                return self.write_json(file_path, updated_data)
+            except Exception as e:
+                logging.exception(f"Failed to update JSON {file_path}: {e}")
+                return False
+
+
+# Global instance for shared use
+json_manager = SafeJSONManager()
+
+
+def setup_logging(name: str, level: int = logging.INFO,
+                 log_file: Optional[str] = None) -> logging.Logger:
+    """Standardized logging setup for automation components"""
+    logger = logging.getLogger(name)
+
+    # Avoid duplicate handlers
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(level)
+
+    # Create formatter
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+
+    # Console handler
+    console_handler = logging.StreamHandler()
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
+    # File handler if specified
+    if log_file:
+        os.makedirs(os.path.dirname(log_file), exist_ok=True)
+        file_handler = logging.FileHandler(log_file)
+        file_handler.setFormatter(formatter)
+        logger.addHandler(file_handler)
+
+    return logger
+
+
+def get_env_config(prefix: str = "AUTOMATION_") -> Dict[str, str]:
+    """Get all environment variables with specified prefix"""
+    config = {}
+    for key, value in os.environ.items():
+        if key.startswith(prefix):
+            # Remove prefix and convert to lowercase
+            config_key = key[len(prefix):].lower()
+            config[config_key] = value
+    return config
+
+
+def get_email_config() -> Dict[str, str]:
+    """Get email configuration from environment variables"""
+    email_config = {
+        "smtp_server": os.getenv("SMTP_SERVER", "localhost"),
+        "smtp_port": int(os.getenv("SMTP_PORT", "587")),
+        "email_user": os.getenv("EMAIL_USER", ""),
+        "email_pass": os.getenv("EMAIL_PASS", ""),
+        "email_to": os.getenv("EMAIL_TO", ""),
+        "email_from": os.getenv("EMAIL_FROM", os.getenv("EMAIL_USER", ""))
+    }
+    return email_config
+
+
+def validate_email_config(config: Dict[str, str]) -> bool:
+    """Validate that required email configuration is present"""
+    required_fields = ["smtp_server", "email_user", "email_pass", "email_to"]
+    return all(config.get(field) for field in required_fields)
+
+
+def get_automation_limits() -> Dict[str, int]:
+    """Get automation safety limits from environment or defaults"""
+    return {
+        "pr_limit": int(os.getenv("AUTOMATION_PR_LIMIT", "5")),
+        "global_limit": int(os.getenv("AUTOMATION_GLOBAL_LIMIT", "50")),
+        "approval_hours": int(os.getenv("AUTOMATION_APPROVAL_HOURS", "24")),
+        "subprocess_timeout": int(os.getenv("AUTOMATION_SUBPROCESS_TIMEOUT", "300"))
+    }
+
+
+def ensure_directory(file_path: str) -> None:
+    """Ensure directory exists for given file path"""
+    directory = os.path.dirname(file_path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+
+def get_project_root() -> str:
+    """Get project root directory"""
+    current_dir = Path(__file__).resolve()
+    # Look for CLAUDE.md to identify project root
+    for parent in current_dir.parents:
+        if (parent / "CLAUDE.md").exists():
+            return str(parent)
+    # Fallback to parent of automation directory
+    return str(current_dir.parent.parent)
+
+
+def format_timestamp(dt: datetime = None) -> str:
+    """Format datetime as ISO string"""
+    if dt is None:
+        dt = datetime.now()
+    return dt.isoformat()
+
+
+def parse_timestamp(timestamp_str: str) -> datetime:
+    """Parse ISO timestamp string to datetime"""
+    return datetime.fromisoformat(timestamp_str)
+
+
+def get_test_email_config() -> Dict[str, str]:
+    """Get standardized test email configuration"""
+    return {
+        "SMTP_SERVER": "smtp.example.com",
+        "SMTP_PORT": "587",
+        "EMAIL_USER": "test@example.com",
+        "EMAIL_PASS": "testpass",
+        "EMAIL_TO": "admin@example.com"
+    }

--- a/automation/pyproject.toml
+++ b/automation/pyproject.toml
@@ -1,0 +1,82 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "jleechanorg-pr-automation"
+version = "0.1.2"
+description = "GitHub PR automation system with safety limits and actionable counting"
+authors = [
+    {name = "$USER", email = "jlee@$USER.org"}
+]
+readme = "README.md"
+license = "MIT"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Software Development :: Version Control :: Git",
+]
+keywords = ["github", "automation", "pr", "pull-request", "monitoring"]
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.25.0",
+]
+
+[project.optional-dependencies]
+email = ["keyring>=23.0.0"]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "black>=22.0.0",
+    "ruff>=0.1.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/jleechanorg/your-project.com"
+Repository = "https://github.com/jleechanorg/your-project.com"
+Issues = "https://github.com/jleechanorg/your-project.com/issues"
+
+[project.scripts]
+jleechanorg-pr-monitor = "jleechanorg_pr_automation.jleechanorg_pr_monitor:main"
+automation-safety-cli = "jleechanorg_pr_automation.automation_safety_manager:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["jleechanorg_pr_automation*"]
+
+[tool.setuptools.package-data]
+jleechanorg_pr_automation = ["*.md", "*.txt"]
+
+[tool.black]
+line-length = 120
+target-version = ['py39']
+
+[tool.ruff]
+line-length = 120
+target-version = "py39"
+select = ["E", "F", "W", "I", "N", "UP", "YTT", "ANN", "S", "BLE", "FBT", "B", "A", "COM", "C4", "DTZ", "T10", "EM", "EXE", "FA", "ISC", "ICN", "G", "INP", "PIE", "T20", "PYI", "PT", "Q", "RSE", "RET", "SLF", "SLOT", "SIM", "TID", "TCH", "INT", "ARG", "PTH", "ERA", "PD", "PGH", "PL", "TRY", "FLY", "NPY", "RUF"]
+ignore = ["ANN101", "ANN102", "S101", "PLR0913", "PLR0912", "PLR0915", "COM812", "ISC001"]
+
+[tool.pytest.ini_options]
+testpaths = ["jleechanorg_pr_automation/tests", "tests"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "--cov=.",
+    "--cov-report=term-missing",
+    "--cov-report=html",
+    "--cov-fail-under=20",
+]
+markers = [
+    "comprehensive: Run comprehensive, slower coverage tests",
+    "automation: Critical automation infrastructure tests",
+    "fast: Fast tests for every commit",
+    "smoke: Basic functionality checks",
+]

--- a/automation/pyproject.toml
+++ b/automation/pyproject.toml
@@ -7,7 +7,7 @@ name = "jleechanorg-pr-automation"
 version = "0.1.2"
 description = "GitHub PR automation system with safety limits and actionable counting"
 authors = [
-    {name = "$USER", email = "jlee@$USER.org"}
+    {name = "automation-user", email = "automation@example.com"}
 ]
 readme = "README.md"
 license = "MIT"
@@ -38,9 +38,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/jleechanorg/your-project.com"
-Repository = "https://github.com/jleechanorg/your-project.com"
-Issues = "https://github.com/jleechanorg/your-project.com/issues"
+Homepage = "https://github.com/OWNER/REPO"
+Repository = "https://github.com/OWNER/REPO"
+Issues = "https://github.com/OWNER/REPO/issues"
 
 [project.scripts]
 jleechanorg-pr-monitor = "jleechanorg_pr_automation.jleechanorg_pr_monitor:main"

--- a/automation/requirements.txt
+++ b/automation/requirements.txt
@@ -1,0 +1,4 @@
+# Install the jleechanorg-pr-automation package in editable mode
+# This allows tests to import from jleechanorg_pr_automation.*
+# Use relative path from project root since CI runs pip from root directory
+-e ./automation

--- a/automation/simple_pr_batch.sh
+++ b/automation/simple_pr_batch.sh
@@ -1,0 +1,462 @@
+#!/bin/bash
+
+set -euo pipefail
+IFS=$'\n\t'
+
+# Ensure only one instance runs at a time
+exec 9>/tmp/pr-batch.lock
+if ! flock -n 9; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Another batch instance is running; exiting." | tee -a "/tmp/pr_automation.log"
+    exit 0
+fi
+
+# Simplified PR automation - posts Codex comment instructions to drive follow-up agents
+# Focuses on batch processing, attempt tracking, cooldowns, and notifications
+
+PROCESSED_FILE="/tmp/pr_automation_processed.txt"
+LOG_FILE="/tmp/pr_automation.log"
+ATTEMPT_FILE="/tmp/pr_fix_attempts.txt"
+MAX_BATCH_SIZE=5
+MAX_FIX_ATTEMPTS=3
+
+# Timeout configuration (in seconds)
+COMMENT_TIMEOUT=1200   # Allow Codex comment posting with generous buffer (20 minutes)
+
+# Create files if they don't exist
+touch "$PROCESSED_FILE" "$ATTEMPT_FILE"
+
+# Function to log with timestamp
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# Default Codex instruction (can be overridden by exporting CODEX_COMMENT)
+RAW_ASSISTANT_HANDLE="${ASSISTANT_HANDLE:-$(python3 - <<'PY'
+from automation.codex_config import DEFAULT_ASSISTANT_HANDLE
+print(DEFAULT_ASSISTANT_HANDLE)
+PY
+)}"
+CLEAN_ASSISTANT_HANDLE="${RAW_ASSISTANT_HANDLE#@}"
+ASSISTANT_HANDLE="@${CLEAN_ASSISTANT_HANDLE}"
+CODEX_COMMENT_DEFAULT="$(python3 - "$CLEAN_ASSISTANT_HANDLE" <<'PY'
+import sys
+from automation.codex_config import build_default_comment
+
+print(build_default_comment(sys.argv[1]))
+PY
+)"
+CODEX_COMMENT="${CODEX_COMMENT:-$CODEX_COMMENT_DEFAULT}"
+CODEX_COMMIT_MARKER_PREFIX="$(python3 - <<'PY'
+from automation.codex_config import CODEX_COMMIT_MARKER_PREFIX
+print(CODEX_COMMIT_MARKER_PREFIX)
+PY
+)"
+CODEX_COMMIT_MARKER_SUFFIX="$(python3 - <<'PY'
+from automation.codex_config import CODEX_COMMIT_MARKER_SUFFIX
+print(CODEX_COMMIT_MARKER_SUFFIX)
+PY
+)"
+
+GH_REPO="${GH_REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)}"
+if [ -z "$GH_REPO" ]; then
+    log "❌ Unable to determine GitHub repository context for Codex automation"
+    exit 1
+fi
+
+# Function to send email notification
+send_email_notification() {
+    local pr_number="$1"
+    local issue_type="$2"
+    local details="$3"
+    local attempt_count="$4"
+
+    # Load email configuration if present
+    if [ -f "$HOME/.memory_email_config" ]; then
+        set -a
+        . "$HOME/.memory_email_config"
+        set +a
+    fi
+
+    local subject="PR #$pr_number Automation Failed: $issue_type"
+    local body="PR #$pr_number requires manual intervention after $attempt_count automated fix attempts.
+
+Issue Type: $issue_type
+Details: $details
+
+PR URL: https://github.com/$GH_REPO/pull/$pr_number
+
+Automated fix attempts have been exhausted. Please review and fix manually.
+
+=== Recent Automation Logs ===
+$(tail -20 "$LOG_FILE")
+
+=== Test Failure Details ===
+$(timeout 30 gh pr checks "$pr_number" --repo "$GH_REPO" 2>/dev/null || echo "Could not retrieve test details")
+"
+
+    SUBJECT="$subject" BODY="$body" python3 - <<'PY'
+import os
+import smtplib
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+
+smtp_server = os.environ.get('SMTP_SERVER', 'smtp.gmail.com')
+smtp_port = int(os.environ.get('SMTP_PORT', '587'))
+username = os.environ.get('SMTP_USERNAME')
+password = os.environ.get('SMTP_PASSWORD')
+from_email = os.environ.get('MEMORY_EMAIL_FROM')
+to_email = os.environ.get('MEMORY_EMAIL_TO')
+subject = os.environ.get('SUBJECT', '')
+body = os.environ.get('BODY', '')
+
+if not all([smtp_server, smtp_port, from_email, to_email]):
+    print('Email configuration incomplete - skipping notification')
+    raise SystemExit(0)
+
+msg = MIMEMultipart()
+msg['From'] = from_email
+msg['To'] = to_email
+msg['Subject'] = subject
+msg.attach(MIMEText(body, 'plain'))
+
+try:
+    with smtplib.SMTP(smtp_server, smtp_port, timeout=30) as server:
+        server.starttls()
+        if username and password:
+            server.login(username, password)
+        server.send_message(msg)
+    print('Email sent successfully')
+except Exception as exc:  # pragma: no cover - best effort logging
+    print(f'Email failed: {exc}')
+PY
+}
+
+# Function to count fix attempts for a PR
+get_fix_attempts() {
+    local pr_number="$1"
+    local attempts=$(grep "^$pr_number:" "$ATTEMPT_FILE" 2>/dev/null | cut -d':' -f2)
+    if [ -z "$attempts" ]; then
+        echo "0"
+    else
+        echo "$attempts"
+    fi
+}
+
+# Function to increment fix attempts
+increment_fix_attempts() {
+    local pr_number="$1"
+    local lock_file="${ATTEMPT_FILE}.lock"
+    local new_attempts
+
+    new_attempts=$(
+        flock -x 200 || exit 1
+        local current_attempts=$(grep "^$pr_number:" "$ATTEMPT_FILE" 2>/dev/null | cut -d':' -f2)
+        if [ -z "$current_attempts" ]; then
+            current_attempts=0
+        fi
+        local updated=$((current_attempts + 1))
+        grep -v "^$pr_number:" "$ATTEMPT_FILE" > "${ATTEMPT_FILE}.tmp" 2>/dev/null || true
+        echo "$pr_number:$updated" >> "${ATTEMPT_FILE}.tmp"
+        mv "${ATTEMPT_FILE}.tmp" "$ATTEMPT_FILE"
+        echo "$updated"
+    ) 200>"$lock_file"
+
+    echo "$new_attempts"
+}
+
+# Function to reset fix attempts (on success)
+reset_fix_attempts() {
+    local pr_number="$1"
+    local lock_file="${ATTEMPT_FILE}.lock"
+
+    (
+        flock -x 200
+        if [ -s "$ATTEMPT_FILE" ]; then
+            grep -v "^$pr_number:" "$ATTEMPT_FILE" > "${ATTEMPT_FILE}.tmp" 2>/dev/null || true
+            mv "${ATTEMPT_FILE}.tmp" "$ATTEMPT_FILE"
+        fi
+    ) 200>"$lock_file"
+}
+
+write_processed_timestamp() {
+    local pr_number="$1"
+    local timestamp="$2"
+    local lock_file="${PROCESSED_FILE}.lock"
+
+    (
+        flock -x 201
+        grep -v "^$pr_number:" "$PROCESSED_FILE" > "${PROCESSED_FILE}.tmp" 2>/dev/null || true
+        echo "$pr_number:$timestamp" >> "${PROCESSED_FILE}.tmp"
+        mv "${PROCESSED_FILE}.tmp" "$PROCESSED_FILE"
+    ) 201>"$lock_file"
+}
+
+run_with_timeout() {
+    local duration="$1"
+    shift
+
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$duration" "$@"
+    else
+        log "⚠️ 'timeout' command not found; running without explicit limit for $1"
+        "$@"
+    fi
+}
+
+# Function to handle command execution with timeout and error detection
+execute_with_timeout() {
+    local timeout_duration="$1"
+    shift
+    local pr_number="$1"
+    shift
+    local operation_name="$1"
+    shift
+
+    if [ "$#" -eq 0 ]; then
+        log "❌ No command provided for $operation_name (PR #$pr_number)"
+        return 1
+    fi
+
+    log "⏱️  Executing $operation_name for PR #$pr_number (timeout: ${timeout_duration}s)"
+
+    run_with_timeout "$timeout_duration" "$@"
+    local exit_code=$?
+
+    if [ $exit_code -eq 0 ]; then
+        log "✅ $operation_name succeeded for PR #$pr_number"
+        return 0
+    elif [ $exit_code -eq 124 ]; then
+        log "⏰ $operation_name timed out after ${timeout_duration}s for PR #$pr_number"
+        return 2  # Special return code for timeout
+    else
+        log "❌ $operation_name failed for PR #$pr_number (exit code: $exit_code)"
+        return 1
+    fi
+}
+
+# Function to notify about automation completion
+notify_pr_completion() {
+    local pr_number="$1"
+    local status="$2"  # success, failure, timeout
+    local details="$3"
+
+    case "$status" in
+        "success")
+            log "✅ Automated processing completed successfully for PR #$pr_number"
+            ;;
+        "failure")
+            log "❌ Automated processing failed for PR #$pr_number. Details: $details"
+            ;;
+        "timeout")
+            log "⏰ Automated processing timed out for PR #$pr_number after ${COMMENT_TIMEOUT}s"
+            ;;
+        *)
+            log "📝 Automated processing completed with status: $status for PR #$pr_number"
+            ;;
+    esac
+}
+
+# Codex instruction handling - posts default comment to PR
+post_codex_instruction() {
+    local pr_number="$1"
+
+    log "💬 Requesting Codex instruction comment for PR #$pr_number"
+
+    local pr_state_json
+    local decision="post:"
+
+    if pr_state_json=$(gh pr view "$pr_number" --repo "$GH_REPO" --json headRefOid,comments 2>/dev/null); then
+        decision=$(printf '%s' "$pr_state_json" | python3 automation/check_codex_comment.py "$CODEX_COMMIT_MARKER_PREFIX" "$CODEX_COMMIT_MARKER_SUFFIX" 2>/dev/null || echo "post:")
+    else
+        log "⚠️ Unable to fetch PR state; proceeding with Codex comment"
+    fi
+
+    local action
+    local head_sha
+    if [ -z "$decision" ]; then
+        action="post"
+        head_sha=""
+    else
+        action="${decision%%:*}"
+        head_sha="${decision#*:}"
+    fi
+
+    if [ "$action" = "skip" ]; then
+        if [ -n "$head_sha" ]; then
+            log "♻️ Codex instruction already posted for commit $head_sha on PR #$pr_number; skipping"
+        else
+            log "♻️ Codex instruction already posted for current head on PR #$pr_number; skipping"
+        fi
+        notify_pr_completion "$pr_number" "success" ""
+        return 0
+    fi
+
+    local comment_body="$CODEX_COMMENT"
+    if [ -n "$head_sha" ]; then
+        comment_body=$(printf "%s\n\n%s%s%s" "$CODEX_COMMENT" "$CODEX_COMMIT_MARKER_PREFIX" "$head_sha" "$CODEX_COMMIT_MARKER_SUFFIX")
+    fi
+
+    local tmp_body
+    tmp_body=$(mktemp)
+    printf "%s" "$comment_body" > "$tmp_body"
+
+    execute_with_timeout "$COMMENT_TIMEOUT" "$pr_number" "Codex instruction comment" \
+        gh pr comment "$pr_number" --repo "$GH_REPO" --body-file "$tmp_body"
+    local comment_result=$?
+
+    rm -f "$tmp_body"
+
+    case $comment_result in
+        0)
+            notify_pr_completion "$pr_number" "success" ""
+            ;;
+        2)
+            notify_pr_completion "$pr_number" "timeout" ""
+            ;;
+        *)
+            notify_pr_completion "$pr_number" "failure" "Codex instruction comment failed"
+            ;;
+    esac
+
+    return $comment_result
+}
+
+# Function to post threaded comment replies with AI Cron Responder prefix
+post_threaded_comment() {
+    local pr_number="$1"
+    local message="$2"
+    local in_reply_to="$3"  # Optional: comment ID to reply to
+
+    local prefixed_message="[AI Cron Responder] $message"
+
+    if [ -n "$in_reply_to" ]; then
+        # Reply to specific comment thread
+        execute_with_timeout "$COMMENT_TIMEOUT" "$pr_number" "Codex threaded reply" \
+            gh pr comment "$pr_number" --repo "$GH_REPO" --body "$prefixed_message" --reply-to "$in_reply_to"
+        local reply_result=$?
+        case $reply_result in
+            0)
+                log "💬 Posted threaded reply to PR #$pr_number (reply to: $in_reply_to)"
+                ;;
+            2)
+                log "⏰ Codex threaded reply timed out for PR #$pr_number"
+                return 1
+                ;;
+            *)
+                log "❌ Failed to post threaded reply for PR #$pr_number"
+                return 1
+                ;;
+        esac
+    else
+        # Post general comment
+        execute_with_timeout "$COMMENT_TIMEOUT" "$pr_number" "Codex general reply" \
+            gh pr comment "$pr_number" --repo "$GH_REPO" --body "$prefixed_message"
+        local comment_result=$?
+        case $comment_result in
+            0)
+                log "💬 Posted comment to PR #$pr_number"
+                ;;
+            2)
+                log "⏰ Codex general reply timed out for PR #$pr_number"
+                return 1
+                ;;
+            *)
+                log "❌ Failed to post comment for PR #$pr_number"
+                return 1
+                ;;
+        esac
+    fi
+
+    return 0
+}
+
+# Main processing logic
+log "🚀 Starting simplified PR batch processing with Codex instruction comments"
+
+# Get PRs updated in last 24 hours
+RECENT_PRS=$(gh pr list --repo "$GH_REPO" --state open --limit 20 --json number,updatedAt | \
+    jq -r '.[] | select((.updatedAt | fromdateiso8601) > (now - 86400)) | .number')
+
+if [ -z "$RECENT_PRS" ]; then
+    log "No PRs updated in the last 24 hours"
+    exit 0
+fi
+
+# Process each PR
+PROCESSED_COUNT=0
+CURRENT_TIME=$(date +%s)
+
+for PR in $RECENT_PRS; do
+    # Check processing limits
+    if [ $PROCESSED_COUNT -ge $MAX_BATCH_SIZE ]; then
+        log "Reached batch size limit ($MAX_BATCH_SIZE)"
+        break
+    fi
+
+    # Check if processed recently (4 hour cooldown for successful processing)
+    LAST_PROCESSED=$(grep "^$PR:" "$PROCESSED_FILE" 2>/dev/null | cut -d':' -f2)
+    if [ -n "$LAST_PROCESSED" ]; then
+        TIME_DIFF=$((CURRENT_TIME - LAST_PROCESSED))
+        if [ $TIME_DIFF -lt 14400 ]; then  # 4 hours
+            log "Skipping PR #$PR (processed $(($TIME_DIFF / 60)) minutes ago)"
+            continue
+        fi
+    fi
+
+    # Codex comment automation - instructs Codex by default
+    ATTEMPT_COUNT=$(get_fix_attempts "$PR")
+
+    log "💬 Processing PR #$PR with Codex comment automation (attempt count: $ATTEMPT_COUNT)"
+
+    if [ $ATTEMPT_COUNT -lt $MAX_FIX_ATTEMPTS ]; then
+        # Attempt Codex instruction comment posting
+        NEW_ATTEMPT_COUNT=$(increment_fix_attempts "$PR")
+        log "💬 Codex instruction attempt $NEW_ATTEMPT_COUNT/$MAX_FIX_ATTEMPTS for PR #$PR"
+
+        post_codex_instruction "$PR"
+        result=$?
+
+        if [ $result -eq 0 ]; then
+            # Processing succeeded - mark as completed
+            TIMESTAMP=$(date +%s)
+            write_processed_timestamp "$PR" "$TIMESTAMP"
+            reset_fix_attempts "$PR"
+            log "✅ Successfully posted Codex instruction comment for PR #$PR"
+            PROCESSED_COUNT=$((PROCESSED_COUNT + 1))
+        elif [ $result -eq 2 ]; then
+            # Timeout - don't count as failure, will retry later
+            log "⏰ Codex instruction attempt $NEW_ATTEMPT_COUNT timed out for PR #$PR - will retry next cycle"
+            # Decrement attempt count since timeout shouldn't count as attempt
+            DECREMENTED_COUNT=$((NEW_ATTEMPT_COUNT - 1))
+            # Ensure DECREMENTED_COUNT doesn't go below 0
+            if [ $DECREMENTED_COUNT -lt 0 ]; then
+                DECREMENTED_COUNT=0
+            fi
+            if [ $DECREMENTED_COUNT -gt 0 ]; then
+                grep -v "^$PR:" "$ATTEMPT_FILE" > "${ATTEMPT_FILE}.tmp" 2>/dev/null || true
+                echo "$PR:$DECREMENTED_COUNT" >> "${ATTEMPT_FILE}.tmp"
+                mv "${ATTEMPT_FILE}.tmp" "$ATTEMPT_FILE"
+            else
+                reset_fix_attempts "$PR"
+            fi
+        else
+            log "❌ Codex instruction attempt $NEW_ATTEMPT_COUNT failed for PR #$PR"
+        fi
+    else
+        # Max attempts reached - send email notification
+        log "📧 Max Codex instruction attempts reached for PR #$PR - sending email notification"
+        FAILURE_DETAILS_RAW=$(gh pr checks "$PR" --repo "$GH_REPO" 2>/dev/null | grep -E "(FAILURE|ERROR)" | head -5)
+        FAILURE_DETAILS_FALLBACK="Could not retrieve failure details for PR #$PR. Last attempt may have timed out - check automation logs for timeout vs failure details."
+        if [ -z "$FAILURE_DETAILS_RAW" ]; then
+            FAILURE_DETAILS="$FAILURE_DETAILS_FALLBACK"
+        else
+            FAILURE_DETAILS="$FAILURE_DETAILS_RAW"
+        fi
+        send_email_notification "$PR" "codex_comment_max_attempts" "$FAILURE_DETAILS" "$ATTEMPT_COUNT"
+
+        # Reset attempts to allow future processing
+        reset_fix_attempts "$PR"
+    fi
+done
+
+log "🏁 Simplified PR batch processing complete (processed: $PROCESSED_COUNT)"

--- a/automation/testing_util/mock_gh_cli.py
+++ b/automation/testing_util/mock_gh_cli.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Lightweight mock for the GitHub CLI used by automation smoke tests.
+
+The monitor relies on the `gh` binary to fetch PR metadata and post
+comments. This helper emulates the handful of commands we need so the
+automation can be exercised offline:
+
+* ``gh pr view <number> --repo <repo> --json ...``
+* ``gh pr comment <number> --repo <repo> --body <text>``
+
+It returns deterministic fixture data for three synthetic pull requests:
+
+``#101``  Eligible – no Codex summary comment referencing the head SHA.
+``#102``  Ineligible – includes a Codex summary comment that cites the
+          current head commit (should trigger the pending-commit skip).
+``#103``  Eligible – contains a historic Codex marker for a different SHA.
+
+Usage::
+
+    PATH="/path/to/mock/bin:$PATH" gh ...
+
+where ``/path/to/mock/bin`` contains a copy or symlink of this script
+named ``gh``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Dict, List
+
+PR_FIXTURES: Dict[str, Dict] = {
+    "101": {
+        "title": "Fix eligible automation path",
+        "headRefName": "feature/eligible",
+        "baseRefName": "main",
+        "url": "https://github.com/jleechanorg/your-project.com/pull/101",
+        "author": {"login": "dev-user"},
+        "headRefOid": "abc1234def5678abc1234def5678abc1234def5",
+        "comments": [
+            {
+                "author": {"login": "reviewer"},
+                "body": "Looks good to me!",
+                "createdAt": "2025-01-01T00:00:00Z",
+            }
+        ],
+    },
+    "102": {
+        "title": "Pending Codex automation commit",
+        "headRefName": "feature/pending",
+        "baseRefName": "main",
+        "url": "https://github.com/jleechanorg/your-project.com/pull/102",
+        "author": {"login": "automation-bot"},
+        "headRefOid": "ffeeddbcaa99887766554433221100ffeeddccbb",
+        "comments": [
+            {
+                "author": {"login": "codex-bot"},
+                "body": "Automation summary: Written by Cursor Bugbot for commit ffeeddbc.",
+                "createdAt": "2025-01-02T00:00:00Z",
+            }
+        ],
+    },
+    "103": {
+        "title": "No codex involvement",
+        "headRefName": "feature/manual",
+        "baseRefName": "main",
+        "url": "https://github.com/jleechanorg/your-project.com/pull/103",
+        "author": {"login": "dev-two"},
+        "headRefOid": "1234567890abcdef1234567890abcdef12345678",
+        "comments": [
+            {
+                "author": {"login": "codex-helper"},
+                "body": "Previous run marker: <!-- codex-automation-commit:1234567 -->",
+                "createdAt": "2025-01-03T00:00:00Z",
+            }
+        ],
+    },
+}
+
+
+def _handle_pr_view(args: List[str]) -> int:
+    pr_number = args[0]
+    fixture = PR_FIXTURES.get(pr_number)
+    if not fixture:
+        print("{}", end="")
+        return 0
+
+    if "--json" in args:
+        json_index = args.index("--json")
+        if json_index + 1 < len(args):
+            json_fields = args[json_index + 1]
+            fields = [field.strip() for field in json_fields.split(",")]
+        else:
+            fields = []
+    else:
+        fields = []
+
+    response: Dict[str, object] = {}
+    for field in fields:
+        if field in {"title", "headRefName", "baseRefName", "url", "author", "headRefOid", "comments"}:
+            response[field] = fixture[field]
+        elif field == "statusCheckRollup":
+            response[field] = [{"name": "ci", "state": "SUCCESS"}]
+
+    print(json.dumps(response))
+    return 0
+
+
+def _handle_pr_comment(args: List[str]) -> int:
+    # We only need to simulate success; the automation logs the comment body.
+    print("Comment posted")
+    return 0
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if len(args) < 2 or args[0] != "pr":
+        print("Unsupported command", file=sys.stderr)
+        return 1
+
+    command = args[1]
+    if command == "view" and len(args) >= 3:
+        return _handle_pr_view(args[2:])
+    if command == "comment" and len(args) >= 3:
+        return _handle_pr_comment(args[2:])
+
+    print("Unsupported command", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mcp_common.sh
+++ b/scripts/mcp_common.sh
@@ -40,7 +40,7 @@ if [[ -z "${MCP_BASH_REEXEC_DONE:-}" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
 # Allow callers to preconfigure behaviour while providing sensible defaults.
 TEST_MODE=${TEST_MODE:-false}

--- a/scripts/mcp_common.sh
+++ b/scripts/mcp_common.sh
@@ -40,7 +40,7 @@ if [[ -z "${MCP_BASH_REEXEC_DONE:-}" ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 # Allow callers to preconfigure behaviour while providing sensible defaults.
 TEST_MODE=${TEST_MODE:-false}


### PR DESCRIPTION
**🚨 AUTOMATED EXPORT** with directory exclusions applied per requirements.

## 🎯 Directory Exclusions Applied
This export **excludes** the following project-specific directories:
- ❌ `analysis/` - Project-specific analytics and reporting
- ❌ `claude-bot-commands/` - Project-specific bot implementation
- ❌ `coding_prompts/` - Project-specific AI prompting templates
- ❌ `prototype/` - Project-specific experimental code

## ✅ Export Contents
- **📋 193 Commands**: Complete workflow orchestration system
- **📎 43 Hooks**: Essential Claude Code workflow automation
- **🚀 19 Scripts**: Development environment management (scripts/ directory)
- **🧠 21 Skills**: Reference knowledge exports (.claude/skills/)
- **🤖 Orchestration System**: Core multi-agent task delegation (WIP prototype)
- **📚 Complete Documentation**: Setup guide with adaptation examples

## Manual Installation
From your project root:
```bash
mkdir -p .claude/{commands,hooks,agents,skills}
mkdir -p scripts
cp -R commands/. .claude/commands/
cp -R hooks/. .claude/hooks/
cp -R agents/. .claude/agents/
cp -R skills/. .claude/skills/
# Optional scripts directory
cp -n scripts/* ./scripts/
```

## 🔄 Content Filtering Applied
- **Generic Paths**: mvp_site/ → \$PROJECT_ROOT/
- **Generic Domain**: worldarchitect.ai → your-project.com
- **Generic User**: jleechan → \$USER
- **Generic Commands**: TESTING=true vpython → TESTING=true python

## ⚠️ Reference Export
This is a filtered reference export. Commands may need adaptation for specific environments, but Claude Code excels at helping customize them for any workflow.

---
🤖 **Generated with [Claude Code](https://claude.ai/code)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a full PR automation system (monitor + safety manager) with installers/docs/tests and updates the exporter to include the new `automation/` directory, plus minor path/doc tweaks.
> 
> - **Automation**:
>   - Add `automation/` package implementing cross-org PR monitoring with safety limits, actionable counting, email notifications, and commit-gated Codex comments (`jleechanorg_pr_automation/*`).
>   - Provide CLI entry points, installers (`install_launchd_automation.sh`, `install_jleechanorg_automation.sh`), cron setup, and detailed docs (`AUTOMATION_SAFETY_LIMITS.md`, `JLEECHANORG_AUTOMATION.md`, `automation/README.md`).
>   - Include extensive test suite (matrix tests, error handling, actor matching) and packaging files (`pyproject.toml`, `requirements.txt`).
> - **Exporter** (`.claude/commands/exportcommands.py`):
>   - Export `automation/` directory, track `automation_count`, map to repo root, and include in export summary.
> - **Scripts**:
>   - Fix repo root resolution in `.claude/scripts/mcp_common.sh`.
> - **Docs/Examples**:
>   - Update `README.md` version history; normalize paths in `pair-examples.md` to `$PROJECT_ROOT/` and generic bucket name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c743e3de1fc50ab54f58841be0c3d4a03bb0a026. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added a comprehensive PR automation system for cross-organization management with worktree isolation and safety controls
- Implemented rate limiting and manual approval workflows with email notifications
- Integrated Codex automation support for automated PR processing and commenting

## Documentation

- Added detailed automation system guides, safety limits documentation, and setup instructions
- Created installation scripts for macOS integration

## Tests

- Added extensive test coverage for PR filtering, safety limits, and automation workflows

## Chores

- Added Python package configuration and requirements files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->