### PR TITLE
Claude Commands Export 2026-02-11: Directory Exclusions Applied

### DIFF
--- a/.claude/commands/_copilot_modules/commentfetch.py
+++ b/.claude/commands/_copilot_modules/commentfetch.py
@@ -387,6 +387,31 @@ class CommentFetch(CopilotCommandBase):
             if str(other_comment.get("in_reply_to_id", "")) == comment_id:
                 return True
 
+        # Consolidated summary mode: a single [AI responder] issue comment can address inline comments
+        # without creating a threaded in_reply_to. Detect those by reference patterns.
+        comment_created_at = str(comment.get("created_at", ""))
+        for other_comment in all_comments:
+            other_body = str(other_comment.get("body", ""))
+            other_author = other_comment.get("author", "")
+
+            # Only treat AI responder comments created after the original as replies.
+            if not self._is_ai_responder_comment(other_body, other_author):
+                continue
+            if str(other_comment.get("created_at", "")) <= comment_created_at:
+                continue
+
+            other_body_lower = other_body.lower()
+            if (
+                f"comment #{comment_id}" in other_body_lower
+                or f"#{comment_id}" in other_body_lower
+                or f"discussion_r{comment_id}" in other_body_lower
+            ):
+                return True
+
+            # Fallback: content/author similarity check.
+            if self._appears_to_be_reply_to(other_comment, comment):
+                return True
+
         return False
 
     def _check_already_replied_general(self, comment: Dict[str, Any], all_comments: List[Dict[str, Any]] = None) -> bool:
@@ -530,11 +555,6 @@ class CommentFetch(CopilotCommandBase):
             line = line.strip()
             if len(line) > 10 and line in reply_body:
                 return True
-
-        # Check for author references
-        original_author = original_comment.get("author", "")
-        if original_author and f"@{original_author}" in reply_body:
-            return True
 
         return False
 

--- a/.claude/commands/exportcommands.py
+++ b/.claude/commands/exportcommands.py
@@ -506,6 +506,8 @@ class ClaudeCommandsExporter:
             "run_lint.sh",
             # CI/CD and infrastructure
             "setup-github-runner.sh",
+            "setup-github-runner-redundant.sh",
+            "setup-runner-with-drift.sh",
             "setup_email.sh",
             # Development environment
             "create_snapshot.sh",
@@ -518,6 +520,12 @@ class ClaudeCommandsExporter:
 
         # Secondo command scripts (multi-model AI feedback system)
         secondo_scripts = ["auth-cli.mjs", "secondo-cli.sh", "test_secondo_pr.sh"]
+
+        # GitHub runner setup scripts (from scripts/self-hosted/ subdirectory)
+        runner_setup_scripts = [
+            "self-hosted/setup-runner-with-drift.sh",
+            "self-hosted/setup-github-runner-redundant.sh",
+        ]
 
         # Get scripts referenced in settings.json
         settings_scripts = self._get_scripts_from_settings()
@@ -560,6 +568,21 @@ class ClaudeCommandsExporter:
                 self.scripts_count += 1
             else:
                 print(f"   ⚠️  Warning: Secondo script not found: scripts/{script_name}")
+
+        # Export runner setup scripts from scripts/ subdirectory
+        for script_name in runner_setup_scripts:
+            script_path = os.path.join(scripts_subdir, script_name)
+            if os.path.exists(script_path):
+                target_path = os.path.join(target_dir, script_name)
+                # Create subdirectory if needed (e.g., self-hosted/)
+                os.makedirs(os.path.dirname(target_path), exist_ok=True)
+                shutil.copy2(script_path, target_path)
+                self._apply_content_filtering(target_path)
+
+                print(f"   • scripts/{script_name} (runner setup)")
+                self.scripts_count += 1
+            else:
+                print(f"   ⚠️  Warning: Runner setup script not found: scripts/{script_name}")
 
         # Export scripts referenced in settings.json from scripts/ subdirectory
         for script_name in settings_scripts:

--- a/.claude/skills/modal-agent-pattern.md
+++ b/.claude/skills/modal-agent-pattern.md
@@ -1,0 +1,457 @@
+# Modal Agent Pattern - Strict Character Creation & Level-Up
+
+**Purpose:** Design specification for "modal" agents that cannot be exited until the user explicitly chooses to exit. This prevents accidental escapes from character creation and level-up flows.
+
+## Problem Statement
+
+### Current Behavior (Problematic)
+1. **Character Creation can be bypassed**: Users can start a campaign and immediately begin the story without creating a character
+2. **Classifier interference**: The intent classifier can route away from CharacterCreationAgent to other agents (dialog, combat, etc.) based on user input
+3. **No explicit exit mechanism**: No forced "Exit Character Creation" choice that must be selected
+4. **Level-up escapes**: Users can exit level-up flows without completing ability score improvements, feat selection, or spell choices
+
+### Root Cause
+- `get_agent_for_input()` routing logic allows semantic classification to override character creation/level-up state
+- Priority 5 (semantic classifier) can route to Dialog, Combat, Rewards agents EVEN when Priority 4 (CharacterCreationAgent state check) should be active
+- No enforcement of completion choices in the LLM prompt
+
+## Solution: Modal Agent Pattern
+
+### Core Principles
+
+**1. MODAL AGENTS**
+Agents that implement the modal pattern:
+- **CharacterCreationAgent** (for new character creation AND level-ups)
+- **LevelUpAgent** (new dedicated agent for level-up flows)
+
+**2. MODAL CONSTRAINTS**
+When a modal agent is active:
+- User CANNOT leave until they explicitly select an "Exit" choice
+- Semantic classifier is DISABLED (bypassed entirely)
+- Only two agents can be accessed:
+  - The modal agent itself (CharacterCreationAgent or LevelUpAgent)
+  - GodModeAgent (always accessible via "GOD MODE:" prefix)
+
+**3. EXIT MECHANISM**
+Two ways to exit modal agents:
+- **LLM-generated choice**: Modal agent MUST include "Exit Character Creation" / "Exit Level-Up" as a choice in `planning_block.choices`
+- **Python-side injection**: If LLM forgets to include exit choice, Python backend injects it automatically
+
+**4. ROUTING PRIORITY OVERRIDE**
+When modal agent is active (based on game state):
+- Priority 1: GodModeAgent (unchanged)
+- **Priority 2: MODAL AGENT CHECK (NEW - BLOCKS ALL OTHER ROUTING)**
+  - If `character_creation_in_progress == true`, ONLY route to CharacterCreationAgent or GodModeAgent
+  - If `level_up_in_progress == true`, ONLY route to LevelUpAgent or GodModeAgent
+- Priority 3+: All other routing (SKIPPED during modal flows)
+
+## Implementation Design
+
+### 1. State Flags
+
+**Character Creation Modal State:**
+```json
+"custom_campaign_state": {
+  "character_creation_in_progress": true,  // MODAL LOCK - prevents exit
+  "character_creation_stage": "mechanics", // Current stage
+  "character_creation_completed": false    // Final completion flag
+}
+```
+
+**Level-Up Modal State:**
+```json
+"custom_campaign_state": {
+  "level_up_in_progress": true,           // MODAL LOCK - prevents exit
+  "level_up_stage": "asi_selection",      // Current stage
+  "level_up_from_level": 3,               // Level before level-up
+  "level_up_to_level": 4                  // Target level
+}
+```
+
+### 2. Agent Routing Logic (`get_agent_for_input`)
+
+**NEW Priority 2: Modal Agent Lock**
+
+```python
+def get_agent_for_input(
+    user_input: str,
+    game_state: GameState | None = None,
+    mode: str | None = None,
+    last_ai_response: str | None = None,
+) -> tuple[BaseAgent, dict[str, Any]]:
+    """
+    Priority:
+    1. GodModeAgent (Manual override)
+    2. MODAL AGENT LOCK (NEW - CharacterCreation/LevelUp active)
+    3. Character Creation Completion Override
+    4. CampaignUpgradeAgent (State-based)
+    5. Semantic Intent Classification
+    6. API Explicit Mode
+    7. StoryModeAgent (Default)
+    """
+
+    # 1. God Mode (always accessible)
+    if GodModeAgent.matches_input(user_input, mode):
+        return GodModeAgent(game_state), {...}
+
+    # 2. MODAL AGENT LOCK (NEW)
+    # This check MUST come before ALL other routing (except God Mode)
+    if game_state is not None:
+        custom_state = get_custom_state(game_state)
+
+        # Check for modal agent lock flags
+        if custom_state.get("character_creation_in_progress", False):
+            logging_util.info("🔒 MODAL_LOCK: CharacterCreationAgent locked - ignoring classifier")
+            return CharacterCreationAgent(game_state), {
+                "intent": constants.MODE_CHARACTER_CREATION,
+                "classifier_source": "modal_lock",
+                "confidence": 1.0,
+                "routing_priority": "2_modal_char_creation"
+            }
+
+        if custom_state.get("level_up_in_progress", False):
+            logging_util.info("🔒 MODAL_LOCK: LevelUpAgent locked - ignoring classifier")
+            return LevelUpAgent(game_state), {
+                "intent": constants.MODE_LEVEL_UP,
+                "classifier_source": "modal_lock",
+                "confidence": 1.0,
+                "routing_priority": "2_modal_level_up"
+            }
+
+    # 3. Character Creation Completion (check if user explicitly exited)
+    # ... existing completion logic ...
+
+    # 4-7. All other routing continues as normal
+    # ... existing routing logic ...
+```
+
+### 3. LLM Prompt Instructions
+
+**Updated `character_creation_instruction.md`:**
+
+Add new section after "Core Principle":
+
+```markdown
+## CRITICAL: Modal Agent Constraints
+
+**YOU ARE IN A MODAL DIALOG - USER CANNOT LEAVE WITHOUT EXPLICIT EXIT**
+
+While character creation is in progress:
+1. **CLASSIFIER IS DISABLED**: User input will NOT be routed to other agents
+2. **ONLY TWO AGENTS ACCESSIBLE**:
+   - CharacterCreationAgent (you)
+   - GodModeAgent (via "GOD MODE:" prefix only)
+3. **REQUIRED EXIT CHOICE**: You MUST provide an explicit exit choice in EVERY response:
+   - "Exit Character Creation" (complete and return to story)
+   - OR "Continue Creating Character" (stay in this mode)
+
+**MANDATORY CHOICE FORMAT:**
+```json
+"planning_block": {
+  "choices": {
+    "option_1": {
+      "text": "Finish Character Creation",
+      "description": "Complete character and start the adventure"
+    },
+    "option_2": {
+      "text": "Continue Editing",
+      "description": "Make more changes to the character"
+    }
+  }
+}
+```
+
+**If you forget to include the exit choice, the Python backend will inject it automatically.**
+
+### Why This Matters
+- Users cannot accidentally escape character creation by saying things like "let's start the adventure" before character is ready
+- Semantic classifier cannot route dialog-like queries ("tell me about my character") to DialogAgent
+- Combat-like queries ("what weapons do I have?") stay in character creation context
+- Level-up flows cannot be interrupted mid-ASI selection
+```
+
+**New dedicated prompt: `level_up_instruction.md`:**
+
+```markdown
+# Level-Up Mode - Strict Modal Flow
+
+**Purpose:** Process level-ups with full D&D 5e rule compliance. User CANNOT leave until level-up is complete.
+
+## CRITICAL: Modal Agent Constraints
+
+**YOU ARE IN A MODAL DIALOG - USER CANNOT LEAVE WITHOUT EXPLICIT EXIT**
+
+[Same modal constraints as character creation]
+
+## Level-Up Flow
+
+### Step 1: Announce Level-Up
+Present level increase, XP totals, and what will be gained.
+
+### Step 2: Hit Points
+- Roll hit die OR take average
+- Add Constitution modifier
+- Update hp_max
+
+### Step 3: Class Features
+Present new features gained at this level.
+
+### Step 4: Ability Score Improvement (ASI) or Feat
+**MODAL CHECKPOINT**: User MUST make a choice:
+- Increase ability scores (+2 to one, or +1 to two)
+- Select a feat
+
+**REQUIRED CHOICES:**
+```json
+"planning_block": {
+  "choices": {
+    "option_1": {"text": "Increase Ability Scores", "description": "..."},
+    "option_2": {"text": "Choose a Feat", "description": "..."},
+    "option_3": {"text": "Exit Level-Up", "description": "Complete level-up and return to story"}
+  }
+}
+```
+
+### Step 5: Spellcasting (if applicable)
+Process new spell slots, spells known, cantrips.
+
+### Step 6: Completion
+Once all choices made, present summary and REQUIRE exit choice:
+```json
+"planning_block": {
+  "choices": {
+    "option_1": {"text": "Complete Level-Up", "description": "Finish and return to adventure"},
+    "option_2": {"text": "Review Changes", "description": "Double-check selections"}
+  }
+}
+```
+```
+
+### 4. Python-Side Exit Choice Injection
+
+**New utility: `$PROJECT_ROOT/modal_agent_utils.py`**
+
+```python
+"""
+Modal Agent Utilities - Exit Choice Injection
+
+This module ensures modal agents (CharacterCreation, LevelUp) always
+provide explicit exit choices, even if the LLM forgets to include them.
+"""
+
+from mvp_site import logging_util
+
+EXIT_CHOICE_CHAR_CREATION = {
+    "text": "Exit Character Creation",
+    "description": "Complete character creation and start the adventure"
+}
+
+EXIT_CHOICE_LEVEL_UP = {
+    "text": "Exit Level-Up",
+    "description": "Complete level-up and return to the story"
+}
+
+def inject_exit_choice_if_missing(
+    response_dict: dict,
+    agent_type: str  # "character_creation" or "level_up"
+) -> dict:
+    """
+    Inject exit choice into LLM response if missing.
+
+    Args:
+        response_dict: LLM response dictionary with planning_block
+        agent_type: Type of modal agent ("character_creation" or "level_up")
+
+    Returns:
+        Modified response_dict with exit choice guaranteed
+    """
+    # Get planning_block
+    planning_block = response_dict.get("planning_block", {})
+    choices = planning_block.get("choices", {})
+
+    # Determine which exit choice to use
+    exit_choice = (
+        EXIT_CHOICE_CHAR_CREATION
+        if agent_type == "character_creation"
+        else EXIT_CHOICE_LEVEL_UP
+    )
+
+    # Check if any choice matches exit intent
+    has_exit_choice = False
+    exit_keywords = ["exit", "finish", "complete", "done", "return"]
+
+    for choice_key, choice_data in choices.items():
+        if isinstance(choice_data, dict):
+            text = choice_data.get("text", "").lower()
+            if any(keyword in text for keyword in exit_keywords):
+                has_exit_choice = True
+                break
+
+    # Inject exit choice if missing
+    if not has_exit_choice:
+        logging_util.warning(
+            f"🔒 MODAL_AGENT_INJECTION: LLM forgot exit choice for {agent_type}, "
+            f"injecting automatically"
+        )
+
+        # Find next available option number
+        existing_keys = [k for k in choices.keys() if k.startswith("option_")]
+        if existing_keys:
+            max_num = max(int(k.split("_")[1]) for k in existing_keys)
+            new_key = f"option_{max_num + 1}"
+        else:
+            new_key = "option_1"
+
+        # Inject exit choice
+        choices[new_key] = exit_choice
+        planning_block["choices"] = choices
+        response_dict["planning_block"] = planning_block
+
+    return response_dict
+```
+
+**Integration point in `world_logic.py` or response handler:**
+
+```python
+# After LLM response parsing, before returning to user
+if current_agent_type == "character_creation":
+    response_dict = inject_exit_choice_if_missing(
+        response_dict,
+        "character_creation"
+    )
+elif current_agent_type == "level_up":
+    response_dict = inject_exit_choice_if_missing(
+        response_dict,
+        "level_up"
+    )
+```
+
+### 5. Frontend Changes (Optional Enhancement)
+
+**UI-level enforcement:**
+- When `character_creation_in_progress == true`, disable "Send" button unless:
+  - Input matches exit choice text, OR
+  - Input is "GOD MODE:" prefix
+- Show modal dialog backdrop to indicate locked state
+- Display "You are in Character Creation Mode" banner
+
+## Edge Cases & Handling
+
+### Case 1: User tries to escape with dialog-like input
+**Input:** "I want to talk to the bartender"
+**Current behavior:** Classifier routes to DialogAgent
+**New behavior:** Modal lock returns CharacterCreationAgent, responds with:
+```
+[CHARACTER CREATION MODE - Active]
+
+You're currently creating your character. Before you can interact with the world,
+we need to finish building your character.
+
+Would you like to:
+1. Continue Character Creation
+2. Exit Character Creation (if character is ready)
+```
+
+### Case 2: User tries combat-like action
+**Input:** "I attack the goblin"
+**Current behavior:** Classifier routes to CombatAgent
+**New behavior:** Modal lock returns CharacterCreationAgent, responds with:
+```
+[CHARACTER CREATION MODE - Active]
+
+You're eager to jump into action! But first, let's finish creating your character
+so you have the stats and abilities you'll need in combat.
+
+Current Progress: [stage summary]
+
+Ready to exit character creation?
+1. Finish Character Creation (if ready)
+2. Continue Building Character
+```
+
+### Case 3: LLM forgets exit choice
+**LLM response:** Only provides character customization choices, no exit option
+**Python injection:** Automatically adds "Exit Character Creation" as final choice
+**User sees:** All LLM choices + injected exit choice
+
+### Case 4: Level-up with multiple stages
+**Scenario:** Level 4 → Level 5 requires ASI + new spell selection
+**Behavior:**
+- Turn 1: ASI selection (choices: +2 to one, +1 to two, choose feat, exit)
+- Turn 2: Spell selection (choices: spell A, spell B, spell C, exit)
+- Turn 3: Review summary (choices: confirm, review again, exit)
+- Modal lock persists until user selects exit choice
+
+### Case 5: God Mode Override
+**Input:** "GOD MODE: skip character creation and start at level 5"
+**Behavior:** GodModeAgent takes over (Priority 1), can bypass modal lock
+**Justification:** God Mode is admin/debugging tool and should have full override
+
+## Benefits
+
+1. **Prevents accidental bypasses**: Campaign ARrfJ39LhNEi5rcGq1c7 issue would be impossible
+2. **Clear UX**: Users know they're in a modal flow and how to exit
+3. **Classifier isolation**: Semantic classifier doesn't interfere with creation flows
+4. **LLM safety net**: Python injection ensures exit choice always exists
+5. **Consistent pattern**: Same approach for character creation AND level-ups
+
+## Implementation Phases
+
+### Phase 1: Core Modal Lock (Minimum Viable)
+- [ ] Add `character_creation_in_progress` check at Priority 2 in `get_agent_for_input`
+- [ ] Update `character_creation_instruction.md` with modal constraints
+- [ ] Test that classifier is bypassed during character creation
+
+### Phase 2: Exit Choice Injection
+- [ ] Create `modal_agent_utils.py` with `inject_exit_choice_if_missing`
+- [ ] Integrate injection into response handler
+- [ ] Test LLM responses with/without exit choices
+
+### Phase 3: Level-Up Agent
+- [ ] Create dedicated `LevelUpAgent` class
+- [ ] Add `level_up_instruction.md` prompt
+- [ ] Implement `level_up_in_progress` modal lock
+- [ ] Update routing logic for level-up flows
+
+### Phase 4: Enhanced UX (Optional)
+- [ ] Frontend modal dialog backdrop
+- [ ] "Character Creation Mode" banner
+- [ ] Disable irrelevant UI actions during modal flow
+
+## Testing Strategy
+
+### Unit Tests
+- `test_modal_agent_routing.py`: Verify Priority 2 modal lock
+- `test_exit_choice_injection.py`: Verify Python injection logic
+- `test_character_creation_modal.py`: End-to-end character creation with modal lock
+
+### Integration Tests
+- Create campaign → Verify cannot escape char creation with dialog input
+- Level-up flow → Verify cannot escape mid-ASI selection
+- God Mode override → Verify can bypass modal lock
+
+### Edge Case Tests
+- LLM forgets exit choice → Verify injection works
+- Multiple level-up stages → Verify modal lock persists
+- Campaign with pre-populated character → Verify review mode works
+
+## Related Files
+
+**Agent routing:**
+- `/Users/$USER/projects/worktree_worker8/$PROJECT_ROOT/agents.py` (lines 2552-3164)
+
+**Character creation:**
+- `/Users/$USER/projects/worktree_worker8/$PROJECT_ROOT/agents.py` (lines 830-1151, CharacterCreationAgent)
+- `/Users/$USER/projects/worktree_worker8/$PROJECT_ROOT/prompts/character_creation_instruction.md`
+
+**Intent classifier:**
+- `/Users/$USER/projects/worktree_worker8/$PROJECT_ROOT/intent_classifier.py`
+
+**State management:**
+- `/Users/$USER/projects/worktree_worker8/$PROJECT_ROOT/game_state.py`
+
+## References
+
+- CLAUDE.md: LLM decides, server executes (lines 10-30)
+- Intent classifier architecture (intent_classifier.py lines 1-176)
+- Agent routing priority (agents.py lines 2552-2585)

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ See [INSTALL.md](INSTALL.md) for detailed setup, troubleshooting, and platform-s
 
 **46 Hooks** for Claude Code automation and workflow optimization
 
-**19 Scripts** for development tools including git workflow, code analysis, testing, and CI/CD
+**21 Scripts** for development tools including git workflow, code analysis, testing, and CI/CD
 
-**56 Skills** providing shared knowledge references and capabilities
+**57 Skills** providing shared knowledge references and capabilities
 
 ## 🔍 Key Commands
 
@@ -221,8 +221,8 @@ See bottom of README for complete version history.
 **Export Statistics**:
 - **209 Commands**: Complete workflow orchestration system
 - **46 Hooks**: Claude Code automation and workflow hooks
-- **19 Scripts**: Development and automation tools
-- **56 Skills**: Shared knowledge references
+- **21 Scripts**: Development and automation tools
+- **57 Skills**: Shared knowledge references
 
 **Recent Changes**:
 - Script allowlist expansion (12 additional development scripts)

--- a/automation/jleechanorg_pr_automation/jleechanorg_pr_monitor.py
+++ b/automation/jleechanorg_pr_automation/jleechanorg_pr_monitor.py
@@ -39,6 +39,7 @@ from orchestration.cli_validation import (
 )
 from orchestration.task_dispatcher import CLI_PROFILES, CURSOR_MODEL, GEMINI_MODEL, TaskDispatcher
 
+from . import __version__
 from .automation_safety_manager import AutomationSafetyManager
 from .automation_utils import AutomationUtils
 from .codex_config import (
@@ -4201,6 +4202,11 @@ def main():
     """CLI interface for jleechanorg PR monitor"""
 
     parser = argparse.ArgumentParser(description="jleechanorg PR Monitor")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"%(prog)s {__version__}",
+    )
     parser.add_argument(
         "--no-act",
         action="store_true",


### PR DESCRIPTION
**🚨 AUTOMATED EXPORT** with directory exclusions applied per requirements.

## 🎯 Directory Exclusions Applied
This export **excludes** the following project-specific directories:
- ❌ `analysis/` - Project-specific analytics and reporting
- ❌ `claude-bot-commands/` - Project-specific bot implementation
- ❌ `coding_prompts/` - Project-specific AI prompting templates
- ❌ `prototype/` - Project-specific experimental code

## ✅ Export Contents
- **📋 209 Commands**: Complete workflow orchestration system
- **📎 46 Hooks**: Essential Claude Code workflow automation
- **🚀 21 Scripts**: Development environment management (scripts/ directory)
- **🧠 57 Skills**: Reference knowledge exports (.claude/skills/)
- **⚙️  18 Workflows**: GitHub Actions examples (REQUIRE INTEGRATION)
- **🤖 Orchestration System**: Core multi-agent task delegation (WIP prototype)
- **📚 Complete Documentation**: Setup guide with adaptation examples

## Manual Installation
From your project root:
```bash
mkdir -p .claude/{commands,hooks,agents,skills}
mkdir -p scripts
cp -R commands/. .claude/commands/
cp -R hooks/. .claude/hooks/
cp -R agents/. .claude/agents/
cp -R skills/. .claude/skills/
# Optional scripts directory
cp -n scripts/* ./scripts/
```

## 🔄 Content Filtering Applied
- **Generic Paths**: mvp_site/ → \$PROJECT_ROOT/
- **Generic Domain**: worldarchitect.ai → your-project.com
- **Generic User**: jleechan → \$USER
- **Generic Commands**: TESTING=true vpython → TESTING=true python

## ⚠️ Reference Export
This is a filtered reference export. Commands may need adaptation for specific environments, but Claude Code excels at helping customize them for any workflow.

---
🤖 **Generated with [Claude Code](https://claude.ai/code)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how PR comment automation decides an inline comment has already been addressed, which could suppress needed replies or re-trigger responses if the heuristics misfire.
> 
> **Overview**
> Improves PR comment automation by treating consolidated `[AI responder]` issue comments as replies to inline review comments (via ID/reference pattern matching plus a similarity fallback), and simplifies `_appears_to_be_reply_to` by dropping `@author` matching.
> 
> Expands the export allowlist to include additional GitHub runner setup scripts (including `scripts/self-hosted/*`) and updates README script/skill counts accordingly, and adds a new `modal-agent-pattern.md` skill document.
> 
> Adds a `--version` flag to the `jleechanorg_pr_monitor` CLI, sourcing the value from the package `__version__`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0654a13ac79cc7452fef707a00992148d068ed90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced character creation and level-up flows with improved modal constraints and explicit exit options to guide user navigation.

* **Improvements**
  * Expanded export system to include GitHub runner setup scripts.
  * Added version flag support to monitoring tool CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->