### PR TITLE
Claude Commands Export 2026-02-04: Directory Exclusions Applied

### DIFF
--- a/.claude/commands/second_opinion.md
+++ b/.claude/commands/second_opinion.md
@@ -114,11 +114,11 @@ if [ ! -f "$HOME/.claude/scripts/auth-cli.mjs" ]; then
   exit 1
 fi
 
-# CRITICAL: Use AI Universe Firebase credentials (not worldarchitecture-ai)
-export FIREBASE_PROJECT_ID="${AI_UNIVERSE_FIREBASE_PROJECT_ID:-ai-universe-b3551}"
-export FIREBASE_AUTH_DOMAIN="${AI_UNIVERSE_FIREBASE_AUTH_DOMAIN:-ai-universe-b3551.firebaseapp.com}"
+# CRITICAL: Use AI Universe Firebase credentials with VITE_ prefix (required by auth-cli.mjs)
+export VITE_AI_UNIVERSE_FIREBASE_PROJECT_ID="${VITE_AI_UNIVERSE_FIREBASE_PROJECT_ID:-ai-universe-b3551}"
+export VITE_AI_UNIVERSE_FIREBASE_AUTH_DOMAIN="${VITE_AI_UNIVERSE_FIREBASE_AUTH_DOMAIN:-ai-universe-b3551.firebaseapp.com}"
 # API key - hardcoded default for AI Universe shared service (safe to expose per Firebase security model)
-export FIREBASE_API_KEY="${AI_UNIVERSE_FIREBASE_API_KEY:-AIzaSyDWT4aEG2UoKEtTxozniGC6uPZi1fgjtG8}"
+export VITE_AI_UNIVERSE_FIREBASE_API_KEY="${VITE_AI_UNIVERSE_FIREBASE_API_KEY:-AIzaSyDWT4aEG2UoKEtTxozniGC6uPZi1fgjtG8}"
 
 # Get token (auto-refreshes if expired using refresh token)
 # This is silent - only prompts for login if refresh token is invalid/missing
@@ -127,9 +127,9 @@ TOKEN=$(node ~/.claude/scripts/auth-cli.mjs token)
 # If this fails, user needs to authenticate with AI Universe credentials
 if [ $? -ne 0 ]; then
   echo "❌ Authentication failed. Please run:"
-  echo "   FIREBASE_PROJECT_ID=ai-universe-b3551 \\" 
-  echo "   FIREBASE_AUTH_DOMAIN=ai-universe-b3551.firebaseapp.com \\" 
-  echo "   FIREBASE_API_KEY=AIzaSyDWT4aEG2UoKEtTxozniGC6uPZi1fgjtG8 \\" 
+  echo "   VITE_AI_UNIVERSE_FIREBASE_PROJECT_ID=ai-universe-b3551 \\"
+  echo "   VITE_AI_UNIVERSE_FIREBASE_AUTH_DOMAIN=ai-universe-b3551.firebaseapp.com \\"
+  echo "   VITE_AI_UNIVERSE_FIREBASE_API_KEY=AIzaSyDWT4aEG2UoKEtTxozniGC6uPZi1fgjtG8 \\"
   echo "   node ~/.claude/scripts/auth-cli.mjs login"
   exit 1
 fi


### PR DESCRIPTION
**🚨 AUTOMATED EXPORT** with directory exclusions applied per requirements.

## 🎯 Directory Exclusions Applied
This export **excludes** the following project-specific directories:
- ❌ `analysis/` - Project-specific analytics and reporting
- ❌ `claude-bot-commands/` - Project-specific bot implementation
- ❌ `coding_prompts/` - Project-specific AI prompting templates
- ❌ `prototype/` - Project-specific experimental code

## ✅ Export Contents
- **📋 207 Commands**: Complete workflow orchestration system
- **📎 46 Hooks**: Essential Claude Code workflow automation
- **🚀 19 Scripts**: Development environment management (scripts/ directory)
- **🧠 54 Skills**: Reference knowledge exports (.claude/skills/)
- **⚙️  17 Workflows**: GitHub Actions examples (REQUIRE INTEGRATION)
- **🤖 Orchestration System**: Core multi-agent task delegation (WIP prototype)
- **📚 Complete Documentation**: Setup guide with adaptation examples

## Manual Installation
From your project root:
```bash
mkdir -p .claude/{commands,hooks,agents,skills}
mkdir -p scripts
cp -R commands/. .claude/commands/
cp -R hooks/. .claude/hooks/
cp -R agents/. .claude/agents/
cp -R skills/. .claude/skills/
# Optional scripts directory
cp -n scripts/* ./scripts/
```

## 🔄 Content Filtering Applied
- **Generic Paths**: mvp_site/ → \$PROJECT_ROOT/
- **Generic Domain**: worldarchitect.ai → your-project.com
- **Generic User**: jleechan → \$USER
- **Generic Commands**: TESTING=true vpython → TESTING=true python

## ⚠️ Reference Export
This is a filtered reference export. Commands may need adaptation for specific environments, but Claude Code excels at helping customize them for any workflow.

---
🤖 **Generated with [Claude Code](https://claude.ai/code)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update adjusting environment variable names; no runtime code paths or security logic are modified.
> 
> **Overview**
> Updates `/second_opinion` command documentation to use `VITE_AI_UNIVERSE_FIREBASE_*` environment variables (instead of `FIREBASE_*`) for `auth-cli.mjs` token retrieval, including the failure/re-auth instructions.
> 
> No application logic changes; this is a documentation-only correction to align the described auth setup with the CLI’s expected env var names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09e7d5e160a72a3fd9948f587d4aefd4d9901b65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firebase environment variable configuration naming scheme to ensure proper credentials handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>09e7d5e</u></sup><!-- /BUGBOT_STATUS -->