### PR TITLE
fix: bump marketplace version to 1.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "claude-commands",
       "description": "LLM Capital Efficiency Framework: 145+ production-tested slash commands for autonomous development workflows, PR automation, and multi-agent orchestration",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "source": "./",
       "author": {
         "name": "WorldArchitect.AI Team",


### PR DESCRIPTION
Bump version to enable plugin update test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no code or behavior changes; low risk aside from potentially triggering an unintended release/update.
> 
> **Overview**
> Bumps the `claude-commands` plugin version in `.claude-plugin/marketplace.json` from `1.0.0` to `1.0.1` to trigger a marketplace/plugin update.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dba515c999b7da418b37147947f726535713e93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin version to 1.0.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->