### PR TITLE
Apply pull request changes

### DIFF
--- a/automation/jleechanorg_pr_automation/orchestrated_pr_runner.py
+++ b/automation/jleechanorg_pr_automation/orchestrated_pr_runner.py
@@ -161,13 +161,14 @@ def ensure_base_clone(repo_full: str) -> Path:
     if not re.match(r"^[\w.-]+/[\w.-]+$", repo_full):
         raise ValueError(f"Invalid repository format: {repo_full}")
 
+    github_host = os.environ.get('GH_HOST', 'github.com')
     repo_name = repo_full.split("/")[-1]
     base_dir = BASE_CLONE_ROOT / repo_name
     BASE_CLONE_ROOT.mkdir(parents=True, exist_ok=True)
     if not base_dir.exists():
         log(f"Cloning base repo for {repo_full} into {base_dir}")
         run_cmd(
-            ["git", "clone", f"https://github.com/{repo_full}.git", str(base_dir)],
+            ["git", "clone", f"https://{github_host}/{repo_full}.git", str(base_dir)],
             timeout=CLONE_TIMEOUT,
         )
     else:
@@ -182,7 +183,7 @@ def ensure_base_clone(repo_full: str) -> Path:
             )
             shutil.rmtree(base_dir, ignore_errors=True)
             run_cmd(
-                ["git", "clone", f"https://github.com/{repo_full}.git", str(base_dir)],
+                ["git", "clone", f"https://{github_host}/{repo_full}.git", str(base_dir)],
                 timeout=CLONE_TIMEOUT,
             )
     # Reset base clone to main to ensure clean worktrees

--- a/automation/orchestrated_pr_runner.py
+++ b/automation/orchestrated_pr_runner.py
@@ -161,13 +161,14 @@ def ensure_base_clone(repo_full: str) -> Path:
     if not re.match(r"^[\w.-]+/[\w.-]+$", repo_full):
         raise ValueError(f"Invalid repository format: {repo_full}")
 
+    github_host = os.environ.get('GH_HOST', 'github.com')
     repo_name = repo_full.split("/")[-1]
     base_dir = BASE_CLONE_ROOT / repo_name
     BASE_CLONE_ROOT.mkdir(parents=True, exist_ok=True)
     if not base_dir.exists():
         log(f"Cloning base repo for {repo_full} into {base_dir}")
         run_cmd(
-            ["git", "clone", f"https://github.com/{repo_full}.git", str(base_dir)],
+            ["git", "clone", f"https://{github_host}/{repo_full}.git", str(base_dir)],
             timeout=CLONE_TIMEOUT,
         )
     else:


### PR DESCRIPTION
Apply changes from jleechanorg/worldarchitect.ai#3398:
- Replace hardcoded 'github.com' with os.environ.get('GH_HOST', 'github.com')
- Allows users to set GH_HOST environment variable for enterprise instances
- Maintains backward compatibility by defaulting to github.com

Affected files:
- automation/orchestrated_pr_runner.py (line 170)
- automation/jleechanorg_pr_automation/orchestrated_pr_runner.py (lines 170, 185)

This enables workflows to operate with custom or enterprise GitHub instances in addition to the default github.com.

Ref: https://github.com/jleechanorg/worldarchitect.ai/pull/3398

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for custom/enterprise GitHub hosts.
> 
> - Replace hardcoded `github.com` with `os.environ.get('GH_HOST', 'github.com')` for `git clone` in `ensure_base_clone` within `automation/orchestrated_pr_runner.py` and `automation/jleechanorg_pr_automation/orchestrated_pr_runner.py`
> - Default behavior remains unchanged when `GH_HOST` is not set
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit faf66d50c3cae908f29dbc5c85302038d7fc5107. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable Git host via GH_HOST environment variable, enabling users to specify custom Git servers for repository cloning operations instead of defaulting to github.com.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->