### PR TITLE
Claude Commands Export 2026-02-23: Directory Exclusions Applied

### DIFF
--- a/.claude/commands/automation-audit.md
+++ b/.claude/commands/automation-audit.md
@@ -1,0 +1,15 @@
+---
+description: Automation Audit Skill - Analyze PR automation job runs
+type: execution
+execution_mode: immediate
+---
+
+## ⚡ EXECUTION INSTRUCTIONS FOR CLAUDE
+
+**When this command is invoked, YOU (Claude) must execute these steps immediately:**
+
+Execute the automation-audit skill by invoking the Skill tool with `automation-audit` and pass any arguments provided.
+
+**Usage**: `/automation-audit [hours]`
+
+This runs the comprehensive audit of all automation job runs - analyzes logs, checks PR processing metrics, and verifies remote commits with attribution.

--- a/.claude/commands/automation-run.md
+++ b/.claude/commands/automation-run.md
@@ -1,0 +1,79 @@
+---
+description: Run all crontab automation jobs and verify they worked
+type: execution
+execution_mode: immediate
+---
+
+## ⚡ EXECUTION INSTRUCTIONS FOR CLAUDE
+**When this command is invoked, YOU (Claude) must execute these steps immediately:**
+**This is NOT documentation - these are COMMANDS to execute right now.**
+
+## Overview
+Parse `crontab -l` to find all `jleechanorg-pr-monitor` jobs and execute them with the same parameters, then verify success.
+
+## CRITICAL: This command runs automation jobs - use with caution
+
+**Jobs to run** (from crontab):
+1. `jleechanorg-pr-monitor --max-prs 10` (every 2 hours - PR monitoring)
+2. `jleechanorg-pr-monitor --fix-comment --cli-agent minimax --max-prs 3` (every hour at :45)
+3. `jleechanorg-pr-monitor --comment-validation --max-prs 10` (every 30 min)
+4. `jleechanorg-pr-monitor --codex-update --codex-task-limit 10` (every hour at :15)
+5. `jleechanorg-pr-monitor --codex-api --codex-apply-and-push --codex-task-limit 10` (every hour at :30)
+6. `jleechanorg-pr-monitor --fixpr --max-prs 10 --cli-agent minimax` (every 30 min)
+
+## EXECUTION WORKFLOW
+
+### Phase 1: Extract Jobs from Crontab
+
+**Action Steps:**
+1. Run: `crontab -l | grep jleechanorg-pr-monitor`
+2. Parse each line to extract the full command (after the schedule)
+3. Store commands for execution
+
+### Phase 2: Run Each Job
+
+**Action Steps:**
+For each extracted command:
+1. Display the command being run
+2. Execute with timeout (300s max per job)
+3. Capture output and exit code
+4. Log result
+
+### Phase 3: Verify Success
+
+**Action Steps:**
+1. Check exit codes for each job
+2. Look for success indicators in output:
+   - "Successfully processed PR"
+   - "Monitoring cycle complete"
+   - "No open PRs found"
+3. Report any failures with details
+
+## Reference: Cron Job Schedule
+
+```
+# [CRON-JOB-ID: pr-monitor] Run PR monitoring (comment-only mode) every 2 hours
+0 */2 * * * jleechanorg-pr-monitor --max-prs 10
+
+# [CRON-JOB-ID: fix-comment] Run fix-comment workflow with MiniMax every hour at :45
+45 * * * * jleechanorg-pr-monitor --fix-comment --cli-agent minimax --max-prs 3
+
+# [CRON-JOB-ID: comment-validation] Run comment validation workflow every 30 minutes
+*/30 * * * * jleechanorg-pr-monitor --comment-validation --max-prs 10
+
+# [CRON-JOB-ID: codex-update] Run Codex automation every hour at :15
+15 * * * * jleechanorg-pr-monitor --codex-update --codex-task-limit 10
+
+# [CRON-JOB-ID: codex-api] Run Codex API automation every hour at :30
+30 * * * * jleechanorg-pr-monitor --codex-api --codex-apply-and-push --codex-task-limit 10
+
+# [CRON-JOB-ID: fixpr] Run orchestrated PR fixes every 30 minutes
+*/30 * * * * jleechanorg-pr-monitor --fixpr --max-prs 10 --cli-agent minimax
+```
+
+## Verification Checklist
+
+- [ ] All jobs executed without crashes
+- [ ] Exit codes captured
+- [ ] Success/failure status reported for each job
+- [ ] Any errors logged with details

--- a/.claude/commands/export_config.py
+++ b/.claude/commands/export_config.py
@@ -50,7 +50,10 @@ EXCLUDED_COMPONENTS = [
     "learnings.md",      # Project-specific learnings file
     "principal_engineer_review_prompt.md",  # Project-specific prompts
     "settings.toml",     # Deprecated/alternative config format
-    "settings.json.backup"  # Backup files
+    "settings.json.backup",  # Backup files
+    "pairv2",           # Pair v2 command - project-specific workflow
+    "pairv2.md",        # Pair v2 command file
+    "pairv2-usage.md"   # Pair v2 usage guide
 ]
 
 # Component descriptions for documentation

--- a/.claude/commands/header.md
+++ b/.claude/commands/header.md
@@ -88,11 +88,13 @@ no changes added to commit (use "git add -a" to commit all changes, or "git add 
 ```
 
 Examples:
-- `[Local: main | Remote: origin/main | PR: none]`
+- `[Local: main | Remote: upstream/main | PR: none]`
 - `[API: 49/50 requests (98% remaining) | Reset: 15:08:12]`
-- `[Local: feature-x | Remote: origin/main | PR: #123 https://github.com/user/repo/pull/123]`
-- `[Local: dev-branch (ahead 2) | Remote: origin/main | PR: (related to #456 https://github.com/user/repo/pull/456)]`
+- `[Local: feature-x | Remote: upstream/main | PR: #123 https://github.com/user/repo/pull/123]`
+- `[Local: dev-branch (ahead 2) | Remote: upstream/main | PR: (related to #456 https://github.com/user/repo/pull/456)]`
 - `[API: 25/50 requests (50% remaining) | Reset: 08:30:45]`
+
+**NOTE**: Remote must NEVER be `origin/main`. Use actual remote name (e.g., `upstream/main`, `origin/branch-name`).
 
 ## Compliance Note
 

--- a/.claude/commands/pairv1.md
+++ b/.claude/commands/pairv1.md
@@ -1,0 +1,56 @@
+---
+description: Legacy Python pair executor (pair_execute.py)
+type: llm-orchestration
+execution_mode: manual
+---
+
+# /pairv1 - Legacy Python Pair Executor
+
+> **LEGACY**: This command uses the original `pair_execute.py` Python orchestrator.
+> Prefer `/pair` (Teams-native) or `/pairv2` (LangGraph contract-gated) for new sessions.
+
+## Usage
+
+```bash
+python3 .claude/pair/pair_execute.py "Task description"
+python3 .claude/pair/pair_execute.py --coder-cli claude --verifier-cli claude "Task"
+python3 .claude/pair/pair_execute.py --no-worktree "Task description"
+python3 .claude/pair/pair_execute.py --brainstorm "Task description"
+```
+
+## CLI Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--coder-cli` | `claude` | CLI for coder agent (`claude`, `codex`, `gemini`, `cursor`, `minimax`) |
+| `--verifier-cli` | `codex` | CLI for verifier agent |
+| `--no-worktree` | false | Run in current directory (no git worktree isolation) |
+| `--brainstorm` | false | Run brainstorm phase before launching agents |
+| `--max-iterations` | 60 | Max run attempts per agent (initial launch counts as 1) |
+| `--interval` | 60 | Monitor check interval in seconds |
+| `--coder-model` | — | Model for coder agent (e.g., `opus`, `sonnet`, `haiku`) |
+| `--verifier-model` | — | Model for verifier agent (e.g., `gpt-5`) |
+| `--model` | — | Legacy alias for `--coder-model` |
+| `--claude-provider` | — | Global backend override for claude-family roles (`claude`\|`minimax`) |
+| `--coder-claude-provider` | — | Coder backend override (requires `--coder-cli claude\|minimax`) |
+| `--verifier-claude-provider` | — | Verifier backend override (requires `--verifier-cli claude\|minimax`) |
+
+## Logging
+
+Logs written to `/tmp/{repo_name}/{branch}/pair_logs/` with format `[YYYY-MM-DD HH:MM:SS] [PHASE] message`.
+
+## Completion criteria
+
+A session is complete when:
+
+1. Coder signals `IMPLEMENTATION_READY`.
+2. Verifier signals `VERIFICATION_COMPLETE`.
+3. Lead synthesizes both outputs.
+
+## When to use
+
+- You need the original Python orchestration (no LangGraph, no contract gates).
+- Debugging or reproducing behavior from the legacy executor.
+- CI environments where `pair_execute_v2.py` is unavailable.
+
+For all new work, prefer `/pair` (Teams-native) or `/pairv2` (contract-gated).

--- a/.claude/commands/pairv2.md
+++ b/.claude/commands/pairv2.md
@@ -1,0 +1,57 @@
+---
+description: Launch LangGraph-based pair programming v2 with left/right contract gating
+argument-hint: '"task description"'
+type: llm-orchestration
+execution_mode: immediate
+---
+## ⚡ EXECUTION INSTRUCTIONS FOR CLAUDE
+When this command is invoked, execute the script below directly.
+
+Install dev dependencies first (once per workspace):
+
+```bash
+./vpython -m pip install -r .claude/scripts/requirements-dev.txt
+```
+
+```bash
+python3 .claude/pair/pair_execute_v2.py \
+  --left-contract path/to/left_contract.json \
+  --right-contract path/to/right_contract.json \
+  "$ARGUMENTS"
+```
+
+Live mode (real coder/verifier agents) example:
+
+```bash
+python3 .claude/pair/pair_execute_v2.py \
+  --coder-cli claude \
+  --verifier-cli codex \
+  --left-contract path/to/left_contract.json \
+  --right-contract path/to/right_contract.json \
+  "$ARGUMENTS"
+```
+
+## Purpose
+
+`/pairv2` is the LangGraph state-machine executor for contract-gated pair programming.
+
+The verifier agent is the **spec adherence enforcer** — it checks both directions:
+
+**Left contract adherence** (spec → implementation):
+Every requirement stated in the left contract must be traceable to actual code.
+The verifier finds the function/file for each requirement and flags gaps.
+
+**Right contract adherence** (implementation → documentation):
+Every factual claim in docs/roadmaps must match file system reality:
+- Line counts verified with `wc -l`
+- Status headers ("COMPLETE") must be consistent with checklist items
+- Test counts must be re-run, not trusted from prior claims
+- `[ ]` items must each carry an explicit DEFERRED reason
+
+The three graph nodes that enforce this:
+1. `_left_contract_node` — gates entry: task spec must be unambiguous
+2. `_implement_node` (coder) → `_verify_right_contract_node` (verifier) — iterative loop
+3. `_finalize_node` — records verdict only after verifier confirms both contracts
+
+It outputs a structured verdict artifact at:
+`benchmark_results/pairv2_latest/pairv2_result.json`

--- a/.claude/commands/statusline.md
+++ b/.claude/commands/statusline.md
@@ -22,8 +22,10 @@ This command delegates to `/header` using Claude's natural workflow orchestratio
 ### Example Output
 
 ```
-[Local: feature-branch | Remote: origin/main | PR: #123 https://github.com/user/repo/pull/123]
+[Local: feature-branch | Remote: upstream/main | PR: #123 https://github.com/user/repo/pull/123]
 ```
+
+**NOTE**: Remote must NEVER be `origin/main`. Use actual remote name (e.g., `upstream/main`, `origin/branch-name`).
 
 ## Command Execution
 

--- a/.claude/commands/team-mini.md
+++ b/.claude/commands/team-mini.md
@@ -1,0 +1,57 @@
+---
+description: Create a minimax-only agent team with haiku for work
+type: agent-orchestration
+execution_mode: immediate
+---
+
+## EXECUTION INSTRUCTIONS FOR CLAUDE
+**When this command is invoked, YOU (Claude) must execute these steps immediately:**
+
+1. Parse the user's prompt from the command arguments
+2. Create a new team using TeamCreate with `minimax-pair-coder` agent type (uses claudem() from bashrc)
+3. Spawn subagents using ONLY minimax or haiku models - NO sonnet or opus
+4. Execute the requested work using the team
+
+## IMPORTANT: HOW MINIMAX WORKS
+
+This command uses your `claudem()` bash function from ~/.bashrc which sets:
+- `ANTHROPIC_BASE_URL="https://api.minimax.io/anthropic"`
+- `ANTHROPIC_MODEL="MiniMax-M2.5"`
+- `ANTHROPIC_SMALL_FAST_MODEL="MiniMax-M2.5"`
+
+The `minimax-pair-coder` and `minimax-pair-verifier` agent types invoke `claudem()` internally.
+
+## TEAM-MINI COMMAND
+
+Usage: `/team-mini <prompt>`
+
+This command creates a Claude team that uses ONLY:
+- **MiniMax-M2.5** via `claudem()` bash function (minimax-pair-coder, minimax-pair-verifier)
+- **Haiku** for quick/simple tasks (`model: "haiku"` in Task calls)
+
+**NOT allowed:** sonnet, opus, or default Claude models (sonnet/opus will cost more)
+
+### Execution Steps:
+
+1. **Create team:**
+   ```python
+   TeamCreate(
+       agent_type="minimax-pair-coder",
+       description="Team using only minimax and haiku models",
+       team_name="minimax-team-<timestamp>"
+   )
+   ```
+
+2. **Spawn workers with model restrictions:**
+   - Use `minimax-pair-coder` for main work (MiniMax-M2.5 via claudem)
+   - Use `minimax-pair-verifier` for verification (MiniMax-M2.5 via claudem)
+   - For simple quick tasks, use `model: "haiku"` in Task calls
+
+3. **Execute the user's prompt** using the team
+
+4. **Shutdown team** when complete
+
+### Example:
+```
+/team-mini Write a test file that logs model usage to /tmp/test.log
+```

--- a/.claude/hooks/tests/test_output_trimmer_enhancement.py
+++ b/.claude/hooks/tests/test_output_trimmer_enhancement.py
@@ -196,10 +196,11 @@ def run_comprehensive_tests():
 
     # Create test suite
     suite = unittest.TestSuite()
+    loader = unittest.TestLoader()
 
     # Add all test cases
-    suite.addTest(unittest.makeSuite(TestArgumentSanitization))
-    suite.addTest(unittest.makeSuite(TestOutputTrimmingIntegration))
+    suite.addTests(loader.loadTestsFromTestCase(TestArgumentSanitization))
+    suite.addTests(loader.loadTestsFromTestCase(TestOutputTrimmingIntegration))
 
     # Run tests with detailed output
     runner = unittest.TextTestRunner(verbosity=2, stream=sys.stdout)

--- a/.claude/scripts/split-pane-launch.sh
+++ b/.claude/scripts/split-pane-launch.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Claude Code Split-Pane Launcher
+# Usage: claudet [model]
+#        claudet          # uses sonnet (default)
+#        claudet opus    # uses opus
+#        claudet haiku   # uses haiku
+
+MODEL="${1:-sonnet}"
+SESSION_NAME="claude-team-$(date +%H%M%S)-$$"  # unique per invocation (time + PID)
+MODEL_Q=$(printf '%q' "$MODEL")  # safe quoting to prevent shell injection in tmux command
+
+# Check if we're already in tmux
+if [ -z "${TMUX:-}" ]; then
+    # Not in tmux - start a new session and launch Claude Code with bypass permissions + tmux split mode
+    tmux new-session -d -s "$SESSION_NAME" "claude --dangerously-skip-permissions --teammate-mode tmux --model $MODEL_Q"
+
+    # Attach to the session
+    tmux attach-session -t "$SESSION_NAME"
+else
+    # Already in tmux - launch Claude Code with bypass permissions + tmux split mode
+    exec claude --dangerously-skip-permissions --teammate-mode tmux --model "$MODEL"
+fi

--- a/.claude/scripts/task_impl.py
+++ b/.claude/scripts/task_impl.py
@@ -1,0 +1,43 @@
+"""
+Task implementation for pair session test task.
+Provides greeting and arithmetic utilities.
+"""
+
+
+def greet(name: str = "World") -> str:
+    """Return a greeting string including the given name."""
+    return f"Hello, {name}!"
+
+
+def add(a, b):
+    """Return the sum of a and b."""
+    return a + b
+
+
+def subtract(a, b):
+    """Return the difference of a and b."""
+    return a - b
+
+
+def multiply(a, b):
+    """Return the product of a and b."""
+    return a * b
+
+
+def divide(a, b):
+    """Return the quotient of a divided by b. Raises ZeroDivisionError if b is zero."""
+    if b == 0:
+        raise ZeroDivisionError("division by zero")
+    return a / b
+
+
+def modulo(a, b):
+    """Return a modulo b. Raises ZeroDivisionError if b is zero."""
+    if b == 0:
+        raise ZeroDivisionError("division by zero")
+    return a % b
+
+
+def power(a, b):
+    """Return a raised to the power of b."""
+    return a ** b

--- a/.claude/skills/automation-audit.md
+++ b/.claude/skills/automation-audit.md
@@ -1,0 +1,168 @@
+# Automation Audit Skill
+
+**Usage**: `/automation-audit [hours]`
+
+**Purpose**: Comprehensive audit of all automation job runs - analyze logs, check PR processing metrics, and verify remote commits with attribution.
+
+## Audit Metrics
+
+### Primary Metrics to Collect
+
+1. **PRs Discovered**: Total PRs found in scan (from `discovering open PRs` or `Total recent PRs discovered`)
+2. **PRs Skipped**: PRs not processed (from `Skipping PR` or `already processed` messages)
+3. **PRs Actioned**: PRs where work was attempted (from `Processing PR` messages)
+4. **PRs with Commits**: PRs that resulted in remote commits with proper attribution
+
+### Secondary Metrics
+
+- **CLI Validation Results**: Which CLIs passed/failed preflight
+- **Cycle Results**: From `Monitoring cycle complete: X actionable, Y skipped`
+- **Errors/Warnings**: Any errors in the logs
+
+## Execution Steps
+
+### Step 1: Gather Log Files
+
+```bash
+# Primary job logs (in /tmp or $HOME/Library/Logs/)
+FIXPR_LOG="/tmp/fixpr.log"
+FIXCOMMENT_LOG="/tmp/fix-comment.log"
+COMMENT_VAL_LOG="/tmp/comment-validation.log"
+
+# Or from home directory
+HOME_LOGS="$HOME/Library/Logs/worldarchitect-automation/"
+```
+
+### Step 2: Parse PR Metrics
+
+Extract key metrics from each log:
+
+```bash
+# Count PRs discovered
+grep -c "Total recent PRs discovered" "$LOG" || echo "0"
+
+# Count PRs skipped
+grep -c "Skipping PR" "$LOG" || echo "0"
+
+# Count PRs processed (actioned)
+grep -c "Processing PR" "$LOG" || echo "0"
+
+# Count actionable results
+grep -oE "Monitoring cycle complete: [0-9]+ actionable" "$LOG"
+```
+
+### Step 3: Check for Remote Commits
+
+Query GitHub API for automation-authored commits:
+
+```bash
+# Time range (default: last 6 hours)
+SINCE="${1:-6}"
+SINCE_DATE=$(date -v-${SINCE}H +%Y-%m-%dT%H:%M:%SZ)
+
+# Search for automation-authored commits
+gh api repos/jleechanorg/your-project.com/commits \
+  --since "$SINCE_DATE" \
+  --jq '.[] | select(.commit.author.name |
+    contains("claude") or
+    contains("Claude") or
+    contains("MiniMax") or
+    contains("codex") or
+    contains("Codex") or
+    contains("automation") or
+    contains("Copilot")
+  ) | {sha: .sha[0:8], author: .commit.author.name, date: .commit.author.date}'
+```
+
+### Step 4: Verify Commit Attribution
+
+For each commit found:
+- Verify author name includes AI identifier
+- Verify commit message follows conventions
+- Verify Co-Authored-By attribution
+
+```bash
+# Check commit details
+gh api repos/jleechanorg/your-project.com/commits/{sha} \
+  --jq '.commit.message, .commit.author.name, .authors'
+```
+
+## Example Output
+
+```
+=== Automation Audit Report (Last 6 hours) ===
+
+| Job          | PRs Discovered | PRs Skipped | PRs Actioned | Commits Made |
+|--------------|---------------|-------------|--------------|--------------|
+| fix-comment  | 12            | 10          | 2            | 1            |
+| fixpr        | 12            | 12          | 0            | 0            |
+| comment-val  | 8             | 8           | 0            | 0            |
+
+=== CLI Preflight Results ===
+- MiniMax: ✅ PASSED
+- Gemini: ❌ FAILED (quota)
+- Cursor: ❌ FAILED (auth)
+
+=== Skip Decision Verification ===
+⚠️ CRITICAL: 7 PRs incorrectly skipped - NEW COMMITS found!
+
+| PR  | Processed Commit | Current HEAD | Status |
+|-----|-----------------|---------------|--------|
+| #5642 | c9270a4c | e815d36a | ❌ NEW COMMIT |
+| #5641 | 88d4163d | 0609ae09 | ❌ NEW COMMIT |
+
+=== Commits Made ===
+- SHA abc1234: [copilot] fix: ... (PR #5584)
+- Attribution: Claude Opus 4.6 <noreply@anthropic.com>
+```
+
+## Log File Locations
+
+- `/tmp/fixpr.log` - fixpr job runs
+- `/tmp/fix-comment.log` - fix-comment job runs
+- `/tmp/comment-validation.log` - comment-validation job runs
+- `$HOME/Library/Logs/worldarchitect-automation/` - persistent logs
+
+## Key Log Patterns
+
+| Pattern | Meaning |
+|---------|---------|
+| `Skipping PR ... - already processed` | PR already handled, no action needed |
+| `Processing PR` | Work was attempted on this PR |
+| `Monitoring cycle complete: X actionable, Y skipped` | Summary of cycle |
+| `✅ Preflight: X passed` | CLI validation passed |
+| `❌ Preflight: X failed` | CLI validation failed |
+
+## Skeptical Review Checklist
+
+- [ ] Are all "skipped" PRs legitimately already processed? (Check commit hash)
+- [ ] Are any "actioned" PRs showing failures?
+- [ ] Are commits properly attributed (Co-Authored-By)?
+- [ ] Are there any errors in the logs that were missed?
+- [ ] Did any PRs fail to get processed due to errors?
+
+### Step 5: Verify Skip Decisions (CRITICAL)
+
+For each skipped PR, verify the "already processed" commit matches current HEAD:
+
+```bash
+# Extract PR numbers and processed commits from logs
+grep "Skipping PR" "$LOG" | grep -oE "#[0-9]+" | tr -d '#' | head -10
+
+# For each PR, compare processed commit to current HEAD
+# Processed: look for "already processed commit XXXXXXX"
+# Current: gh api repos/owner/repo/pulls/{number} --jq '.head.sha'
+
+# If they differ, this is a BUG - PR should have been reprocessed!
+```
+
+**Known Issues**:
+- Commit hash may be truncated (7 chars) causing false positives
+- History storage may be stale/out of sync
+
+### Why Only N PRs?
+
+The automation filters by `cutoff_hours` (default 24):
+- Only PRs updated within the cutoff are discovered
+- Total open PRs may be much larger (e.g., 2612) but only recent ones are scanned
+- Verify with: `gh api "search/issues?q=repo:owner/repo+is:pr+is:open+updated:>YYYY-MM-DD"`

--- a/.claude/skills/beads-issue-tracking.md
+++ b/.claude/skills/beads-issue-tracking.md
@@ -1,0 +1,130 @@
+# Beads Issue Tracking - Your Project Reference
+
+Beads (`bd`) is the project's git-native issue tracker. Issues live in `.beads/issues.jsonl` (version-controlled) with a SQLite cache (`beads.db`, gitignored).
+
+## Essential Commands
+
+```bash
+bd list                              # List open issues
+bd list --status in_progress         # Filter by status
+bd show REV-abc123                   # Show issue detail
+bd create "Fix the login bug"        # Create issue
+bd update REV-abc123 --status done   # Close issue
+bd search "keyword"                  # Full-text search
+bd status                            # DB health summary
+```
+
+## Status Values
+
+`open` | `in_progress` | `blocked` | `done` | `closed`
+
+## Commit Convention
+
+Reference beads in commit messages:
+
+```
+fix(auth): resolve JWT expiry edge case
+
+REV-abc123
+```
+
+## Database Recovery ("no beads database found")
+
+The SQLite DB (`beads.db`) is gitignored and ephemeral — created by the daemon, not committed. If the daemon is killed (e.g. by `integrate.sh`), the DB disappears and `bd` commands fail.
+
+**Fix:** run `bd init` to rebuild from the committed JSONL:
+
+```bash
+bd init       # rebuilds beads.db from .beads/issues.jsonl
+bd status     # verify
+```
+
+Do **not** set `no-db: true` in `.beads/config.yaml` unless you want to permanently disable SQLite. The SQLite DB gives you search, filtering, and daemon-backed performance.
+
+## Why the Pre-Commit Hook Sometimes Warns
+
+The `bd` pre-commit hook flushes pending changes to JSONL before every commit/stash. If the daemon is down and the DB is missing, it prints:
+
+```
+Warning: bd sync --flush-only failed (daemon may be down, run 'bd init' to restore DB)
+```
+
+This is a **warning only** — it does not block commits. Run `bd init` afterward to restore the DB.
+
+## Integrate.sh and Beads
+
+`integrate.sh` can kill the beads daemon as part of its cleanup. After running `integrate.sh`, if `bd status` shows the error above, just run `bd init`.
+
+`integrate.sh --force` skips the expensive squash-merge detection for branches with >1000 commits (configurable via `FORCE_SQUASH_CHECK_MAX`).
+
+## Config File: `.beads/config.yaml`
+
+Key settings (uncomment to activate):
+
+```yaml
+issue-prefix: "REV"      # prefix for all issue IDs
+sync-branch: "beads-sync" # git branch for beads commits
+# no-db: false           # keep false to use SQLite (recommended)
+# no-daemon: false       # keep false to use daemon for speed
+```
+
+## Daemon Management
+
+```bash
+bd daemon start           # start beads daemon
+bd daemon stop            # graceful stop
+bd daemons stop <path>    # stop daemon for specific repo path
+bd doctor                 # diagnose issues
+```
+
+The daemon lives in the background and serves `bd` commands via a Unix socket (`.beads/bd.sock`). It is **not** needed for `bd` to work — just for performance.
+
+## JSONL Sync
+
+`.beads/issues.jsonl` is the source of truth committed to git. Always include `.beads/` changes in commits and PRs (per CLAUDE.md).
+
+```bash
+bd sync                   # sync JSONL ↔ DB
+bd sync --flush-only      # write DB → JSONL only (what pre-commit hook does)
+```
+
+## Worktree Warning
+
+Avoid staging `.worktrees/pr-*/` directories — git treats them as embedded repos and breaks `git stash`. If accidentally staged:
+
+```bash
+git rm --cached .worktrees/pr-5654
+```
+
+## Merge Conflict Prevention (union driver)
+
+`.gitattributes` is configured with `merge=union` for `.beads/issues.jsonl`. This uses git's built-in union merge strategy which concatenates unique lines from both sides — no conflict markers ever, since each JSONL line is a self-contained record with a unique hash ID.
+
+If you see merge conflicts in `.beads/issues.jsonl`, the union driver is not configured:
+
+```bash
+# Check
+cat .gitattributes | grep beads
+# Should show: .beads/issues.jsonl merge=union
+
+# Fix if wrong
+# Edit .gitattributes: change merge=beads to merge=union
+# Remove the old custom driver:
+git config --unset merge.beads.driver
+```
+
+## Working in Worktrees — Main Dir Drift
+
+Each git worktree has its own `.beads/issues.jsonl`. The pre-commit hook (`/.git/hooks/pre-commit`) automatically:
+1. Runs `bd sync --flush-only` (flushes Dolt DB → JSONL)
+2. Runs `git add .beads/issues.jsonl` (auto-stages it)
+
+So beads ride along with every code commit automatically — **no separate bead-only PRs needed**.
+
+If you work primarily in worktrees and the main repo dir shows `modified: .beads/issues.jsonl`, you can safely discard it:
+
+```bash
+git checkout -- .beads/issues.jsonl
+```
+
+The beads from your worktrees will merge to main when those PRs merge (via the union driver).

--- a/.claude/skills/end2end-testing.md
+++ b/.claude/skills/end2end-testing.md
@@ -190,6 +190,31 @@ TESTING=true python3 -m pytest $PROJECT_ROOT/tests/test_code_execution_dice_roll
 ./run_tests_with_coverage.sh
 ```
 
+## Runner Split: pytest vs script entrypoints
+
+`testing_mcp/README.md` defines many MCP suites as direct-run scripts. Use this split:
+
+- Use `pytest` for:
+  - `mvp_site/tests/...`
+  - `tests/test_end2end/...`
+  - Regular unit/integration modules designed for pytest collection
+- Use direct script execution (`vpython <file>.py`) for:
+  - `testing_mcp/test_*_real_*.py`
+  - `testing_mcp/schema/test_schema_*.py`
+  - Other `testing_mcp` files that implement CLI `argparse` + `main()`
+
+Examples:
+
+```bash
+# MCP script-style suite (correct)
+cd testing_mcp
+../vpython test_social_encounter_real_api.py --start-local
+
+# Schema script-style suite (correct)
+cd $PROJECT_ROOT
+./vpython testing_mcp/schema/test_schema_enforcement_journey_real_api.py --work-name schema_enforcement_run
+```
+
 ## Flask API End2End Test Pattern (MANDATORY)
 
 **All API-level end2end tests MUST follow this pattern.** Located in `$PROJECT_ROOT/tests/test_end2end/`.

--- a/.claude/skills/minimax-cli-fix.md
+++ b/.claude/skills/minimax-cli-fix.md
@@ -1,0 +1,51 @@
+# Running Claude with MiniMax
+
+**Usage**: Use this skill when you need to run Claude Code CLI with MiniMax API.
+
+## Quick Start
+
+In an interactive shell, use the `claudem` bash function:
+
+```bash
+claudem --version
+claudem -p "Your prompt here"
+```
+
+## Environment Variables
+
+The `claudem` function sets these required variables:
+
+```bash
+ANTHROPIC_BASE_URL="https://api.minimax.io/anthropic"
+ANTHROPIC_AUTH_TOKEN="$MINIMAX_API_KEY"  # NOT ANTHROPIC_API_KEY
+ANTHROPIC_MODEL="MiniMax-M2.5"
+ANTHROPIC_SMALL_FAST_MODEL="MiniMax-M2.5"
+API_TIMEOUT_MS="3000000"
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
+```
+
+## Common Commands
+
+```bash
+# Version check
+claudem --version
+
+# Interactive prompt
+claudem -p "Explain this code"
+
+# With specific prompt file
+claudem -p @/path/to/prompt.txt
+
+# Continue previous conversation
+claudem --continue
+
+# Skip permissions (for automation)
+claudem --dangerously-skip-permissions -p "Your prompt"
+```
+
+## Troubleshooting
+
+If you get "quota/rate limit" errors:
+1. Verify `MINIMAX_API_KEY` is set: `echo $MINIMAX_API_KEY`
+2. Check `ANTHROPIC_AUTH_TOKEN` is being used (not `ANTHROPIC_API_KEY`)
+3. Ensure `ANTHROPIC_BASE_URL` is set to `https://api.minimax.io/anthropic`

--- a/.claude/skills/minimax.md
+++ b/.claude/skills/minimax.md
@@ -1,0 +1,63 @@
+# MiniMax Automation Runner
+
+**Usage**: Run jleechanorg-pr-monitor automation jobs using MiniMax API provider.
+
+## Quick Start
+
+Run fixpr automation with minimax:
+```bash
+jleechanorg-pr-monitor --fixpr --max-prs 10 --cli-agent minimax
+```
+
+Run fix-comment with minimax:
+```bash
+jleechanorg-pr-monitor --fix-comment --cli-agent minimax --max-prs 3
+```
+
+## How MiniMax Works in Automation
+
+The `minimax` CLI agent runs Claude Code with the MiniMax API endpoint:
+
+- **Binary**: Uses `claude` CLI binary
+- **Auth**: Sets `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL` for MiniMax proxy
+- **Model**: MiniMax-M2.5
+
+## Environment Variables
+
+The automation automatically sets these from `MINIMAX_API_KEY`:
+```bash
+ANTHROPIC_AUTH_TOKEN=<MINIMAX_API_KEY>
+ANTHROPIC_API_KEY=<MINIMAX_API_KEY>
+ANTHROPIC_BASE_URL="https://api.minimax.io/anthropic"
+ANTHROPIC_MODEL="MiniMax-M2.5"
+API_TIMEOUT_MS="3000000"
+CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC="1"
+```
+
+## Preflight Validation
+
+If preflight fails (CLI not found), you can skip it with:
+```bash
+TESTING=true jleechanorg-pr-monitor --fixpr --cli-agent minimax
+```
+
+## Cron Jobs Using MiniMax
+
+From crontab:
+```bash
+# Fix-comment every hour at :45
+45 * * * * jleechanorg-pr-monitor --fix-comment --cli-agent minimax --max-prs 3
+
+# Fixpr every 30 minutes
+*/30 * * * * jleechanorg-pr-monitor --fixpr --max-prs 10 --cli-agent minimax
+```
+
+## Troubleshooting
+
+**Preflight fails with "minimax binary not found"**:
+- This is expected - minimax uses `claude` binary with minimax API
+- Set `TESTING=true` to skip preflight validation
+
+**API errors**:
+- Verify `MINIMAX_API_KEY` is set: `echo $MINIMAX_API_KEY`
+- Check orchestration package is up to date: `pip show jleechanorg-orchestration`

--- a/.claude/skills/pair-benchmark-all-executors.md
+++ b/.claude/skills/pair-benchmark-all-executors.md
@@ -1,0 +1,74 @@
+---
+name: pair-benchmark-all-executors
+description: Run one benchmark script that compares pairv2, pair via Claude Teams, and pair via direct Python
+type: usage
+scope: project
+---
+
+# Pair Benchmark (All Executors)
+
+## Purpose
+Use one script to benchmark all pair executors:
+- `pairv2` (`.claude/pair/pair_execute_v2.py`)
+- `/pair` via Claude Teams prompt path
+- `/pair` via direct Python (`.claude/pair/pair_execute.py`)
+
+## Script
+`./vpython .claude/pair/benchmark_pair_executors.py`
+
+## Quick Start
+Run all three executors in one benchmark:
+
+```bash
+./vpython .claude/pair/benchmark_pair_executors.py \
+  --executor-set all \
+  --iterations 1 \
+  --timeout-seconds 180 \
+  --teams-command "claude --print" \
+  --artifact /tmp/{repo}/{branch}/pair/all_three.json
+```
+
+Run all three in parallel:
+
+```bash
+./vpython .claude/pair/benchmark_pair_executors.py \
+  --executor-set all \
+  --parallel \
+  --iterations 1 \
+  --timeout-seconds 180 \
+  --teams-command "claude --print" \
+  --artifact /tmp/{repo}/{branch}/pair/all_three_parallel.json
+```
+
+## Executor Modes
+- `--executor-set all`: pair python + pair teams + pairv2
+- `--executor-set legacy-vs-v2`: pair python vs pairv2
+- `--executor-set teams-vs-v2`: pair teams vs pairv2
+- `--executor-set pairv2-only`: pairv2 only
+
+## Key Output Fields
+- `pair_python`, `pair_python_status_counts`, `pair_python_raw`
+- `pair_claude_teams`, `pair_teams_status_counts`, `pair_teams_raw`
+- `pairv2_langgraph`, `pairv2_status_counts`, `pairv2_raw`
+- `speedup_ratio_pair_python_over_v2`
+- `speedup_ratio_pair_teams_over_v2`
+- `speedup_ratio_pair_python_over_teams`
+
+## Current Defaults (updated Feb 2026)
+
+- `--executor-set`: `pairv2-only`
+- `--coder-cli`: `minimax`
+- `--verifier-cli`: `minimax`
+- `--task`: hello world script + pytest test
+- `--timeout-seconds`: `600`
+
+Run with no args to use these defaults:
+```bash
+venv/bin/python3 .claude/pair/benchmark_pair_executors.py
+```
+
+## Notes
+- `pairv2` is LangGraph-based (`.claude/pair/pair_execute_v2.py`).
+- Artifacts default to `/tmp/{repo}/{branch}/pair/<timestamp>/pair_executor_benchmark.json` when `--artifact` is omitted.
+- Use `--coder-cli` and `--verifier-cli` to align model/runtime choices across runs.
+- **`minimax` is not a CLI binary** — it runs `claude` with MiniMax API endpoint. See `pairv2-usage.md` for details.

--- a/.claude/skills/pairv2-usage.md
+++ b/.claude/skills/pairv2-usage.md
@@ -1,0 +1,146 @@
+---
+name: pairv2-usage
+description: How to run pairv2 directly and via the benchmark script, including what "minimax" means as a CLI option
+type: usage
+scope: project
+---
+
+# pairv2 Usage Guide
+
+## What is pairv2?
+
+`pair_execute_v2.py` is a LangGraph-based pair-programming executor. It:
+1. Generates left/right contracts (task spec + acceptance criteria) via LLM
+2. Launches a **coder** agent to implement the task
+3. Launches a **verifier** agent to review the implementation
+4. Retries up to `--max-cycles` times if verification fails
+
+Files:
+- Executor: `.claude/pair/pair_execute_v2.py`
+- Benchmark: `.claude/pair/benchmark_pair_executors.py`
+- Contracts: `.claude/contracts/left_contract.template.json`, `right_contract.template.json`
+
+---
+
+## What "minimax" means as `--coder-cli` / `--verifier-cli`
+
+**`minimax` is NOT a CLI binary.** There is no `minimax` command on PATH.
+
+`--coder-cli minimax` means: run the **`claude` CLI binary** with the MiniMax API endpoint injected via environment variables.
+
+The orchestration library (`orchestration/task_dispatcher.py`) handles this:
+
+```python
+"minimax": {
+    "binary": "claude",           # still the claude CLI
+    "env_set": {
+        "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+        "ANTHROPIC_MODEL": "MiniMax-M2.5",
+        "ANTHROPIC_API_KEY": "<from MINIMAX_API_KEY>",
+    },
+    "env_unset": ["ANTHROPIC_AUTH_TOKEN", "CLAUDECODE"],
+}
+```
+
+Auth is resolved automatically from `$MINIMAX_API_KEY` → `~/.bashrc` → `~/.automation_env`.
+
+Other CLI options work similarly:
+- `claude` — Claude Code CLI, direct Anthropic OAuth (no key needed)
+- `codex` — OpenAI Codex CLI (`codex exec --yolo`)
+- `gemini` — Gemini CLI (`gemini -m <model> --yolo`)
+- `cursor` — Cursor CLI (`cursor-agent -f`)
+
+---
+
+## Running pairv2 Directly
+
+```bash
+venv/bin/python3 .claude/pair/pair_execute_v2.py \
+  --coder-cli minimax \
+  --verifier-cli minimax \
+  --no-worktree \
+  "Your task description here"
+```
+
+With explicit contracts:
+```bash
+venv/bin/python3 .claude/pair/pair_execute_v2.py \
+  --coder-cli minimax \
+  --verifier-cli codex \
+  --left-contract .claude/contracts/left_contract.template.json \
+  --right-contract .claude/contracts/right_contract.template.json \
+  --no-worktree \
+  --max-cycles 3 \
+  "Your task description here"
+```
+
+Key flags:
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--coder-cli` | `minimax` | Agent that writes code |
+| `--verifier-cli` | `codex` | Agent that reviews code |
+| `--max-cycles` | `5` | Max retry loops |
+| `--no-worktree` | off | Skip git worktree isolation |
+| `--live-timeout` | `600` | Heartbeat timeout in seconds |
+| `--fan-out` | `1` | Parallel coder attempts |
+| `--validate-contracts-only` | off | Check contracts without running agents |
+
+Output JSON is printed to stdout and saved to `--artifact-dir` (default: `/tmp/.../pairv2_latest/`).
+
+---
+
+## Running the Benchmark
+
+The benchmark runs pairv2 (and optionally legacy pair executors) on a task and records timing/verdict.
+
+**Current defaults** (as of Feb 2026):
+- Task: "Write hello_world.py + test_hello_world.py"
+- Executor set: `pairv2-only`
+- Coder CLI: `minimax`
+- Verifier CLI: `minimax`
+
+```bash
+# Run with all defaults (pairv2-only, minimax+minimax, hello world task)
+venv/bin/python3 .claude/pair/benchmark_pair_executors.py
+
+# Custom task
+venv/bin/python3 .claude/pair/benchmark_pair_executors.py \
+  --task "Implement a Python function that reverses a linked list"
+
+# pairv2 vs legacy pair comparison
+venv/bin/python3 .claude/pair/benchmark_pair_executors.py \
+  --executor-set legacy-vs-v2 \
+  --iterations 2
+
+# All three executors in parallel
+venv/bin/python3 .claude/pair/benchmark_pair_executors.py \
+  --executor-set all \
+  --parallel
+```
+
+Key output fields (from result JSON):
+```json
+{
+  "mode": "pairv2_only",
+  "pairv2_langgraph": { "avg_ms": 404900, "count": 1 },
+  "pairv2_status_counts": { "completed": 1 },
+  "pairv2_raw": [{ "verdict": "PASS", "cycle_count": 1, "duration_ms": 404900 }]
+}
+```
+
+---
+
+## Typical Run Time
+
+- Hello world task: ~5-7 minutes (contract generation + coder + verifier)
+- Complex task (800+ lines): ~20-40 minutes
+
+The benchmark imposes a process-level timeout cap of 1800s (30 min).
+
+---
+
+## See Also
+
+- `minimax.md` — MiniMax in the context of PR automation (pr-monitor, fixpr)
+- `pair-benchmark-all-executors.md` — Benchmark executor-set reference
+- `agents.md` — Agent orchestration patterns

--- a/.claude/skills/pr-preview-servers.md
+++ b/.claude/skills/pr-preview-servers.md
@@ -1,0 +1,98 @@
+# PR Preview Servers — GCP Cloud Run Pool
+
+Reference for the rotating preview server pool used to deploy PR branches.
+
+## Pool Configuration
+
+- **Pool size**: 10 servers (`mvp-site-app-s1` through `mvp-site-app-s10`)
+- **Service prefix**: `mvp-site-app`
+- **GCP project**: `worldarchitecture-ai`
+- **Region**: `us-central1`
+- **Trigger**: Any PR push to `$PROJECT_ROOT/**`, `Dockerfile`, `requirements.txt`, etc.
+- **Workflow**: `.github/workflows/pr-preview.yml`
+- **Pool assignment script**: `.github/scripts/pr-server-pool.sh`
+
+## URL Pattern
+
+```
+https://mvp-site-app-s{N}-{hash}-uc.a.run.app
+```
+
+Where `{N}` is 1–10 and `{hash}` is Cloud Run's stable unique URL segment.
+
+### Finding the Current PR's Preview URL
+
+**From GitHub CLI (fastest):**
+```bash
+gh pr view <PR_NUMBER> --json comments --jq '.comments[].body' | grep -o 'https://mvp-site-app-s[^ ]*'
+```
+
+**From PR comments in the UI:**
+Look for the bot comment that says "Preview deployed to: `https://...`"
+
+**From Cloud Run directly:**
+```bash
+gcloud run services describe mvp-site-app-s{N} \
+  --project=worldarchitecture-ai \
+  --region=us-central1 \
+  --format='value(status.url)'
+```
+
+## Deployment Details
+
+The preview server is deployed with:
+- `FLASK_ENV=production`
+- `ENVIRONMENT=preview`
+- Secrets: `GEMINI_API_KEY`, `CEREBRAS_API_KEY`, `OPENROUTER_API_KEY`
+- **NO** `TESTING_AUTH_BYPASS=true` — real Firebase auth is required for protected endpoints
+- Max 2 Cloud Run instances, same timeout as production
+
+## Health Endpoint
+
+```
+GET /health
+→ 200 {"status": "healthy", "service": "worldarchitect-ai", "timestamp": "..."}
+```
+
+Note: `/health` does **not** expose the `ENVIRONMENT` env var. Confirmed 2026-02-20.
+
+## Testing Against Preview Servers
+
+Use the standalone smoke test (no local server startup needed):
+
+```bash
+# Test the current PR's preview server
+python3 testing_mcp/test_openclaw_gateway_url_preview.py
+
+# Test a specific preview URL
+python3 testing_mcp/test_openclaw_gateway_url_preview.py \
+  --server-url https://mvp-site-app-s10-i6xf2p72ka-uc.a.run.app
+```
+
+### What You Can Test Without Auth
+
+| Test | Why |
+|------|-----|
+| `/health` → 200 | Public health endpoint |
+| `/settings` HTML → 200, field present | Public HTML page |
+| `POST /api/settings` → 401 (not 404) | Route wired, auth enforced |
+| Static assets | Public static files |
+
+### What Requires Real Firebase Auth
+
+- `POST /api/settings` with actual settings values (save to Firestore)
+- `GET /api/settings` (read user settings)
+- Any campaign API endpoint
+
+## Pool Eviction Policy
+
+When all 10 slots are taken, the oldest assignment is evicted to make room.
+The evicted PR loses its preview URL. Check PR #N's comments for current status.
+
+## Known Preview Server URLs by PR
+
+| PR | Server | URL |
+|----|--------|-----|
+| #5662 | s10 | `https://mvp-site-app-s10-i6xf2p72ka-uc.a.run.app` |
+
+> Update this table as PRs are deployed. URL stays stable as long as the pool slot isn't evicted.

--- a/.claude/skills/testing-infrastructure.md
+++ b/.claude/skills/testing-infrastructure.md
@@ -111,6 +111,26 @@ print(f"Debug: {result}")
 - Run only SPECIFIC tests: `TESTING=true python $PROJECT_ROOT/tests/test_<specific>.py`
 - GitHub CI is the authoritative source for test results
 
+## README-aligned Runner Selection (Critical)
+
+### `testing_mcp` suites
+- Treat many `testing_mcp/*.py` files as **script entrypoints**, not pytest-collected test modules.
+- Prefer direct execution:
+  - `cd testing_mcp && ../vpython test_<name>.py --server http://127.0.0.1:8001`
+  - `cd testing_mcp && ../vpython test_<name>.py --start-local`
+  - Schema scripts: `./vpython testing_mcp/schema/test_schema_<name>.py`
+- Avoid `pytest testing_mcp/...` for script-style files that parse CLI args or expect script runtime setup.
+
+### `testing_ui` browser auth bypass
+- Follow `mvp_site/testing_ui/README_TEST_MODE.md` exactly:
+  - Start backend with `TESTING_AUTH_BYPASS=true`.
+  - Open UI with `?test_mode=true&test_user_id=<id>`.
+  - Verify browser flow sets/uses:
+    - `window.testAuthBypass.enabled`
+    - `X-Test-Bypass-Auth: true`
+    - `X-Test-User-ID: <id>`
+- This is mandatory for browser E2E runs that cannot inject custom auth headers directly.
+
 ## MCP Smoke Tests
 
 ```bash

--- a/.claude/skills/video-frame-review.md
+++ b/.claude/skills/video-frame-review.md
@@ -1,0 +1,66 @@
+# Video Frame Review Skill
+
+## How it works
+
+Claude Code is multimodal: `Read` on a JPEG/PNG renders it visually.
+ffmpeg extracts frames → Read individual frames at key timestamps = video review without Gemini or any API.
+
+No external tools needed beyond ffmpeg (already at `/opt/homebrew/bin/ffmpeg`).
+
+## Standard extraction command
+
+```bash
+# 1 FPS into a frames/ directory
+ffmpeg -i test.webm -vf fps=1 /tmp/review/frames/frame_%04d.jpg
+
+# Scene-change only (cheaper, catches state transitions)
+ffmpeg -i test.webm -vf "select='gt(scene,0.4)'" -vsync vfr /tmp/review/scene/scene_%04d.jpg
+
+# Contact sheet (quick visual overview, all frames tiled)
+ffmpeg -i test.webm -vf "fps=1,scale=320:-1,tile=4x4" /tmp/review/contact_sheet.jpg
+```
+
+## Review strategy
+
+Don't read every frame. Sample strategically:
+
+| Frame | Purpose |
+|---|---|
+| frame_0001 | Loading state — blank? error? |
+| frame_0005 | First meaningful UI state |
+| frame_0010, 0020 | Early flow |
+| frame_0030–0050 | Mid-flow — key interactions |
+| frame_0060–0080 | Late flow |
+| frame_last | Final state — did it succeed? |
+
+Read the contact sheet first for a spatial overview, then dive into specific frames.
+
+## What to look for (skeptically)
+
+- **Does the UI actually change?** Same screen across many frames = stuck/frozen
+- **Error messages in GM/system responses?** e.g. `[CHARACTER CREATION - No Character Built]`
+- **Party/state panels populated correctly?** Placeholder names ("Hero L1") ≠ real character data
+- **Chat history grows?** Empty chat for 60% of video duration = long wait or no actions
+- **Final frame matches claimed outcome?** Video can be 101s of failure and still have valid ffprobe metadata
+
+## Key insight from first use (2026-02-20)
+
+The `test_full_lifecycle_video` (101.76s) was reported "pass" because ffprobe confirmed a valid .webm file. Frame review revealed every GM response was `[CHARACTER CREATION - No Character Built]` — the game never actually worked. Character creation data was never persisted before the session started.
+
+**File existence + duration ≠ test passed. Frame content is the ground truth.**
+
+## Skill invocation pattern
+
+```
+1. ffmpeg extract 1FPS frames to /tmp/review/frames/
+2. Read contact sheet for overview
+3. Read frame_0001 (load state)
+4. Read frame_0005 (first UI)
+5. Read frames at 25%, 50%, 75%, 100% of total count
+6. Read any frames around timestamps of interest from server logs
+7. Report what actually happened on screen
+```
+
+## Cost note
+
+Reading ~10 JPEG frames locally costs nothing beyond Claude context. For 34 test videos, batch the review: extract all frames, then sweep through contact sheets first to triage which videos need deep frame inspection.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,168 @@
+# 📚 Reference Export - Agents Configuration
+
+**Note**: This is a reference export from a working Claude Code project. These agent
+configurations and guidelines may contain project-specific references that need adaptation.
+
+Customize the following for your project:
+- Project-specific paths ($PROJECT_ROOT/ → your main source directory)
+- Repository and domain references
+- CI commands and test runner paths
+
+---
+
+# Repository Guidelines (Compact Core)
+
+## Purpose
+This is the enforceable core contract for agents working in this repo. Keep this file concise; place detailed procedures in `.claude/skills/` or `.codex/skills/` and link them here.
+
+## Non-Negotiables
+- Preserve existing `GITHUB_TOKEN=...` lines in the user's real crontab unless explicitly asked to modify them.
+- Do not use sparse checkout in this repository.
+- Keep `.beads/` tracked and include beads changes in PRs.
+- Use `gh` for GitHub operations (PRs/issues/checks/releases).
+- Never delete/remove the worktree directory you are currently operating in (or the user's stated active worktree) unless explicitly asked.
+- At session end: quality checks + push branch updates; work is not complete until push succeeds.
+
+## LLM Architecture Principles
+### Core rule
+- LLM decides, server executes.
+- Provide full context to the LLM for decision-making.
+- Execute tools/state changes server-side.
+- Incorporate actual tool results in final output.
+
+### Banned patterns
+- Keyword intent bypasses that skip LLM judgment.
+- Stripping tool definitions based on predicted need.
+- Pre-computing results the LLM should request.
+- "Optimization" that removes required context.
+- Requested features hidden behind disabled-by-default flags.
+
+### Prefer schemas
+- Prefer structured JSON input/output schemas over prose templates.
+
+## File Protocol (Required)
+Before touching any file, document:
+- GOAL
+- MODIFICATION
+- NECESSITY
+- INTEGRATION PROOF
+
+Default to integrating into existing files. New file creation is last resort.
+Integration order:
+1. Existing similar file
+2. Existing utility
+3. Existing `__init__.py`
+4. Existing test file
+5. Existing class method
+6. Config file
+7. New file only if justified
+
+## Python Logging & Imports
+- In `$PROJECT_ROOT/`, use unified logger: `from mvp_site import logging_util`.
+- Keep imports module-level (no inline function imports outside tests).
+
+## Skills Discovery
+Before starting work, check relevant skills in:
+- Personal: `~/.claude/skills/`
+- Project: `.claude/skills/`
+
+When conflicts exist, personal skills win.
+Use matching skills automatically based on request context.
+
+## Project Structure & Module Organization
+- `$PROJECT_ROOT/`: Python 3.11 backend (Flask, MCP tooling), tests, templates, and static assets. Frontends live in `$PROJECT_ROOT/frontend_v1/` and `$PROJECT_ROOT/frontend_v2/`.
+- `$PROJECT_ROOT/tests/` and `$PROJECT_ROOT/test_integration/`: Unit and integration tests. Additional top‑level tests exist in `tests/`.
+- `scripts/` and top‑level `run_*.sh`: Development, CI, and utility commands.
+- `.claude/` and related folders: Agent orchestration commands and docs (detailed conventions live in `docs/CLAUDE.md`).
+- `docs/`, `roadmap/`, `world/`: Documentation, plans, and content assets.
+
+## Build, Test, and Development Commands
+- `./vpython $PROJECT_ROOT/main.py serve`: Run the API locally. Alt: `./run_local_server.sh`.
+- `./run_tests.sh [--full|--integration|--coverage]`: Run Python tests.
+- `./run_tests_with_coverage.sh`: Generate coverage; HTML output under `/tmp/$PROJECT_NAME/coverage/`.
+- `./run_ui_tests.sh`: Execute UI/browser tests.
+- `./run_lint.sh` or `pre-commit run -a`: Lint/format.
+
+### testing_mcp and testing_ui execution policy
+- Do not use pytest collection for script-style `testing_mcp/` suites. Run directly with `vpython`.
+- Canonical: `cd testing_mcp && ../vpython test_<name>.py --server http://127.0.0.1:8001`
+- Browser tests: Start server with `TESTING_AUTH_BYPASS=true`, navigate with `?test_mode=true&test_user_id=<id>`.
+
+## Coding Style
+- Python: 4‑space indent, 88‑char lines, double quotes. Lint/format via Ruff; imports via isort.
+- JavaScript/CSS: Prettier (2‑space tabs, single quotes).
+- Naming: `snake_case` for files/functions, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
+
+## Testing Guidelines
+- Frameworks: unittest/pytest via `run_tests.sh`. Integration tests opt‑in (`--integration`).
+- Environment: Default `TEST_MODE=mock`.
+- Conventions: Feature tests near code in `$PROJECT_ROOT/tests/`; prefer small, deterministic tests.
+
+## Commit & Pull Request Guidelines
+- Commits: Imperative mood, e.g., `Context Optimization: Reduce token usage`.
+- After completing work, push commits to the PR remote branch so CI and reviewers see the latest state.
+- PRs: Clear description, linked issues, screenshots for UI changes, test plan. Ensure CI passes and lint is clean.
+
+## Security & Configuration
+- Never commit secrets. Copy `.env.example` to `.env` and populate locally.
+- Firebase `serviceAccountKey.json` and `GEMINI_API_KEY` must be set as documented in `README.md`.
+- WorldArchitecture.AI Firebase Admin key at `~/serviceAccountKey.json`. Set `GOOGLE_APPLICATION_CREDENTIALS`.
+
+## Timeout Guardrail
+Keep all request-handling layers at **600 seconds (10 minutes)**. Use `scripts/timeout_config.sh` with `WORLDARCH_TIMEOUT_SECONDS`. WorldAI campaign LLM/browser waits should default to at least **180 seconds (3 minutes)**.
+
+## Beads Issue Tracking
+- **NEVER gitignore `.beads/`** - Must be version controlled.
+- Always include `.beads/` changes in PRs - do not drop, revert, or omit beads diffs.
+
+## Modal Routing Reference (Critical)
+Routing order in `$PROJECT_ROOT/agents.py:get_agent_for_input()`:
+1. God mode prefix
+2. Character creation completion override
+3. Modal locks (character creation / level-up)
+4. Campaign upgrade
+5. Character creation state
+6. Combat state
+7. Semantic intent classifier
+8. Explicit mode override
+9. Story mode fallback
+
+Use stale-flag guards for level-up:
+- Explicit `level_up_in_progress=False` blocks stale reactivation.
+- Explicit `level_up_pending=False` blocks stale reactivation unless in-progress is true.
+
+Finish choice injection in `$PROJECT_ROOT/world_logic.py` must use pre-update state and preserve injected choice in structured fields.
+
+## Git & Rebase Rules
+- Before `git rebase --continue`, always:
+  1. Check conflict markers: `rg '<<<<<<<|=======|>>>>>>>'`
+  2. Run lint/type-check.
+  3. Stage resolved files and verify `git status`.
+- If rebase appears stuck, inspect lint/type errors first. Abort if needed: `git rebase --abort`.
+
+## GitHub CLI Protocol
+- Verify branch names via `gh pr view <num> --json headRefName` (never guess).
+- Use HEREDOCs for multi-line `gh` bodies.
+- Task completion: Always push to remote before reporting done.
+
+## Agent-Specific Notes
+- Run the `/header` command (`$(git rev-parse --show-toplevel)/.claude/hooks/git-header.sh --with-api`) and append its output as the final element in every reply, after all other text and code blocks.
+
+## Landing the Plane
+When ending a coding session:
+1. Create/update beads for remaining work.
+2. Run quality gates relevant to changed code.
+3. Update bead statuses.
+4. `git pull --rebase` then `git push`.
+5. Confirm branch is up to date.
+6. Hand off with context and artifact paths.
+
+## Agent‑Specific Notes
+
+- Run the `/header` command (`$(git rev-parse --show-toplevel)/.claude/hooks/git-header.sh --with-api`) and append its output as the final element in every reply, after all other text and code blocks.
+
+## References
+- Detailed workflows: `CLAUDE.md`, `docs/CLAUDE.md`
+- Skills: `.claude/skills/`, `.codex/skills/`
+- Modal lock patterns: `$PROJECT_ROOT/agents.py`, `$PROJECT_ROOT/world_logic.py`
+- Beads usage: `docs/beads_creation_manual.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,829 +1,189 @@
 # 📚 Reference Export - Adaptation Guide
 
-**Note**: This is a reference export from a working Claude Code project. You may need to personally debug some configurations, but Claude Code can easily adjust for your specific needs.
+**Note**: This is a reference export from a working Claude Code project. You may need to
+personally debug some configurations, but Claude Code can easily adjust for your specific needs.
 
 These configurations may include:
 - Project-specific paths and settings that need updating for your environment
 - Setup assumptions and dependencies specific to the original project
 - References to particular GitHub repositories and project structures
 
-Feel free to use these as a starting point - Claude Code excels at helping you adapt and customize them for your specific workflow.
+Feel free to use these as a starting point - Claude Code excels at helping you adapt and
+customize them for your specific workflow.
 
 ---
 
-EOF < /dev/null
 # CLAUDE.md - Primary Rules and Operating Protocol
 
-**Primary rules file for AI collaboration on this project**
-
-## 🚨 CRITICAL: MANDATORY BRANCH HEADER PROTOCOL
-
-**EVERY SINGLE RESPONSE MUST END WITH THIS HEADER - NO EXCEPTIONS:**
-
-```
-[Local: <branch> | Remote: <upstream> | PR: <number> <url>]
-```
-
-**Header Generation Methods:**
-- **PREFERRED:** Use `/header` command (finds project root automatically by looking for CLAUDE.md)
-- **Manual:** Run individual commands:
-- `git branch --show-current` - Get local branch
-- `git rev-parse --abbrev-ref @{upstream} 2>/dev/null || echo "no upstream"` - Get remote
-- `gh pr list --head $(git branch --show-current) --json number,url` - Get PR info
-
-**🎯 Memory Aid:** The `/header` command reduces 3 commands to 1, making compliance effortless and helping build the habit of "header last, sign off properly".
-
-**Examples:**
-- `[Local: main | Remote: origin/main | PR: none]`
-- `[Local: feature-x | Remote: origin/main | PR: #123 https://github.com/user/repo/pull/123]`
-
-**❌ NEVER SKIP THIS HEADER - USER WILL CALL YOU OUT IMMEDIATELY**
-
-**🚨 POST-RESPONSE CHECKPOINT**: Before submitting ANY response, ask:
-1. "Did I include the mandatory branch header at the END?"
-2. "Does this violate any other rules in CLAUDE.md?"
-
-**🚨 HEADER PR CONTEXT TRACKING**: Header must reflect actual work context, not just mechanical branch matching
-- ❌ NEVER show "PR: none" when work is related to existing PR context
-- ✅ ALWAYS consider actual work context when determining PR relevance
-- ✅ If working on feature related to PR #X, header should reference PR #X even if branch name differs
-
-## 🚨 CRITICAL PR & COPILOT PROTOCOLS
-
-🚨 **ZERO TOLERANCE PR MERGE APPROVAL PROTOCOL**: ⚠️ MANDATORY
-- ❌ **NEVER MERGE PRS WITHOUT EXPLICIT USER APPROVAL - ZERO EXCEPTIONS**
-- 🚨 **CRITICAL RULE**: "dont merge without my approval EVER" - User statement with zero tolerance
-- ✅ **ALWAYS require explicit approval** before any action that could trigger PR merge
-- ✅ **CHECK PR state** before any push/update that could auto-merge
-- ✅ **MANDATORY approval phrase**: User must type "MERGE APPROVED" for merge-triggering actions
-- ❌ **NO assumptions**: Even PR updates require merge approval verification
-- **Scope**: Applies to ALL operations - manual, /copilot, orchestration, agents
-
-🚨 **COPILOT COMMAND AUTONOMOUS OPERATION**: ⚠️ MANDATORY (FOR ANALYSIS ONLY)
-- ✅ `/copilot` commands operate autonomously without user approval prompts FOR ANALYSIS ONLY
-- ❌ **EXCEPTION**: MERGE operations ALWAYS require explicit user approval regardless of command
-- ✅ ALWAYS proceed with full analysis regardless of conflicts/issues detected
-- ✅ Claude should automatically apply fixes and resolve issues without asking
-- ✅ Continue workflow through conflicts, CI failures, or other blockers
-- 🔒 **CRITICAL**: Must implement merge approval protocol before any merge-triggering push
-- **Purpose**: `/copilot` is designed for autonomous PR analysis and fixing, NOT merging
-
-## Legend
-🚨 = CRITICAL | ⚠️ = MANDATORY | ✅ = Always/Do | ❌ = Never/Don't | → = See reference | PR = Pull Request
-
-## File Organization
-- **CLAUDE.md** (this file): Primary operating protocol
-- **.cursor/rules/rules.mdc**: Cursor-specific configuration
-- **.cursor/rules/lessons.mdc**: Technical lessons and incident analysis
-- **.cursor/rules/examples.md**: Detailed examples and patterns
-- **.cursor/rules/validation_commands.md**: Common command reference
-
-## Meta-Rules
-
-🚨 **PRE-ACTION CHECKPOINT**: Before ANY action, ask: "Does this violate CLAUDE.md rules?" | "Check constraints first?"
-
-🚨 **DUAL COMPOSITION ARCHITECTURE**: Two command processing mechanisms
-- **Cognitive** (/think, /arch, /debug): Universal Composition (natural semantic understanding)
-- **Operational** (/headless, /handoff, /orchestrate): Protocol Enforcement (mandatory workflow execution)
-- ✅ Scan "/" prefixes → classify command type → trigger required workflows
-- ❌ NEVER process operational commands as regular tasks without workflow setup
-- **Pattern**: Cognitive = semantic composition, Operational = protocol enforcement
-
-🚨 **NO FALSE ✅**: Only use ✅ for 100% complete/working. Use ❌ ⚠️ 🔄 or text for partial.
-
-🚨 **NO PREMATURE VICTORY DECLARATION**: Task completion requires FULL verification
-- ❌ NEVER declare success based on intermediate steps (file edits, partial work)
-- ✅ ONLY declare success when ALL steps verified complete
-- ✅ Agent tasks: Requires PR created + pushed + link verified
-- ✅ Direct tasks: Requires changes committed + pushed + tested
-
-🚨 **NO EXCUSES FOR TEST FAILURES**: When asked to fix tests, FIX THEM ALL
-- ❌ NEVER say "pre-existing issues" or settle for partial fixes (97/99 NOT acceptable)
-- ✅ ALWAYS fix ALL failing tests to 100% pass rate
-
-🚨 **DELEGATION DECISION MATRIX**: ⚠️ MANDATORY - Before using Task tool:
-- Tests: Parallelism? Resource <50%? Overhead justified? Specialization needed? Independence?
-- ❌ NEVER delegate sequential workflows - Execute directly for 10x better performance
-
-🚨 **NO ASSUMPTIONS ABOUT RUNNING COMMANDS**: Wait for actual results, don't speculate
-
-🚨 **SOLO DEVELOPER CONTEXT**: Never give enterprise advice to solo developers
-- ✅ **Solo Approach**: "Test it on real PRs" vs complex validation frameworks
-- ❌ **NEVER suggest**: Complex testing frameworks, enterprise validation, infrastructure
-
-## 🚨 CRITICAL IMPLEMENTATION RULES
-
-🚨 **NO FAKE IMPLEMENTATIONS**: ⚠️ MANDATORY - Always audit existing functionality before implementing new code
-- ❌ NEVER create placeholder/demo code or duplicate existing protocols
-- ✅ ALWAYS build real, functional code | Enhance existing systems vs creating parallel ones
-- **Pattern**: Real implementation > No implementation > Fake implementation
-- **Rule**: If you can't implement properly, don't create the file at all
-
-🚨 **ORCHESTRATION OVER DUPLICATION**: ⚠️ MANDATORY
-- **Principle**: Orchestrators delegate to existing commands, never reimplement functionality
-- ✅ Use existing /commentreply, /pushl, /fixpr rather than duplicating logic
-- ❌ NEVER copy systematic protocols from other .md files into new commands
-
-🚨 **NO OVER-ENGINEERING**: Prevent building parallel inferior systems vs enhancing existing ones
-- ✅ Ask "Can LLM handle this naturally?" before building parsers/analytics
-- ✅ Enhance existing systems before building parallel new ones
-- **Pattern**: Trust LLM capabilities, enhance existing systems, prioritize immediate user value
-
-🚨 **NO UNNECESSARY EXTERNAL APIS**: Before adding ANY external API integration:
-- ✅ FIRST ask "Can Claude solve this directly without external APIs?"
-- ✅ Try direct implementation before adding dependencies
-- **Pattern**: Direct solution → Justify external need → Only then integrate
-
-🚨 **GEMINI API JUSTIFICATION REQUIRED**: Only use when Claude lacks capabilities or autonomy required
-
-🚨 **USE LLM CAPABILITIES**: When designing command systems or natural language features:
-- ❌ NEVER suggest keyword matching, regex patterns, rule-based parsing
-- ✅ ALWAYS leverage LLM's natural language understanding
-- **Pattern**: User intent → LLM understanding → Natural response
-
-## 🚨 CRITICAL SYSTEM UNDERSTANDING
-
-🚨 **SLASH COMMAND ARCHITECTURE UNDERSTANDING**: ⚠️ CRITICAL
-- **SLASH COMMANDS ARE EXECUTABLE COMMANDS, NOT DOCUMENTATION**
-- `.claude/commands/*.md` = EXECUTABLE PROMPT TEMPLATES | `.claude/commands/*.py` = EXECUTABLE SCRIPTS
-- **Flow**: User types `/pushl` → Claude reads `pushl.md` → Executes implementation
-- **Two types**: Cognitive (semantic understanding) vs Operational (protocol enforcement)
-- ❌ **NEVER treat .md files as documentation** - they are executable instructions
-
-🚨 **NEVER SIMULATE INTELLIGENCE**: When building response generation systems:
-- ❌ NEVER create Python functions that simulate Claude's responses with templates
-- ✅ ALWAYS invoke actual Claude for genuine response generation
-- **Pattern**: Collect data → Claude analyzes → Claude responds
-- **Anti-pattern**: Collect data → Python templates → Fake responses
-- **Violation Count**: 100+ times - STOP THIS PATTERN IMMEDIATELY
-
-🚨 **NEVER FAKE "LLM-NATIVE" SYSTEMS**: ⚠️ MANDATORY
-- ❌ NEVER use hardcoded keyword matching and call it "LLM-native"
-- ✅ ALWAYS use actual LLM API calls for natural language analysis
-- **Pattern**: Task → LLM API → Analysis → Constraints
-
-🚨 **NO COMMAND PARSING PATTERNS**: ⚠️ MANDATORY - When building Claude integration systems:
-- ❌ NEVER use hardcoded response patterns or lookup tables
-- ✅ ALWAYS call actual Claude CLI or API for real responses
-- **Pattern**: Receive prompt → Call real Claude → Return real response
-
-🚨 **EVIDENCE-BASED APPROACH**: Core principles for all analysis
-- ✅ Extract exact error messages/code snippets before analyzing
-- ✅ Show actual output before suggesting fixes | Reference specific line numbers
-- 🔍 All claims must trace to specific evidence
-
-🚨 **TERMINAL SESSION PRESERVATION**: ⚠️ MANDATORY - Scripts must NOT exit terminal on errors
-- ❌ NEVER use `exit 1` that terminates user's terminal session
-- ✅ ALWAYS use graceful error handling: echo error + read prompt + fallback mode
-- ✅ Users need control over their terminal session - let them Ctrl+C to go back
-- ❌ Only use `exit` for truly unrecoverable situations
-
-🚨 **NO UNVERIFIED SOURCE CITATION**: ⚠️ MANDATORY - Only cite sources you've actually read
-- ❌ NEVER present search result URLs as "sources" without reading their content first
-- ✅ ALWAYS distinguish between "potential sources found" vs "verified sources read"
-- ✅ ONLY cite URLs as evidence after successfully using WebFetch to read their content
-
-🚨 **QUICK QUALITY CHECK** (⚡): For debugging/complex tasks, verify:
-- 🔍 Evidence shown? | ✓ Claims match evidence? | ⚠️ Uncertainties marked? | ➡️ Next steps clear?
-
-## 🚨 MANDATORY QUALITY ASSURANCE PROTOCOL
-
-**ZERO TOLERANCE**: Cannot declare "COMPLETE" without following ALL steps
-
-### 📋 Pre-Testing Checklist (⚠️ MANDATORY)
-- [ ] **Test Matrix Created**: Document ALL user paths/options before testing begins
-- [ ] **Code Scanning Checklist**: For hardcoded value fixes, search ALL related patterns
-- [ ] **Red Team Questions**: Prepare adversarial testing approach to break fixes
-
-### 🔍 Testing Evidence Requirements (⚠️ MANDATORY)
-- [ ] **Screenshot for EACH test matrix cell** with exact path labels
-- [ ] **Evidence documented for EACH ✅ claim** with specific file references
-- [ ] **Path Coverage Report**: Visual showing tested vs. untested combinations
-
-### ✅ Completion Validation Gates (⚠️ MANDATORY)
-- [ ] **Adversarial Testing Completed**: Actively tried to break the fixes
-- [ ] **Testing Debt Documented**: Related patterns verified after bug discovery
-- [ ] **All Evidence Screenshots**: Properly labeled and linked with path information
-
-### 🔒 Evidence Standards
-**Each Completion Claim Format**: "✅ [Claim] [Evidence: screenshot1.png, screenshot2.png]"
-**Path Label Format**: "Screenshot: Custom Campaign → Step 1 → Character Field"
-**Test Matrix Example**: Campaign Type (Dragon Knight, Custom) × Input Fields × Navigation
-
-### 🚨 Enforcement Rules
-- **RULE 1**: Any "COMPLETE" claim without this evidence is automatically INVALID
-- **RULE 2**: Cannot proceed to next milestone without validation gate completion
-- **RULE 3**: Missing path coverage must be documented as "testing debt" and addressed
-- **RULE 4**: All ✅ symbols require corresponding screenshot evidence or they become ❌
-
-**Purpose**: Prevent testing failures through systematic process adherence, not memory-dependent judgment
-
-## Self-Learning Protocol
-
-🚨 **AUTO-LEARN**: Document corrections immediately when: User corrects | Self-realizing "Oh, I should have..." | Something fails | Pattern repeats
-
-**Process**: Detect → Analyze → Document (CLAUDE.md/learnings.md/lessons.mdc) → Apply → Persist to Memory MCP
-
-**/learn Command**: `/learn [optional: specific learning]` - The unified learning command with Memory MCP integration for persistent knowledge graph storage
-
-## Claude Code Specific Behavior
-
-1. **Directory Context**: Operates in worktree directory shown in environment
-2. **Tool Usage**: File ops, bash commands, web tools available
-3. **Test Execution**: Use `TESTING=true vpython` from project root
-4. **File Paths**: Always absolute paths
-5. **Gemini SDK**: `from google import genai` (NOT `google.generativeai`)
-6. **Path Conventions**: `roadmap/` = `/roadmap/` from project root | ✅ **USE ~ NOT /home/jleechan**: Always use `~` instead of `/home/jleechan` in paths for portability
-7. 🚨 **DATE INTERPRETATION**: Environment date format is YYYY-MM-DD where MM is the month number (01=Jan, 07=July)
-8. 🚨 **Branch Protocol**: → See "Git Workflow" section
-9. 🚨 **TOOL EXPLANATION VS EXECUTION**: ⚠️ MANDATORY distinction
-- ✅ When user asks "does X tool do Y?", clearly state if you're explaining or executing
-- ❌ NEVER explain tool capabilities as if you executed them
-10. 🚨 **PUSH VERIFICATION**: ⚠️ ALWAYS verify push success by querying remote commits after every `git push`
-11. 🚨 **PR STATUS INTERPRETATION**: ⚠️ CRITICAL - GitHub PR states mean:
-- **OPEN** = Work In Progress (WIP) - NOT completed | **MERGED** = Completed | **CLOSED** = Abandoned
-- ✅ ONLY mark completed when PR state = "MERGED"
-12. 🚨 **PLAYWRIGHT MCP DEFAULT**: ⚠️ MANDATORY - When running in Claude Code CLI:
-- ✅ ALWAYS use Playwright MCP (@playwright/mcp) for browser automation by default
-- ✅ ALWAYS use headless mode for browser automation (no visible browser windows), **except when debugging or developing new automation scripts, where non-headless mode is permitted for visibility**
-- ✅ Fallback to Puppeteer MCP for Chrome-specific or stealth testing when needed
-
-🚨 **INLINE SCREENSHOTS ARE USELESS**: ⚠️ MANDATORY - Screenshot documentation requirements:
-- ❌ NEVER rely on inline screenshots in chat - they count for NOTHING
-- ✅ ONLY use screenshot tools that save actual files to filesystem
-- ✅ **SCREENSHOT LOCATION**: All screenshots must be saved to `docs/` directory for proper organization and accessibility
-
-13. 🚨 **CONTEXT7 MCP PROACTIVE USAGE**: ⚠️ MANDATORY - When encountering API/library issues:
-- ✅ ALWAYS use Context7 MCP for accurate API documentation when facing errors
-- ✅ **Pattern**: Error occurs → Use `mcp__context7__resolve-library-id` → Get docs with `mcp__context7__get-library-docs`
-
-14. 🚨 **GITHUB TOOL PRIORITY**: ⚠️ MANDATORY - Tool hierarchy for GitHub operations:
-- ✅ **PRIMARY**: GitHub MCP tools (`mcp__github-server__*`) for all GitHub operations
-- ✅ **SECONDARY**: `gh` CLI as fallback when MCP fails or unavailable
-
-15. 🚨 **SERENA MCP FILE OPERATIONS PRIORITY**: ⚠️ MANDATORY - Tool hierarchy for semantic file operations:
-- ✅ **PRIMARY**: Serena MCP tools for semantic code analysis and file operations when available
-- ✅ **SECONDARY**: Standard file tools (Read, Edit, MultiEdit) as fallback
-- ✅ **Pattern**: Complex file operations → Use Serena for semantic understanding → Fallback to basic file tools
-- ✅ **Use Cases**: Code analysis, symbol finding, refactoring, project understanding
-
-16. 🚨 **MEMORY ENHANCEMENT PROTOCOL**: ⚠️ MANDATORY for specific commands
-- **Enhanced Commands**: `/think`, `/learn`, `/debug`, `/analyze`, `/fix`, `/plan`, `/execute`, `/arch`, `/test`, `/pr`, `/perp`, `/research`
-- **High-Quality Memory Standards**: Include exact error messages, file paths with line numbers, code snippets, actionable information, external references
-- **Enhanced Entity Types**: `technical_learning`, `implementation_pattern`, `debug_session`, `workflow_insight`, `architecture_decision`
-- **Execution Steps**: 1) Extract technical terms 2) Search Memory MCP 3) Log results transparently 4) Natural integration 5) Capture high-quality learnings
-- **Transparency**: Show "🔍 Searching memory..." → Report "📚 Found X relevant memories" → Indicate "📚 Enhanced with memory context"
-
-17. 🚨 **FILE CREATION PREVENTION**: ⚠️ MANDATORY - Stop unnecessary file proliferation
-- ❌ **FORBIDDEN PATTERNS**: Creating `_v2`, `_new`, `_backup`, `_temp` files when existing file can be edited
-- ✅ **REQUIRED CHECK**: Before any Write tool usage: "Can I edit an existing file instead?"
-- ✅ **GIT IS SAFETY**: Version control provides backup/history - no manual backup files needed
-
-### 🔧 GitHub MCP Setup
-**Token**: Set in `claude_mcp.sh` line ~247 via `export GITHUB_TOKEN="<your-token>"`
-**Private Repos**: Use direct functions only (no search) | `mcp__github-server__get_pull_request()`
-**Restart After Token Change**: Remove & re-add github-server MCP
-
-🚨 **GITHUB API SELF-APPROVAL LIMITATION**: ⚠️ MANDATORY - Cannot approve own PRs via API
-- ❌ **NEVER attempt**: `gh api repos/{owner}/{repo}/pulls/{pr_number}/reviews --method POST --field event=APPROVE` on own PRs
-- ✅ **ALWAYS use**: General issue comments `gh api repos/owner/repo/issues/{pr_number}/comments --method POST` instead
-
-## Orchestration System
-
-**Full Documentation**: → `.claude/commands/orchestrate.md` for complete system details
-
-### 🚨 Agent Operation
-**System**: Uses tmux sessions with dynamic task agents (task-agent-*) managed by Python monitor
-**Startup**: `./claude_start.sh` auto-starts orchestration | Manual: `./orchestration/start_system.sh start`
-**Monitoring**: `/orch What's the status?` or `/orch monitor agents`
-**Cost**: $0.003-$0.050/task | Redis required for coordination
-**CRITICAL**: ❌ NEVER execute orchestration tasks yourself | ✅ ALWAYS delegate to agents when /orch or /orchestrate is used
-
-🚨 **ORCHESTRATION DIRECT EXECUTION PREVENTION**: ⚠️ MANDATORY HARD STOP PROTOCOL
-- **Hard Stop Pattern**: Input scan for "/orch" prefix → immediate tmux orchestration delegation, NO exceptions
-- **Mental Model**: "/orch" = "create tmux agent to do this", NEVER "/orch" = "I should do this directly"
-- **Zero Exception Rule**: "/orch" ALWAYS triggers tmux orchestration system regardless of context or user statements
-- **CRITICAL**: Task tool ≠ orchestration system. Orchestration = tmux agents via `python3 .claude/commands/orchestrate.py`
-
-🚨 **ABSOLUTE BRANCH ISOLATION PROTOCOL**: ⚠️ MANDATORY - NEVER LEAVE CURRENT BRANCH
-- ❌ **FORBIDDEN**: `git checkout`, `git switch`, or any branch switching commands
-- ❌ **FORBIDDEN**: Working on other branches, PRs, or repositories
-- ✅ **MANDATORY**: Stay on current branch for ALL work - delegate everything else to agents
-- ✅ **DELEGATION RULE**: Any work requiring different branch → `/orch` or orchestration agents
-- **MENTAL MODEL**: "Current branch = My workspace, Other branches = Agent territory"
-
-**NO HARDCODING**: ❌ NEVER hardcode task patterns - agents execute EXACT tasks requested
-
-🚨 **ORCHESTRATION TASK COMPLETION**: When using /orch, task completion requires FULL end-to-end verification
-- ✅ Agent must complete entire workflow (find issue → fix → commit → push → create PR)
-- ✅ Verify PR creation with link before declaring success
+**COMPACTNESS RULE**: Keep this file under 200 lines. Move detailed procedures to `.claude/skills/*.md`.
+
+**Primary rules file for AI collaboration on Your Project**
+
+## Mandatory Greeting Protocol
+
+**Every response must begin with:** `Genesis Coder, Prime Mover,`
+
+**Every response must end with:** `[Local: <branch> | Remote: <upstream> | PR: <number> <url>]`
+
+Lead with architectural thinking, follow with tactical execution. Write code as senior architect.
+
+## Output Formatting
+
+**Full absolute paths ALWAYS** - Never abbreviate with `...` or relative paths
+- ✅ `/tmp/your-project.com/fix/branch/test/iteration_004/`
+- ❌ `.../iteration_004/` or "evidence directory"
+- Evidence bundles: Show full structure, symlinks (e.g., `latest -> iteration_004`)
+
+## LLM Architecture Principles
+
+**Core Rule**: LLM decides, server executes - Give full context, never pre-compute decisions
+
+**BANNED Anti-Patterns**:
+- Keyword/substring matching for intent (use FastEmbed classifier, <50ms)
+- Creating new env vars (use constants; env vars only for credentials/URLs)
+- Stripping tool definitions to "optimize"
+- Disabled-by-default env vars
+
+**Intent Detection**: Local classifier ONLY. Exception: Parsing structured prefixes (`CHOICE:`, `GOD MODE:`)
+
+**Error Handling Philosophy**: Warnings only - no assertions, retries, or default content. Log warnings and let validation surface issues.
+
+## File Protocols
+
+**New Files**: DEFAULT NO - Integration hierarchy: existing file → utility → `__init__.py` → test → config → NEW (last resort)
+
+**Placement**: Python → `$PROJECT_ROOT/` | Scripts → `scripts/` | Tests → `$PROJECT_ROOT/tests/` | No `_v2`, `_new`, `_backup` files
+
+**Deletion**: NEVER delete unrelated content from origin/main. Task-related only: Integration > Modification > Deletion. Before deleting: Search imports → Fix references → Verify dependencies → Delete. When in doubt: ASK first.
+
+## Critical Rules
+
+| Rule | Requirement |
+|------|-------------|
+| **NO UNRELATED DELETIONS** | Never delete content from origin/main unrelated to current task |
+| **CI test failures are BLOCKERS** | ALL failing tests must be fixed - NEVER merge with failing CI |
+| Character creation modal exit | User cannot exit until selecting specific planning_block choice |
+| GEMINI 3 CODE EXECUTION ONLY | Code execution mode REQUIRED. Fix root causes, NOT workarounds |
+| Test failures | Fix ALL, no excuses, no "pre-existing" excuses |
+| Beads tracking | Always include `.beads/` changes in commits/PRs |
+| No bash arguments | NEVER pass bash arguments without explicit user approval |
+| Timeout integrity | 10min/600s across all layers |
+| WorldAI campaign LLM waits | Default >= 3min/180s; 30s insufficient |
+
+## PR & Merge Protocols
+
+- Never merge PRs without explicit "MERGE APPROVED" from user
+- MANDATORY: ALL CI tests must pass before merge - check `statusCheckRollup`
+- `/pr` must create actual PR with working URL - never give manual steps
+- Verify agent work: file existence check, `git diff --stat`, `git status`
+
+### PR Description Requirements
+
+**Required sections**: Summary (1-4 bullets) | Production Code Changes (before → now → why) | Test Changes | Known Limitations
+
+## Claude Code Behavior
+
+1. Operates in worktree directory | 2. `TESTING_AUTH_BYPASS=true vpython` for mock mode | 3. `from google import genai` | 4. Use `~` for paths | 5. MCP tools primary, `gh` fallback | 6. No `_v2`, `_new`, `_backup` files | 7. Cross-platform | 8. Use Read tool | 9. Never `exit 1` | 10. Read/Grep → Edit → Bash | 11. TodoWrite for 3+ steps | 12. Slash commands: `.claude/commands/*.md`
+
+## Diagnostic Efficiency
+
+**Config debugging**: Read source code first (Read tool on consuming file), not exploratory Bash. Max 3 diagnostic attempts before reassessing.
+
+**Env vars**: Set via Cloud Run/Docker/shell profile (NOT `.env` files). Check consuming code for exact names (e.g., `VITE_*` prefix for frontend).
+
+**Grep tool**: Use `Grep` tool for code search, not `grep`/`rg` in Bash (except piping command output).
 
 ## Project Overview
 
-**Stack**: Python 3.11/Flask/Gunicorn | Gemini API | Firebase Firestore | Vanilla JS/Bootstrap | Docker/Cloud Run
+Your Project = AI-powered tabletop RPG platform (digital D&D 5e GM)
 
-**Key Docs**:
-- **AI Assistant Guide**: → `$PROJECT_ROOT/README_FOR_AI.md` (CRITICAL system architecture for AI assistants)
-- **📋 MVP Site Architecture**: → `$PROJECT_ROOT/README.md` (comprehensive codebase overview)
-- **📋 Code Review & File Responsibilities**: → `$PROJECT_ROOT/CODE_REVIEW_SUMMARY.md` (detailed file-by-file analysis)
-- **Browser Test Mode**: → `$PROJECT_ROOT/testing_ui/README_TEST_MODE.md` (How to bypass auth in browser tests)
-- Documentation map → `.cursor/rules/documentation_map.md`
-- Quick reference → `.cursor/rules/quick_reference.md`
-- Progress tracking → `roadmap/templates/progress_tracking_template.md`
-- Directory structure → `/directory_structure.md`
+**Stack:** Python 3.11/Flask/Gunicorn | Gemini API | Firebase Firestore | Vanilla JS/Bootstrap | Docker/Cloud Run
 
-## Core Principles & Interaction
+**Testing Methodology:** Red-green (`/tdd` or `/rg`): Write failing tests → Confirm fail → Minimal code → Refactor
 
-**Work Approach**:
-Clarify before acting | User instructions = law | ❌ delete without permission | Leave working code alone |
-Focus on primary goal | Propose before implementing | Summarize key takeaways | Externalize all knowledge
+### MCP CLI JSON Piping
 
-**Branch Protocol**: → See "Git Workflow" section
-
-**Response Modes**: Default = structured for complex | Direct for simple | Override: "be brief"
-
-**Rule Management**:
-"Add to rules" → CLAUDE.md | Technical lessons → lessons.mdc | General = rules | Specific = lessons
-
-**Development Protocols**: → `.cursor/rules/planning_protocols.md`
-
-**Edit Verification**: `git diff`/`read_file` before proceeding | Additive/surgical edits only
-
-**Testing**: Red-green methodology | Test truth verification | UI = test experience not code | Use ADTs
-
-**Red-Green Protocol** (`/tdd` or `/rg`):
-1. Write failing tests FIRST → 2. Confirm fail (red) → 3. Minimal code to pass (green) → 4. Refactor
-
-🚨 **Testing Standards**: → See "Testing Protocol" section for complete rules
+**CRITICAL**: Use `printf` or `cat`, NOT `echo` (adds `\n` that breaks parsing)
+- ✅ `printf '{"key":"value"}' | mcp-cli call tool -`
+- ✅ `cat file.json | mcp-cli call tool -`
+- ❌ `echo '{"key":"value"}' | mcp-cli call tool -`
 
 ## Development Guidelines
 
-### Code Standards
-**Principles**: SOLID, DRY | **Templates**: Use existing patterns | **Validation**: `isinstance()` checks
-**Constants**: Module-level (>1x) or constants.py (cross-file) | **Imports**: Module-level only, NO inline/try-except
-**Path Computation**: ✅ Use `os.path.dirname()`, `os.path.join()`, `pathlib.Path` | ❌ NEVER use `string.replace()` for paths
+**Code Standards**: SOLID, DRY, use existing patterns. Constants: Module-level or constants.py. Path Computation: Use `os.path.dirname()`, `os.path.join()`, `pathlib.Path` - NEVER `string.replace()`.
 
-🚨 **DYNAMIC AGENT ASSIGNMENT**: Replace hardcoded agent mappings with capability-based selection
-- ❌ NEVER use patterns like `if "test" in task: return "testing-agent"`
-- ✅ Use capability scoring with load balancing
+**Comments**: No PR/bead/ticket references in production code. Write comments that explain *why* for future readers, not *when* or *which ticket*. Ticket references belong in commit messages only.
 
-🚨 **API GATEWAY BACKWARD COMPATIBILITY**: API gateways MUST maintain exact contract during architectural changes
-- ✅ Maintain identical HTTP status codes, response formats, validation behavior
-- ✅ Fix API gateway layer when tests fail after architectural changes
-- **Pattern**: Tests validate API contracts, not implementation details
+**Security**: `shell=False, timeout=30`. GitHub Actions: SHA-pinned versions only.
 
-### Feature Compatibility
-**Critical**: Audit integration points | Update filters for new formats | Test object/string conversion
-**Always Reuse**: Check existing code | Extract patterns to utilities | No duplication
-**Organization**: Imports at top (stdlib → third-party → local) | Extract utilities | Separate concerns
-**No**: Inline imports, temp comments (TODO/FIXME), hardcoded strings | Use descriptive names
+### Import Standards (CI Enforced)
 
-### Gemini SDK
-✅ `from google import genai` | ✅ `client = genai.Client(api_key=api_key)`
-Models: `gemini-2.5-flash` (default), `gemini-1.5-flash` (test)
-🚨 **WARNING**: See "NO UNNECESSARY EXTERNAL APIS" rule before using Gemini
+- **FORBIDDEN**: try/except around imports (`try: import foo except: pass`)
+- **FORBIDDEN**: Inline imports inside functions (`def test(): from foo import bar`)
+- **MANDATORY**: All imports at module level - top of file only
+  - Order: Standard library → third-party → local (alphabetically sorted within each group)
 
-### Development Practices
-`tempfile.mkdtemp()` for test files | Verify before assuming | ❌ unsolicited refactoring
-**Logging**: ✅ `import logging_util` | ❌ `import logging` | Use project's unified logging
+## Testing & Evidence
 
-🚨 **FILE EDITING PROTOCOL**: ⚠️ MANDATORY - Prevent unnecessary file proliferation
-- ❌ **NEVER create**: `file_v2.sh`, `file_backup.sh`, `file_new.sh` when editing existing file
-- ✅ **ALWAYS edit**: Existing files in place using Edit/MultiEdit tools
-- ✅ **Git handles safety**: Version control provides backup/rollback, no manual backup files needed
-- ✅ **Use branches**: For experimental changes, create git branches not new files
-- **Anti-Pattern**: "Let me create a new version..." → Should be "Let me edit the existing file..."
+- Run specific tests: `./run_tests.sh $PROJECT_ROOT/tests/test_feature.py` (not all)
+- testing_mcp: Run directly with `vpython`, NOT pytest
+- testing_ui: Run via `python3 $PROJECT_ROOT/main.py testui` with `TESTING_AUTH_BYPASS=true`
+- Evidence path: `/tmp/your-project.com/<branch>/<test_name>/latest/`
+- TDD: RED (bug) → GREEN (fix) → REFACTOR
 
-🚨 **PR Review Verification**: Always verify current state before applying review suggestions
-- ✅ Check if suggested fix already exists in code | Read actual file content before changes
+**Context Limits:** 500K (Enterprise) / 200K (Paid) | Health: Green (0-30%) | Yellow (31-60%) | Orange (61-80%) | Red (81%+)
 
-⚠️ **PR COMMENT PRIORITY**: Address review comments in strict priority order
-1. **CRITICAL**: Undefined variables, inline imports, runtime errors
-2. **HIGH**: Bare except clauses, security issues
-3. **MEDIUM**: Logging violations, format issues
-4. **LOW**: Style preferences, optimizations
+## Orchestration
 
-🚨 **BOT COMMENT FILTERING**: ⚠️ MANDATORY - Ignore specific bot patterns when explicitly overridden
-- ❌ **IGNORE**: Bot comments about `--dangerously-skip-permissions` when user explicitly chose to keep it
-- ✅ **ACKNOWLEDGE**: Respond but indicate user decision to retain flag
-
-### Website Testing & Deployment Expectations (🚨 CRITICAL)
-🚨 **BRANCH ≠ WEBSITE**: ❌ NEVER assume branch changes are visible on websites without deployment
-- ✅ Check PR description first - many changes are tooling/CI/backend only
-- ✅ Feature branches need local server OR staging deployment for UI changes
-
-### Quality Standards
-**Files**: Descriptive names, <500 lines | **Tests**: Natural state, visual validation, dynamic discovery
-**Validation**: Verify PASS/FAIL detection | Parse output, don't trust exit codes | Stop on contradictions
-
-### 🚨 Testing Protocol
-**Zero Tolerance**: Run ALL tests before completion | Fix ALL failures | No "pre-existing issues" excuse
-**Commands**: `./run_tests.sh` | `./run_ui_tests.sh mock` | `gh pr view`
-**Protocol**: STOP → FIX → VERIFY → EVIDENCE → Complete
-
-🚨 **TEST WITH REAL CONFLICTS**: ⚠️ MANDATORY
-- ✅ ALWAYS test merge conflict detection with PRs that actually have conflicts
-- ✅ Use `gh pr view [PR] --json mergeable` to verify real conflict state before testing
-
-**Test Assertions**: ⚠️ MANDATORY - Must match actual validation behavior exactly
-
-**Exception Specificity**: ✅ Use specific exception types in tests (ValidationError, not Exception)
-
-**Rules**: ✅ Run before task completion | ❌ NEVER skip without permission | ✅ Only use ✅ after real results
-
-### Safety & Security
-❌ Global `document.addEventListener('click')` without approval | Test workflows after modifications
-Document blast radius | Backups → `tmp/` | ❌ commit if "DO NOT SUBMIT" | Analysis + execution required
-
-### File Placement Rules (🚨 HARD RULE)
-🚨 **NEVER add new files directly to $PROJECT_ROOT/** without explicit user permission
-- ❌ NEVER create test files, documentation, or scripts directly in $PROJECT_ROOT/
-- ✅ If unsure, add content to roadmap/scratchpad_[branch].md instead
-
-🚨 **Test File Policy**: Add to existing files, NEVER create new test files
-- ⚠️ MANDATORY: Always add tests to existing test files that match the functionality
-
-🚨 **Code Review**: Check README.md and CODE_REVIEW_SUMMARY.md before $PROJECT_ROOT/ changes
-
-### Browser vs HTTP Testing (🚨 HARD RULE)
-**CRITICAL DISTINCTION**: Never confuse browser automation with HTTP simulation
-- 🚨 **testing_ui/**: ONLY real browser automation using **Playwright MCP** (default) or Puppeteer MCP
-- 🚨 **testing_http/**: ONLY HTTP requests using `requests` library
-- ⚠️ **/testui and /testuif**: MUST use real browser automation (Playwright MCP preferred)
-- ⚠️ **/testhttp and /testhttpf**: MUST use HTTP requests | NO browser automation
-- **Red Flag**: If writing "browser tests" with `requests.get()`, STOP immediately
-
-**Command Structure** (Claude Code CLI defaults to Playwright MCP):
-- `/testui` = Browser (Playwright MCP) + Mock APIs
-- `/testuif` = Browser (Playwright MCP) + REAL APIs (costs $)
-- `/testhttp` = HTTP + Mock APIs
-- `/testhttpf` = HTTP + REAL APIs (costs $)
-- `/tester` = End-to-end tests with REAL APIs (user decides cost)
-
-### Real API Testing Protocol (🚨 MANDATORY)
-**NEVER push back or suggest alternatives when user requests real API testing**:
-- ✅ User decides if real API costs are acceptable - respect their choice
-- ✅ `/tester`, `/testuif`, `/testhttpf` commands are valid user requests
-- **User autonomy**: User controls their API usage and testing approach
-
-### Browser Test Execution Protocol (🚨 MANDATORY)
-🚨 **PREFERRED**: Playwright MCP in Claude Code CLI - Accessibility-tree based, AI-optimized, cross-browser
-🚨 **SECONDARY**: Puppeteer MCP for Chrome-specific or stealth testing scenarios
-🚨 **HEADLESS MODE**: ⚠️ ALWAYS use headless mode for browser automation - no visible browser windows
-**Commands**: `./run_ui_tests.sh mock --playwright` (default) | `./run_ui_tests.sh mock --puppeteer` (secondary)
-**Test Mode URL**: `http://localhost:8081?test_mode=true&test_user_id=test-user-123` - Required for auth bypass!
-
-### Coverage Analysis Protocol (⚠️)
-**MANDATORY**: When analyzing test coverage:
-1. **ALWAYS use**: `./run_tests.sh --coverage` or `./coverage.sh` (HTML default)
-2. **NEVER use**: Manual `coverage run` commands on individual test files
-3. **Verify full test suite**: Ensure all 94+ test files are included in coverage analysis
-4. **HTML location**: `/tmp/worldarchitectai/coverage/index.html`
+- tmux sessions with dynamic task agents
+- Never execute orchestration tasks yourself - delegate to agents
+- `/orch` prefix → immediate tmux delegation | `/converge` → autonomous until goal achieved
 
 ## Git Workflow
 
-**Core Rules**: Main = Truth | All changes via PRs | Verify before push | Set upstream tracking
-**Commands**: `git push origin HEAD:branch-name` | `gh pr create` + test results | `./integrate.sh`
-**Progress**: Scratchpad + JSON (`roadmap/scratchpad_[branch].md` + `tmp/milestone_*.json`)
+- Main = Truth | All changes via PRs | Fresh branches from main
+- **FORBIDDEN**: Merging directly to main without PR | `git sparse-checkout`
 
-🚨 **No Main Push**: ✅ `git push origin HEAD:feature` | ❌ `git push origin main`
-- **ALL changes require PR**: Including roadmap files, documentation, everything
-- **Fresh branches from main**: Always create new branch from latest main for new work
-- **Pattern**: `git checkout main && git pull && git checkout -b descriptive-name`
+## Environment
 
-🚨 **PR Context Management**: Verify before creating PRs - Check git status | Ask which PR if ambiguous
-
-🚨 **Branch Protection**: ❌ NEVER switch without explicit request | ❌ NEVER use dev[timestamp] for development
-✅ Create descriptive branches | Verify context before changes | Ask if ambiguous
-
-🚨 **Conflict Resolution**: Analyze both versions | Assess critical files | Test resolution | Document decisions
-**Critical Files**: CSS, main.py, configs, schemas | **Process**: `./resolve_conflicts.sh`
-
-🚨 **GIT ANALYSIS CONTEXT CHECKPOINT**: ⚠️ MANDATORY protocol before any git comparison
-- ✅ **Steps**: 1) Identify current branch 2) Determine branch type 3) Select appropriate remote comparison 4) Execute
-- **Mapping**: sync-main-* → `origin/main` | Feature branches → `origin/branch-name` | main → `origin/main`
-
-🚨 **COMMAND FAILURE TRANSPARENCY** (⚠️ MANDATORY): When user commands fail unexpectedly:
-- ✅ Immediately explain what failed and why | Show system messages/errors received
-- ✅ Explain resolution approach | Ask preference for alternatives (merge vs rebase, etc.)
-- **Pattern**: Command fails > Explain > Show options > Get preference > Execute
-
-**Commit Format**: → `.cursor/rules/examples.md`
-
-🚨 **GITHUB API PAGINATION PROTOCOL**: ⚠️ MANDATORY - Before ANY GitHub API analysis:
-- ✅ **Check total count first**: Use `gh pr view [PR] --json changed_files` to get file count before analysis
-- ✅ **Verify pagination**: GitHub API defaults to 30 items per page - always check if more pages exist
-- ✅ **Use pagination parameters**: Add `?per_page=100&page=N` for complete results when file count > 30
-- ❌ **NEVER assume**: API returns complete results without verifying pagination and total counts
-
-🚨 **CHALLENGE RESPONSE PROTOCOL**: ⚠️ MANDATORY - When user provides specific evidence:
-- ✅ **Immediate re-verification**: Treat user evidence as debugging signal, not personal attack
-- ✅ **Methodology review**: Re-check approach when user mentions details not in your analysis
-- ❌ **NEVER defend**: Wrong analysis - acknowledge error and re-verify immediately
-
-## Environment, Tooling & Scripts
-
-1. **Python venv**: Verify activated before running Python/tests | If missing/corrupted → `VENV_SETUP.md`
-2. **Robust Scripts**: Make idempotent, work from any subdirectory
-3. **Python Execution**: ✅ Run from project root | ❌ cd into subdirs
-4. **vpython Tests**: ⚠️ "run all tests" → `./run_tests.sh` | ⚠️ Test fails → fix immediately or ask user
-- ✅ `TESTING=true vpython $PROJECT_ROOT/test_file.py` (from root)
-5. 🚨 **Test Compliance**: → See "Testing Protocol" section
-6. **Tool Failure**: Try alternative after 2 fails | Fetch from main if corrupted
-7. **Web Scraping**: Use full-content tools (curl) not search snippets
-8. **Log Files Location**:
-- ✅ **Server logs are in `/tmp/project/`** with branch isolation and service-specific files
-- ✅ **Branch-specific structure**: `/tmp/project/[branch-name]/`
-- ✅ **Service logs**: `/tmp/project/[branch]/[service-name].log`
-- ✅ **Log commands**: `tail -f /tmp/project/[branch]/[service].log` for real-time monitoring
-- ✅ **Search logs**: `grep -i "pattern" /tmp/project/[branch]/[service].log`
-- ✅ **Find current log**: `git branch --show-current` then check corresponding log file
-
-9. 🚨 **SMART SYNC CHECK PROTOCOL**: ⚠️ MANDATORY - Prevent local changes not pushed to remote
-- **Purpose**: Automatically detect and push unpushed commits after tools create changes
-- **Script Location**: `<project-root>/scripts/sync_check.sh` (e.g. `$(git rev-parse --show-toplevel)/scripts/sync_check.sh`)
-- **Integration**: Tools that create commits MUST call sync check at completion
-- **Usage**: `$(git rev-parse --show-toplevel)/scripts/sync_check.sh` or source common utilities
-- **Tools Required**: `/fixpr`, `/commentreply`, `/integrate`, any commit-creating tools
-- **Behavior**: Detects unpushed commits → Shows commits → Auto-pushes → Confirms success
-- **Safety**: Only pushes when unpushed commits detected, handles edge cases gracefully
-- **Error Handling**: Graceful fallback for no upstream, detached HEAD, push failures
-- **Benefits**: Eliminates "forgot to push" syndrome while maintaining workflow transparency
-
-10. 🚨 **GITHUB CLI (gh) INSTALLATION**: ⚠️ MANDATORY for GitHub operations
-- **Primary Tool**: GitHub MCP tools (`mcp__github-server__*`) for all GitHub operations
-- **Fallback**: `gh` CLI when MCP fails or unavailable
-- **Installation & Usage**: See [`.claude/skills/github-cli-reference.md`](.claude/skills/github-cli-reference.md) for detailed setup
-- **Authentication**: Uses `GITHUB_TOKEN` via `gh auth login --with-token`
-- **Benefits**: Direct binary extraction to /tmp avoids permission issues
-
-**Test Commands**: → `.cursor/rules/validation_commands.md`
-
-## Data Integrity & AI Management
-
-1. **Data Defense**: Assume incomplete/malformed | Use `dict.get()` | Validate structures
-2. **Critical Logic**: Implement safeguards in code, not just prompts
-3. **Single Truth**: One clear way per task | Remove conflicting rules
+- Firebase: `~/serviceAccountKey.json` → `GOOGLE_APPLICATION_CREDENTIALS`
+- Python: Verify venv, run with `vpython`
+- Temp files: Use `mktemp`, never predictable `/tmp/` names
 
 ## Operations Guide
 
-### Memory MCP Usage
-**Create**: `mcp__memory-server__create_entities([{name, entityType, observations}])`
-**Search**: `mcp__memory-server__search_nodes("query")` → Find existing before creating
-**Pattern**: Search first → Create if new → Add observations to existing → Build relationships
+**Tool Hierarchy**: Serena MCP → Read/Grep → Edit → Bash (OS only)
 
-### Task Agent Patterns
-**⚠️ Token Cost**: Each agent loads ~50k+ tokens. See `.claude/commands/parallel-vs-subagents.md` for alternatives.
-**When to Spawn**: Complex workflows | Different directories | Long operations (>5 min)
-**When NOT to Spawn**: Simple searches | Independent file ops | Data gathering (<30s each)
-**Pattern**: `Task(description="Research X", prompt="Detailed instructions...")`
+**Test Execution**: DO NOT run `./run_tests.sh` without arguments. Use CI for full regression. Print evidence bundle path after testing_mcp tests.
 
-### TodoWrite Protocol
-**When Required**: Tasks with 3+ steps | Complex implementations | /execute commands
-**Status Flow**: `pending` → `in_progress` → `completed`
-**Update Pattern**: Mark current task `in_progress`, complete it, then move to next
-
-### Common Operations
-**Multi-file Edits**: Use MultiEdit with 3-4 edits max per call to avoid timeouts
-**Context Management**: Check remaining % before complex operations | Split large tasks
-**Tool Recovery**: After 2 failures → Try alternative tool → Fetch from main if corrupted
-
-### Context Optimization for Large PRs (🚨 MANDATORY)
-**When working on PRs with 50+ changed files**, follow these patterns to prevent context exhaustion:
-
-**1. Use Serena MCP Semantic Navigation** (PRIMARY):
-- ✅ `find_symbol` for specific functions/classes instead of reading entire files
-- ✅ `get_symbols_overview` to understand file structure before diving in
-- ✅ `search_for_pattern` with targeted regex instead of broad file reads
-- ❌ NEVER read entire files when you only need specific sections
-
-**2. Smart File Reading Patterns**:
-- ✅ Use `limit` and `offset` parameters for large files
-- ✅ Target specific line ranges based on comment references
-- ✅ Use Grep with `-A`/`-B` context flags for targeted reads
-- ❌ AVOID reading files multiple times in same session
-
-**3. API Response Management**:
-- ✅ Use `--json` flags with specific fields (e.g., `--json id,path,line`)
-- ✅ Process comments in batches with focused queries
-- ✅ Use `jq` or grep to filter API responses before processing
-- ❌ AVOID fetching full comment bodies when only IDs needed
-
-**4. PR Analysis Workflow**:
-```bash
-# Step 1: Get high-level PR structure
-gh pr view [PR] --json changedFiles --jq '.changedFiles | length'
-
-# Step 2: Use Serena for targeted symbol analysis
-mcp__serena__find_symbol --name_path "functionName" --relative_path "specific/file.py"
-
-# Step 3: Process comments in focused batches
-gh api repos/{owner}/{repo}/pulls/{pr}/comments --paginate --jq '.[].id'
-```
-
-**Anti-Pattern Example** (AVOID):
-```bash
-# ❌ Reading 50+ files completely
-for file in $(gh pr view --json files); do
-  Read --file_path "$file"  # Context killer!
-done
-```
-
-**Best Practice Example**:
-```bash
-# ✅ Targeted semantic navigation
-mcp__serena__search_for_pattern --pattern "console\\.error" --restrict_search_to_code_files true
-mcp__serena__find_symbol --name_path "ClassName/methodName" --include_body true
-```
-
-## Knowledge Management
-
-### Scratchpad Protocol (⚠️)
-`roadmap/scratchpad_[branch].md`: Goal | Plan | State | Next | Context | Branch info
-
-### File Organization
-- **CLAUDE.md**: Primary protocol
-- **lessons.mdc**: Technical learnings from corrections
-- **project.md**: Repository-specific knowledge base
-- **rules.mdc**: Cursor configuration
-
-### Process Improvement
-- **5 Whys**: Root cause → lessons.mdc
-- **Sync Cursor**: Copy CLAUDE.md to Cursor settings after changes
-- **Proactive Docs**: Update rules/lessons after debugging without prompting
-
-## Critical Lessons (Compressed)
-
-### Core Patterns
-**Trust But Verify**: Test before assuming | Docs ≠ code | Trace data flow | Critical instructions first
-
-### 🚨 Anti-Patterns
-**Silent Breaking Changes**: Update all str() usage when changing objects | Test backward compatibility
-**Unnecessary File Creation**: ❌ NEVER create new files when editing existing ones suffices
-**Branch Confusion**: Verify context before changes | Check PR destination
-**Orchestration Hardcoding**: ❌ NEVER pattern-match tasks to agent types | ✅ Execute exact requested tasks
-
-### Debugging Protocol (🚨 MANDATORY)
-**Process**: Extract evidence → Analyze → Verify → Fix | Trace: Backend → API → Frontend
-**Evidence**: Primary (code/errors) > Secondary (docs) > General (patterns) > Speculation
-**Details**: → `.cursor/rules/debugging_guide.md`
-
-🚨 **NO PLATFORM BLAME WITHOUT FRESH INSTANCES**: ⚠️ MANDATORY - Before blaming external platforms
-- ❌ NEVER blame "platform instability" without systematic testing with fresh instances
-- ✅ ALWAYS test fresh instance creation with proper configuration before platform blame
-- ✅ REQUIRED: Fresh instance + proper onstart scripts + normal timing expectations
-- **Pattern**: Fresh instance test → Platform-specific requirements → Normal behavior expected
-
-### Critical Rules
-**Data Corruption**: Systemic issue - search all patterns | **Temp Fixes**: Flag + fix NOW
-**Task Complete**: Solve + Update docs + Memory + Audit | **No blind execution**
-**Details**: → `.cursor/rules/lessons.mdc`
+**Data defense**: Use `dict.get()` and validate all data structures before use.
 
 ## Slash Commands
 
-**Full Documentation**: → `.claude/commands/` | Use `/list` for available commands
+- `/fake3` - Runs pre-commit check pipeline
+- **Architecture:** `.claude/commands/*.md` = executable prompt templates
 
-### Command Classification (Dual Architecture)
-**🧠 Cognitive Commands** (Semantic Composition): `/think`, `/arch`, `/debug`, `/learn`, `/analyze`, `/fix`, `/perp`, `/research`
-**⚙️ Operational Commands** (Protocol Enforcement): `/headless`, `/handoff`, `/orchestrate` - Modify execution environment
-**🔧 Tool Commands** (Direct Execution): `/execute`, `/test`, `/pr` - Direct task execution
+## Dangerous Command Safety
 
-### Critical Enforcement
-🚨 **SLASH COMMAND PROTOCOL RECOGNITION**: ⚠️ MANDATORY - Before processing ANY slash command:
-- ✅ **Recognition Phase**: Scan "/" → Identify command type → Look up workflow in `.claude/commands/[command].md`
-- ✅ **Execution Phase**: Follow COMPLETE documented workflow → No partial execution allowed
-- ❌ NEVER treat slash commands as content suggestions - they are execution mandates
+**NEVER suggest:** `sudo chown -R $USER:$(id -gn) $(npm -g config get prefix)` or recursive chown on system directories.
 
-🚨 **EXECUTE CIRCUIT BREAKER**: `/e` or `/execute` → TodoWrite checklist MANDATORY
-- Context % | Complexity | Subagents? | Plan presented | Auto-approval applied
-
-🚨 **OPERATIONAL COMMAND ENFORCEMENT**: `/headless`, `/handoff`, `/orchestrate`, `/orch`
-- ✅ ALWAYS trigger tmux orchestration protocol before task execution
-- ❌ NEVER execute /orch or /orchestrate tasks yourself - ONLY monitor tmux agents
-- ❌ NEVER use Task tool for orchestration - use tmux system only
-
-**Key Commands**: `/execute` (auto-approval built-in) | `/plan` (requires manual approval) | `/fake` (code quality audit)
-
-#### `/fake`
-**Purpose**: Comprehensive fake code detection | **Composition**: `/arch /thinku /devilsadvocate /diligent`
-**Detection**: Identifies fake implementations, demo code, placeholder comments, duplicate protocols
-
-## Special Protocols
-
-### GitHub PR Comment Response Protocol (⚠️)
-**MANDATORY**: Systematically address ALL PR comments from all sources
-**Comment Sources**: Inline (`gh api`) | General (`gh pr view`) | Reviews | Copilot (include "suppressed")
-**Response Status**: ✅ RESOLVED | 🔄 ACKNOWLEDGED | 📝 CLARIFICATION | ❌ DECLINED
-
-🚨 **DATA LOSS WARNINGS**: Treat all data loss warnings from CodeRabbit/Copilot as CRITICAL
-- ❌ NEVER dismiss data integrity concerns as "intentional design"
-- ✅ ALWAYS implement proper validation before conflict resolution
-
-### Import Protocol (🚨 CRITICAL)
-**Zero Tolerance**: Module-level only | No inline/try-except/conditionals | Use `as` for conflicts
-
-### API Error Prevention (🚨)
-❌ Print code/file content | ✅ Use file_path:line_number | Keep responses concise
-
-### Browser Testing vs HTTP Testing (🚨)
-**HARD RULE**: NO HTTP simulation for browser tests!
-- `/testuif` = Real browser automation (Puppeteer MCP/Playwright) | `/testi` = HTTP requests OK
-- Auth bypass: Use test mode URL params, NOT HTTP simulation
-
-### PR References (⚠️)
-**MANDATORY**: Include full GitHub URL - Format: "PR #123: https://github.com/jleechan2015/your-project.com/pull/123"
-
-### PR Description Protocol (⚠️ MANDATORY)
-**PR descriptions must reflect complete delta vs origin/main, not just recent work**:
-- ✅ Use `git diff --stat origin/main...HEAD` to get comprehensive change summary
-- ✅ Analyze actual file changes, additions, deletions vs main branch
-- ✅ Document all new features, systems, and architectural changes
-- ❌ NEVER describe only latest commits or recent work
-
-## Project-Specific
-
-### Flask: SPA route for index.html | Hard refresh for CSS/JS | Cache-bust in prod
-### Python: venv required | Source .bashrc after changes | May need python3-venv
-### AI/LLM: Detailed prompts crucial | Critical instructions first | Long prompts = fatigue
-### Workflow: Simple-first | Tool fail = try alternative | Main branch = recovery source
+**Safe npm fix:** `mkdir ~/.npm-global && npm config set prefix ~/.npm-global`
 
 ## Quick Reference
 
-- **Test**: `TESTING=true vpython $PROJECT_ROOT/test_file.py` (from root)
-- **Integration**: `TESTING=true python3 $PROJECT_ROOT/test_integration/test_integration.py`
-- **New Branch**: `./integrate.sh`
-- **All Tests**: `./run_tests.sh`
-- **Deploy**: `./deploy.sh` or `./deploy.sh stable`
-
-## Additional Documentation
-
-- **Technical Lessons**: → `.cursor/rules/lessons.mdc`
-- **Cursor Config**: → `.cursor/rules/rules.mdc`
-- **Examples**: → `.cursor/rules/examples.md`
-- **Commands**: → `.cursor/rules/validation_commands.md`
-
-### Archive Process
-Quarterly/2500 lines/new year → `lessons_archive_YYYY.mdc` | Keep critical patterns | Reference archives
-
-## API Timeout Prevention (🚨)
-
-**MANDATORY**: Prevent API timeouts:
-- **Edits**: MultiEdit with 3-4 max | Target sections, not whole files
-- **Thinking**: 5-6 thoughts max | Concise | No unnecessary branching
-- **Responses**: Bullet points | Minimal output | Essential info only
-- **Tools**: Batch calls | Smart search (Grep/Glob) | Avoid re-reads
-- **Complex tasks**: Split across messages | Monitor server load
-
-## AI-Assisted Development Protocols (🚨)
-
-### Development Velocity Benchmarks
-**Claude Code CLI Performance** (based on GitHub stats):
-- **Average**: 15.6 PRs/day, ~20K lines changed/day
-- **Peak**: 119 commits in single day
-- **Parallel Capacity**: 3-5 task agents simultaneously
-- **First-time-right**: 85% accuracy with proper specs
-
-### AI Development Planning (⚠️ MANDATORY)
-**All development timelines must use data-driven estimation**:
-- **Human estimate**: 3 weeks → **AI estimate**: 2-3 days
-- **Calculation Steps**:
-  1. Estimate lines of code (with 20% padding)
-  2. Apply velocity: 820 lines/hour average (excludes debugging, refactoring, and code review time)
-  3. Add PR overhead: 5-12 min per PR
-  4. Apply parallelism: 30-45% reduction
-- Use **30%** if tasks are highly independent and agents are experienced
-- Use **45%** if tasks are interdependent, agents are less experienced, or integration is complex
-  5. Add integration buffer: 10-30%
-- **Realistic multiplier**: 10-15x faster (not 20x)
-- **Avoid**: Anchoring bias from initial suggestions
-
-### Task Decomposition for AI Agents
-**Pattern for maximum efficiency**:
-```
-1. Break into independent, parallel tasks
-2. Each agent gets clear deliverable (1 PR)
-3. No inter-agent dependencies within phase
-4. Integration phase at end of each sprint
+```bash
+vpython $PROJECT_ROOT/test_file.py              # Single test
+./run_tests.sh $PROJECT_ROOT/tests/test_app.py  # Specific tests
+/fake3                                     # Pre-commit check
+./integrate.sh                             # New branch
+./deploy.sh [stable]                       # Deploy
 ```
 
-### AI Sprint Structure (1 Hour Sprint)
-**Phase 1 (15 min)**: Core functionality - 3-5 parallel agents
-**Phase 2 (15 min)**: Secondary features - 3-5 parallel agents
-**Phase 3 (15 min)**: Polish & testing - 2-3 parallel agents
-**Phase 4 (15 min)**: Integration & deploy - 1 agent
+## Skill Files Reference
 
-### Success Patterns from Stats
-- **Micro-PR workflow**: Each agent creates focused PR
-- **Continuous integration**: Merge every 15 minutes
-- **Test-driven**: Tests in parallel with features
-- **Architecture-first**: Design before parallel execution
+See `.claude/skills/`: `agents.md`, `llm-prompt-engineering.md`, `file-justification.md`, `code-centralization.md`, `integration-verification.md`, `testing-infrastructure.md`, `unified-logging.md`, `github-cli-reference.md`, `pr-workflow-manager.md`, `dice-authenticity-standards.md`
 
-### Anti-Patterns to Avoid
-- ❌ Sequential task chains (wastes AI parallelism)
-- ❌ Human-scale estimates (still too conservative)
-- ❌ Single large PR (harder to review/merge)
-- ❌ Waiting for perfection (iterate fast)
-- ❌ **Anchoring to user suggestions** (calculate independently)
-- ❌ **Over-optimistic estimates** (under 1 hour for major features)
-- ❌ **Ignoring PR overhead** (5-12 min per PR adds up)
-- ❌ **Assuming perfect parallelism** (45% max benefit)
+## Meta-Rules
+
+**Pre-action checkpoint:** Does this violate CLAUDE.md rules?
+**Write gate:** Search existing files → Attempt integration → Document why impossible

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ See [INSTALL.md](INSTALL.md) for detailed setup, troubleshooting, and platform-s
 
 **50 Hooks** for Claude Code automation and workflow optimization
 
-**26 Scripts** for development tools including git workflow, code analysis, testing, and CI/CD
+**27 Scripts** for development tools including git workflow, code analysis, testing, and CI/CD
 
-**77 Skills** providing shared knowledge references and capabilities
+**85 Skills** providing shared knowledge references and capabilities
 
 ## 🔍 Key Commands
 
@@ -219,10 +219,10 @@ See bottom of README for complete version history.
 ### Latest Release: v1.1.0 (2025-12-30)
 
 **Export Statistics**:
-- **230 Commands**: Complete workflow orchestration system
+- **235 Commands**: Complete workflow orchestration system
 - **50 Hooks**: Claude Code automation and workflow hooks
-- **26 Scripts**: Development and automation tools
-- **77 Skills**: Shared knowledge references
+- **27 Scripts**: Development and automation tools
+- **85 Skills**: Shared knowledge references
 
 **Recent Changes**:
 - Script allowlist expansion (12 additional development scripts)

--- a/automation/crontab.template
+++ b/automation/crontab.template
@@ -5,22 +5,22 @@ PATH=$HOME/.local/bin:$HOME/.pyenv/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/u
 # Do not edit manually - changes will be overwritten
 
 # [CRON-JOB-ID: pr-monitor] Run PR monitoring (comment-only mode) every 2 hours
-0 */2 * * * jleechanorg-pr-monitor-wrapper.sh --max-prs 10 >> $HOME/Library/Logs/worldarchitect-automation/jleechanorg_pr_monitor.log 2>&1
+0 */2 * * * jleechanorg-pr-monitor --max-prs 10 >> $HOME/Library/Logs/worldarchitect-automation/jleechanorg_pr_monitor.log 2>&1
 
 # [CRON-JOB-ID: fix-comment] Run fix-comment workflow with MiniMax every hour at :45
-45 * * * * jleechanorg-pr-monitor-wrapper.sh --fix-comment --cli-agent minimax,gemini,cursor --max-prs 3 >> $HOME/Library/Logs/worldarchitect-automation/minimax_fix_comment.log 2>&1
+45 * * * * jleechanorg-pr-monitor --fix-comment --cli-agent minimax --max-prs 3 >> $HOME/Library/Logs/worldarchitect-automation/minimax_fix_comment.log 2>&1
 
 # [CRON-JOB-ID: comment-validation] Run comment validation workflow every 30 minutes
-*/30 * * * * jleechanorg-pr-monitor-wrapper.sh --comment-validation --max-prs 10 >> $HOME/Library/Logs/worldarchitect-automation/comment_validation.log 2>&1
+*/30 * * * * jleechanorg-pr-monitor --comment-validation --max-prs 10 >> $HOME/Library/Logs/worldarchitect-automation/comment_validation.log 2>&1
 
 # [CRON-JOB-ID: codex-update] Run Codex automation every hour at :15
-15 * * * * jleechanorg-pr-monitor-wrapper.sh --codex-update --codex-task-limit 10 >> $HOME/Library/Logs/worldarchitect-automation/codex_automation.log 2>&1
+15 * * * * jleechanorg-pr-monitor --codex-update --codex-task-limit 10 >> $HOME/Library/Logs/worldarchitect-automation/codex_automation.log 2>&1
 
 # [CRON-JOB-ID: codex-api] Run Codex API automation every hour at :30
-30 * * * * jleechanorg-pr-monitor-wrapper.sh --codex-api --codex-apply-and-push --codex-task-limit 10 >> $HOME/Library/Logs/worldarchitect-automation/codex_automation_api.log 2>&1
+30 * * * * jleechanorg-pr-monitor --codex-api --codex-apply-and-push --codex-task-limit 10 >> $HOME/Library/Logs/worldarchitect-automation/codex_automation_api.log 2>&1
 
 # [CRON-JOB-ID: fixpr] Run orchestrated PR fixes every 30 minutes
-*/30 * * * * jleechanorg-pr-monitor-wrapper.sh --fixpr --max-prs 10 --cli-agent minimax,gemini,cursor >> $HOME/Library/Logs/worldarchitect-automation/jleechanorg_pr_monitor.log 2>&1
+*/30 * * * * jleechanorg-pr-monitor --fixpr --max-prs 10 --cli-agent minimax >> $HOME/Library/Logs/worldarchitect-automation/jleechanorg_pr_monitor.log 2>&1
 
 # Backup Claude conversations to Dropbox every 4 hours
 0 */4 * * * "$HOME/.local/bin/claude_backup_cron.sh" "$HOME/Library/CloudStorage/Dropbox" 2>&1

--- a/automation/install_cron_entries.sh
+++ b/automation/install_cron_entries.sh
@@ -2,18 +2,118 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CANONICAL_HOME="${CANONICAL_HOME:-}"
+
+canonical_home() {
+    local user candidate_home
+
+    user="${SUDO_USER:-${LOGNAME:-${USER:-$(id -un 2>/dev/null || true)}}}"
+
+    if [[ -n "$CANONICAL_HOME" ]]; then
+        echo "$CANONICAL_HOME"
+        return 0
+    fi
+
+    if [[ -n "$user" ]] && command -v dscl >/dev/null 2>&1; then
+        candidate_home="$(dscl . -read "/Users/$user" NFSHomeDirectory 2>/dev/null | awk '/NFSHomeDirectory/ {print $2}' | tail -n1)"
+        if [[ -n "$candidate_home" && -d "$candidate_home" ]]; then
+            echo "$candidate_home"
+            return 0
+        fi
+    fi
+
+    if [[ -n "$user" ]] && command -v getent >/dev/null 2>&1; then
+        candidate_home="$(getent passwd "$user" 2>/dev/null | awk -F: '{print $6}')"
+        if [[ -n "$candidate_home" && -d "$candidate_home" ]]; then
+            echo "$candidate_home"
+            return 0
+        fi
+    fi
+
+    echo "$HOME"
+}
+
+CANONICAL_HOME="$(canonical_home)"
+
+resolve_jleechanorg_pr_monitor() {
+    local candidate
+
+    candidate="$(type -P jleechanorg-pr-monitor 2>/dev/null || true)"
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+        echo "$candidate"
+        return 0
+    fi
+
+    for candidate in \
+        "$CANONICAL_HOME/.local/bin/jleechanorg-pr-monitor" \
+        "/opt/homebrew/bin/jleechanorg-pr-monitor" \
+        "/usr/local/bin/jleechanorg-pr-monitor" \
+        "/usr/bin/jleechanorg-pr-monitor" \
+        "/bin/jleechanorg-pr-monitor"; do
+        if [[ -x "$candidate" ]]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+
+    echo "jleechanorg-pr-monitor"
+}
+
+inject_resolved_monitor() {
+    local line="$1"
+
+    if [[ "$MONITOR_BINARY_PATH" == "jleechanorg-pr-monitor" ]]; then
+        echo "$line"
+        return 0
+    fi
+
+    echo "$line" | sed -E "s@(^|[[:space:]])\"?(jleechanorg-pr-monitor)\"?([[:space:]]|$)@\1$MONITOR_BINARY_PATH\3@g"
+}
+
 # Allow CRON_FILE to be overridden via environment variable
 CRON_FILE="${CRON_FILE:-$SCRIPT_DIR/crontab.template}"
-BACKUP_DIR="$HOME/.cron_backups"
+MONITOR_BINARY_PATH="$(resolve_jleechanorg_pr_monitor)"
+if [[ "$MONITOR_BINARY_PATH" == "jleechanorg-pr-monitor" ]]; then
+    echo "WARNING: could not resolve jleechanorg-pr-monitor to an absolute path; installed jobs will keep bare command name"
+else
+    echo "Resolved jleechanorg-pr-monitor to: $MONITOR_BINARY_PATH"
+fi
+
+BASHRC_PATH="${BASHRC_PATH:-$CANONICAL_HOME/.bashrc}"
+CRON_BASH_ENV_PATH="${CRON_BASH_ENV_PATH:-$CANONICAL_HOME/.codex/cron_bash_env.sh}"
+BACKUP_DIR="$CANONICAL_HOME/.cron_backups"
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RUN_EVERY_MINUTE="${CRON_RUN_EVERY_MINUTE:-0}"
 MANAGED_START="# === Automation entries (managed by install_cron_entries.sh) ==="
 MANAGED_END="# === End automation entries ==="
 
 expand_home_vars() {
     local value="$1"
-    value="${value//\$HOME/$HOME}"
-    value="${value//\$\{HOME\}/$HOME}"
+    value="${value//\$HOME/$CANONICAL_HOME}"
+    value="${value//\$\{HOME\}/$CANONICAL_HOME}"
     echo "$value"
+}
+
+ensure_cron_bash_env() {
+    local target="$1"
+    local target_dir
+
+    target_dir="$(dirname "$target")"
+    mkdir -p "$target_dir"
+
+    cat > "$target" <<EOF
+#!/bin/bash
+# Managed by install_cron_entries.sh (non-interactive cron bootstrap)
+if [ -f "$BASHRC_PATH" ]; then
+    source "$BASHRC_PATH"
+fi
+
+if [ -f "\$HOME/.nvm/nvm.sh" ]; then
+    # shellcheck disable=SC1091
+    source "\$HOME/.nvm/nvm.sh"
+fi
+EOF
+    chmod 600 "$target"
 }
 
 cron_job_core_signature() {
@@ -29,6 +129,10 @@ cron_job_core_signature() {
                 }
                 gsub(/^"/, "", token)
                 gsub(/"$/, "", token)
+                n = split(token, path_parts, "/")
+                if (n > 0 && path_parts[n] == "jleechanorg-pr-monitor") {
+                    token = "jleechanorg-pr-monitor"
+                }
                 cmd = cmd (cmd == "" ? "" : OFS) token
             }
             if (cmd != "") {
@@ -36,6 +140,29 @@ cron_job_core_signature() {
             }
         }
     '
+}
+
+is_standard_cron_schedule() {
+    local line="$1"
+    local f1 f2 f3 f4 f5 _
+    read -r f1 f2 f3 f4 f5 _ <<< "$line"
+
+    [[ -z "$f1" || -z "$f2" || -z "$f3" || -z "$f4" || -z "$f5" ]] && return 1
+
+    local token_re='^[0-9*/,-]+$'
+    [[ "$f1" =~ $token_re ]] && [[ "$f2" =~ $token_re ]] && [[ "$f3" =~ $token_re ]] && [[ "$f4" =~ $token_re ]] && [[ "$f5" =~ $token_re ]] && return 0
+    return 1
+}
+
+to_every_minute_schedule() {
+    local line="$1"
+    if [[ "$RUN_EVERY_MINUTE" == "1" ]]; then
+        if is_standard_cron_schedule "$line"; then
+            awk '{$1=$2=$3=$4=$5="*"; print}' <<< "$line"
+            return
+        fi
+    fi
+    echo "$line"
 }
 
 if ! command -v crontab >/dev/null 2>&1; then
@@ -61,6 +188,9 @@ fi
 echo "Backed up current crontab to $BACKUP_FILE"
 
 echo "=== Installing automation cron entries ==="
+if [[ "$RUN_EVERY_MINUTE" == "1" ]]; then
+    echo "Temporarily rewriting managed schedules to run every minute for test."
+fi
 
 TEMP_CRON=$(mktemp)
 trap 'rm -f "$TEMP_CRON"' EXIT
@@ -72,7 +202,7 @@ TEMPLATE_CORE_SIGNATURES=$(while IFS= read -r line || [[ -n "$line" ]]; do
     [[ "$line" =~ ^# ]] && continue
     [[ "$line" =~ ^PATH= ]] && continue
     expanded_line="$(expand_home_vars "$line")"
-    cron_job_core_signature "$expanded_line"
+    cron_job_core_signature "$(inject_resolved_monitor "$expanded_line")"
 done < "$CRON_FILE")
 
 # Get existing crontab - preserve ALL entries except automation ones
@@ -105,7 +235,7 @@ unclosed_block_signatures=""
         if [[ "$in_managed_block" -eq 1 ]]; then
             # Collect lines in case block is unclosed - these could be user entries
             unclosed_block_content+="$line"$'\n'
-            signature="$(cron_job_core_signature "$(expand_home_vars "$line")")"
+            signature="$(cron_job_core_signature "$(inject_resolved_monitor "$(expand_home_vars "$line")")")"
             if [[ -n "$signature" ]]; then
                 unclosed_block_signatures+="$signature"$'\n'
             fi
@@ -118,7 +248,7 @@ unclosed_block_signatures=""
         fi
         # Safely remove exact template-equivalent legacy lines.
         # This avoids duplicates while preserving custom variants outside managed block.
-        line_signature="$(cron_job_core_signature "$(expand_home_vars "$line")")"
+        line_signature="$(cron_job_core_signature "$(inject_resolved_monitor "$(expand_home_vars "$line")")")"
         if [[ -n "$line_signature" ]] && echo "$TEMPLATE_CORE_SIGNATURES" | grep -Fxq "$line_signature"; then
             continue
         fi
@@ -136,7 +266,7 @@ unclosed_block_signatures=""
                 echo ""
                 continue
             fi
-            preserved_signature="$(cron_job_core_signature "$(expand_home_vars "$preserved_line")")"
+            preserved_signature="$(cron_job_core_signature "$(inject_resolved_monitor "$(expand_home_vars "$preserved_line")")")"
             if [[ -n "$preserved_signature" ]] && echo "$TEMPLATE_CORE_SIGNATURES" | grep -Fxq "$preserved_signature"; then
                 continue
             fi
@@ -151,11 +281,22 @@ echo "" >> "$TEMP_CRON"
 # Add automation entries from template (with job IDs for future updates)
 echo "$MANAGED_START" >> "$TEMP_CRON"
 
+# Ensure cron runs managed jobs under Bash and loads a dedicated bootstrap that sources bashrc
+# and initializes NVM without relying on interactive-shell detection.
+echo "SHELL=/bin/bash" >> "$TEMP_CRON"
+ensure_cron_bash_env "$CRON_BASH_ENV_PATH"
+echo "BASH_ENV=$CRON_BASH_ENV_PATH" >> "$TEMP_CRON"
+
 # Always set managed PATH from template inside managed block.
 template_path=$(grep -m1 '^PATH=' "$CRON_FILE" || true)
 if [[ -n "$template_path" ]]; then
     echo "$(expand_home_vars "$template_path")" >> "$TEMP_CRON"
     echo "" >> "$TEMP_CRON"
+fi
+
+if [[ ! -f "$BASHRC_PATH" ]]; then
+    echo "=== WARNING: BASHRC not found at $BASHRC_PATH ==="
+    echo "Cron-managed commands will fall back to PATH from the template only."
 fi
 
 while IFS= read -r line || [[ -n "$line" ]]; do
@@ -169,23 +310,15 @@ while IFS= read -r line || [[ -n "$line" ]]; do
     [[ "$line" =~ ^PATH= ]] && continue
 
     # Preserve comments and entries from template to keep metadata in crontab.
-    echo "$line" >> "$TEMP_CRON"
+    expanded_line="$(expand_home_vars "$line")"
+    expanded_line="$(inject_resolved_monitor "$expanded_line")"
+    echo "$(to_every_minute_schedule "$expanded_line")" >> "$TEMP_CRON"
     if [[ "$line" =~ \[CRON-JOB-ID:[[:space:]]*([a-z][a-z0-9-]*)\] ]]; then
         echo "Updated: ${BASH_REMATCH[1]}"
     fi
 done < "$CRON_FILE"
 
 echo "$MANAGED_END" >> "$TEMP_CRON"
-
-# Install wrapper script to ~/.local/bin if it exists in the repo
-WRAPPER_SRC="$SCRIPT_DIR/jleechanorg-pr-monitor-wrapper.sh"
-WRAPPER_DST="$HOME/.local/bin/jleechanorg-pr-monitor-wrapper.sh"
-if [ -f "$WRAPPER_SRC" ]; then
-    mkdir -p "$HOME/.local/bin"
-    cp "$WRAPPER_SRC" "$WRAPPER_DST"
-    chmod +x "$WRAPPER_DST"
-    echo "=== Installed wrapper script to $WRAPPER_DST ==="
-fi
 
 # Warn if .automation_env is missing
 if [ ! -f "$HOME/.automation_env" ]; then

--- a/automation/jleechanorg_pr_automation/openai_automation/codex_cli_tasks.py
+++ b/automation/jleechanorg_pr_automation/openai_automation/codex_cli_tasks.py
@@ -14,6 +14,7 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+from jleechanorg_pr_automation.codex_config import build_automation_commit_marker
 from jleechanorg_pr_automation.orchestrated_pr_runner import ensure_base_clone
 from jleechanorg_pr_automation.utils import detect_repo_path, resolve_repo_full_from_environment_label, resolve_repo_path
 
@@ -511,7 +512,7 @@ class CodexCloudAPI:
             )
 
             # Git commit
-            commit_msg = f"""codex: {task_title}
+            commit_msg = f"""{build_automation_commit_marker("codex-api")} codex: {task_title}
 
 Applied from Codex Cloud task: {task_url}
 
@@ -848,7 +849,7 @@ Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>"""
 
             # Commit
             conflict_note = " (with conflicts - needs resolution)" if has_conflicts else ""
-            commit_msg = f"""codex: {task_title}{conflict_note}
+            commit_msg = f"""{build_automation_commit_marker("codex-api")} codex: {task_title}{conflict_note}
 
 Applied from Codex Cloud task: {task_url}
 

--- a/automation/jleechanorg_pr_automation/tests/test_codex_actor_matching.py
+++ b/automation/jleechanorg_pr_automation/tests/test_codex_actor_matching.py
@@ -132,6 +132,155 @@ class TestCodexActorMatching(unittest.TestCase):
         result = self.monitor._is_head_commit_from_codex(commit_details)
         self.assertFalse(result, "Should treat empty strings as no Codex markers")
 
+    # =========================================================================
+    # Tests for centralized workflow detection (fixcomment, fixpr, codex, etc.)
+    # These tests verify that ALL automation workflows are detected via commit messages
+    # =========================================================================
+
+    def test_detects_fixcomment_via_message_marker(self) -> None:
+        """Test that fixcomment workflow commits are detected via message marker."""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "regular-user",
+            "committer_email": "dev@example.com",
+            "committer_name": "Regular User",
+            "message_headline": "[fixcomment-automation-commit] Fix PR review comments",
+            "message": "Fix PR review comments and address feedback",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected fixcomment detection from commit message marker",
+        )
+
+    def test_detects_fixcomment_with_actor_via_message_marker(self) -> None:
+        """Test that fixcomment workflow commits with actor are detected."""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "claude-bot",
+            "committer_email": "claude@example.com",
+            "committer_name": "Claude Bot",
+            "message_headline": "[fixcomment claude-automation-commit] Fix PR review comments",
+            "message": "Fix PR review comments",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected fixcomment with actor detection from commit message marker",
+        )
+
+    def test_detects_fixpr_with_gemini_actor_via_message_marker(self) -> None:
+        """Test that fixpr workflow commits with gemini actor are detected."""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "gemini-bot",
+            "committer_email": "gemini@example.com",
+            "committer_name": "Gemini Bot",
+            "message_headline": "[fixpr gemini-automation-commit] Resolve conflicts",
+            "message": "Merge main to resolve conflicts",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected fixpr with gemini actor detection from commit message marker",
+        )
+
+    def test_detects_codex_with_cursor_actor_via_message_marker(self) -> None:
+        """Test that codex workflow commits with cursor actor are detected."""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "cursor-bot",
+            "committer_email": "cursor@example.com",
+            "committer_name": "Cursor Bot",
+            "message_headline": "[codex cursor-automation-commit] Update tests",
+            "message": "Update tests for new functionality",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected codex with cursor actor detection from commit message marker",
+        )
+
+    def test_detects_comment_validation_via_message_marker(self) -> None:
+        """Test that comment-validation workflow commits are detected via message marker."""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "regular-user",
+            "committer_email": "dev@example.com",
+            "committer_name": "Regular User",
+            "message_headline": "[comment-validation-automation-commit] Request reviews",
+            "message": "Request AI bot reviews on PR",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected comment-validation detection from commit message marker",
+        )
+
+    def test_detects_automation_via_message_body_not_headline(self) -> None:
+        """Test that automation markers in message body (not just headline) are detected."""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "regular-user",
+            "committer_email": "dev@example.com",
+            "committer_name": "Regular User",
+            "message_headline": "Update functionality",
+            "message": "Update functionality and fix issues [fixcomment-automation-commit]",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected detection from commit body marker",
+        )
+
+    def test_detects_coderabbitai_legacy_marker(self) -> None:
+        """Legacy compatibility: coderabbitai automation markers should still be recognized."""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "regular-user",
+            "committer_email": "dev@example.com",
+            "committer_name": "Regular User",
+            "message_headline": "[coderabbitai-automation-commit] Apply review fixes",
+            "message": "Apply review fixes",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected coderabbitai legacy marker detection",
+        )
+
+    def test_detects_fixpr_coderabbit_legacy_marker(self) -> None:
+        """Legacy compatibility: fixpr + coderabbit markers should still be recognized."""
+        commit_details = {
+            "author_login": "regular-user",
+            "author_email": "dev@example.com",
+            "author_name": "Regular User",
+            "committer_login": "regular-user",
+            "committer_email": "dev@example.com",
+            "committer_name": "Regular User",
+            "message_headline": "[fixpr coderabbit-automation-commit] Resolve conflicts",
+            "message": "Resolve conflicts",
+        }
+
+        self.assertTrue(
+            self.monitor._is_head_commit_from_codex(commit_details),
+            "Expected fixpr coderabbit legacy marker detection",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/automation/jleechanorg_pr_automation/tests/test_fix_pr_4276.py
+++ b/automation/jleechanorg_pr_automation/tests/test_fix_pr_4276.py
@@ -43,7 +43,7 @@ def test_dispatch_agent_includes_worktree_fix_and_push_refspec(tmp_path, monkeyp
     
     assert len(captured_desc) == 1
     desc = captured_desc[0]
-    local_branch = "fixpr_feature-test"
+    local_branch = "fixpr/feature/test"
     remote_branch = "feature/test"
     workspace_root = str(tmp_path / "repo")
     

--- a/automation/jleechanorg_pr_automation/tests/test_fixpr_prompt.py
+++ b/automation/jleechanorg_pr_automation/tests/test_fixpr_prompt.py
@@ -54,7 +54,7 @@ class TestFixprPrompt(unittest.TestCase):
         self.assertIn("params=", dispatcher.task_description, "Prompt should use params= for pagination")
 
     def test_fixpr_uses_local_branch_name_not_remote_branch(self):
-        """Test that fixpr uses local branch name fixpr_{remote_branch} instead of remote branch directly."""
+        """Test that fixpr uses local branch name fixpr/{remote_branch} instead of remote branch directly."""
         pr_payload = {
             "repo_full": "jleechanorg/worldarchitect.ai",
             "repo": "worldarchitect.ai",
@@ -73,8 +73,8 @@ class TestFixprPrompt(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIsNotNone(dispatcher.task_description)
 
-        # Local branch name should be fixpr_feature-add-cool-feature (sanitized)
-        expected_local_branch = "fixpr_feature-add-cool-feature"
+        # Local branch name should be fixpr/feature/add-cool-feature
+        expected_local_branch = "fixpr/feature/add-cool-feature"
 
         # Task description should use local branch for checkout
         self.assertIn(f"git checkout -B {expected_local_branch}", dispatcher.task_description,
@@ -112,8 +112,8 @@ class TestFixprPrompt(unittest.TestCase):
         self.assertTrue(ok)
         self.assertIsNotNone(dispatcher.task_description)
 
-        # Local branch name should be sanitized: fixpr_fix-bug-123-urgent
-        expected_local_branch = "fixpr_fix-bug-123-urgent"
+        # Local branch name should be sanitized: fixpr/fix/bug-123/urgent
+        expected_local_branch = "fixpr/fix/bug-123/urgent"
 
         # Should use local branch name
         self.assertIn(expected_local_branch, dispatcher.task_description,

--- a/automation/jleechanorg_pr_automation/tests/test_fixpr_return_value.py
+++ b/automation/jleechanorg_pr_automation/tests/test_fixpr_return_value.py
@@ -316,10 +316,11 @@ class TestFixprSkipsCleanPRs(unittest.TestCase):
         """
         Test that _process_pr_fixpr processes PRs with merge conflicts.
         """
-        # Mock CONFLICTING merge status
+        # Mock CONFLICTING merge status (GitHub API format)
         mock_result = MagicMock()
         mock_result.returncode = 0
-        mock_result.stdout = '{"mergeable": "CONFLICTING"}'
+        # GitHub API returns: mergeable=false (boolean), mergeableState="CONFLICTING" (string)
+        mock_result.stdout = '{"mergeable": false, "mergeableState": "CONFLICTING"}'
         mock_subprocess.return_value = mock_result
 
         # No failing checks (conflict alone should trigger processing)
@@ -398,6 +399,40 @@ class TestFixprAPIUnknownAndReprocess(unittest.TestCase):
         self.assertEqual(res, "posted")
         mock_dispatch.assert_called_once()
 
+    def test_fixpr_status_unknown_processes_when_gh_returns_nonzero(self):
+        """Non-zero gh returncode should be treated as unknown status, not clean."""
+        pr = self._base_pr()
+
+        with patch("jleechanorg_pr_automation.jleechanorg_pr_monitor.has_failing_checks", return_value=False):
+            mock_subprocess_result = SimpleNamespace(returncode=1, stdout="", stderr="fail")
+            with patch(
+                "jleechanorg_pr_automation.jleechanorg_pr_monitor.AutomationUtils.execute_subprocess_with_timeout",
+                return_value=mock_subprocess_result,
+            ):
+                with patch.object(self.monitor, "_should_skip_pr", return_value=False):
+                    with patch.object(self.monitor, "_get_pr_comment_state", return_value=("abc12345", [])):
+                        with patch("jleechanorg_pr_automation.jleechanorg_pr_monitor.ensure_base_clone", return_value="/tmp/fake/repo"):
+                            with patch("jleechanorg_pr_automation.jleechanorg_pr_monitor.chdir"):
+                                with patch("jleechanorg_pr_automation.jleechanorg_pr_monitor.TaskDispatcher"):
+                                    with patch(
+                                        "jleechanorg_pr_automation.jleechanorg_pr_monitor.dispatch_agent_for_pr",
+                                        return_value=True,
+                                    ) as mock_dispatch:
+                                        with patch.object(self.monitor, "_post_fixpr_queued", return_value=True):
+                                            with patch.object(self.monitor, "_record_processed_pr"):
+                                                with patch.object(self.monitor, "_cleanup_pending_reviews"):
+                                                    with patch.object(self.monitor, "_count_workflow_comments", return_value=0):
+                                                        res = self.monitor._process_pr_fixpr(
+                                                            "test/repo",
+                                                            123,
+                                                            pr,
+                                                            agent_cli="claude",
+                                                            model=None,
+                                                        )
+
+        self.assertEqual(res, "posted")
+        mock_dispatch.assert_called_once()
+
     def test_fixpr_status_unknown_skips_when_already_processed(self):
         pr = self._base_pr()
         
@@ -471,7 +506,8 @@ class TestFixprUsesCorrectDispatchFunction(unittest.TestCase):
 
         # Mock conflicting status so fixpr processes (doesn't skip)
         with patch("jleechanorg_pr_automation.jleechanorg_pr_monitor.has_failing_checks", return_value=False):
-            mock_subprocess_result = SimpleNamespace(returncode=0, stdout='{"mergeable":"CONFLICTING"}', stderr="")
+            # GitHub API returns: mergeable=false (boolean), mergeableState="CONFLICTING" (string)
+            mock_subprocess_result = SimpleNamespace(returncode=0, stdout='{"mergeable": false, "mergeableState": "CONFLICTING"}', stderr="")
             with patch("jleechanorg_pr_automation.jleechanorg_pr_monitor.AutomationUtils.execute_subprocess_with_timeout", return_value=mock_subprocess_result):
                 with patch.object(self.monitor, "_should_skip_pr", return_value=False):
                     with patch.object(self.monitor, "_get_pr_comment_state", return_value=("abc12345", [])):

--- a/automation/jleechanorg_pr_automation/tests/test_mergeable_conflict_detection.py
+++ b/automation/jleechanorg_pr_automation/tests/test_mergeable_conflict_detection.py
@@ -1,0 +1,114 @@
+"""
+Test for merge conflict detection in fixpr mode.
+
+GitHub API returns mergeable as Boolean (false = conflicts), not string.
+This test verifies the fix correctly handles Boolean mergeable values.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from automation.jleechanorg_pr_automation import jleechanorg_pr_monitor as mon
+
+
+class TestMergeableConflictDetection(unittest.TestCase):
+    """Test that fixpr correctly detects merge conflicts from GitHub API."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.monitor = mon.JleechanorgPRMonitor(automation_username="test-automation-user")
+
+    @patch.object(mon, "has_failing_checks", return_value=False)
+    def test_pr_with_mergeable_false_is_actionable(self, mock_failing):
+        """PR with mergeable=false (conflicts) should be marked actionable."""
+        # GitHub API returns mergeable as Boolean false when there are conflicts
+        sample_prs = [
+            {"repository": "repo/a", "number": 1, "title": "has conflicts", "mergeable": False},
+        ]
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=sample_prs):
+            actionable = self.monitor.list_actionable_prs(max_prs=10)
+
+        # Should be actionable because mergeable=False means conflicts
+        self.assertEqual(len(actionable), 1)
+        self.assertEqual(actionable[0]["number"], 1)
+
+    @patch.object(mon, "has_failing_checks", return_value=False)
+    def test_pr_with_mergeable_true_is_not_actionable(self, mock_failing):
+        """PR with mergeable=true (clean) should NOT be marked actionable."""
+        sample_prs = [
+            {"repository": "repo/a", "number": 2, "title": "clean PR", "mergeable": True},
+        ]
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=sample_prs):
+            actionable = self.monitor.list_actionable_prs(max_prs=10)
+
+        # Should NOT be actionable because mergeable=True means clean
+        self.assertEqual(len(actionable), 0)
+
+    @patch.object(mon, "has_failing_checks", return_value=False)
+    def test_pr_with_mergeable_null_is_not_actionable(self, mock_failing):
+        """PR with mergeable=null (unknown) should NOT be marked actionable."""
+        sample_prs = [
+            {"repository": "repo/a", "number": 3, "title": "unknown state", "mergeable": None},
+        ]
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=sample_prs):
+            actionable = self.monitor.list_actionable_prs(max_prs=10)
+
+        # Should NOT be actionable because mergeable=None means unknown
+        self.assertEqual(len(actionable), 0)
+
+    @patch.object(mon, "has_failing_checks", return_value=True)
+    def test_pr_with_failing_checks_is_actionable(self, mock_failing):
+        """PR with failing checks should be marked actionable regardless of mergeable."""
+        sample_prs = [
+            {"repository": "repo/a", "number": 4, "title": "failing checks", "mergeable": True},
+        ]
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=sample_prs):
+            actionable = self.monitor.list_actionable_prs(max_prs=10)
+
+        # Should be actionable because has failing checks
+        self.assertEqual(len(actionable), 1)
+        self.assertEqual(actionable[0]["number"], 4)
+
+    @patch.object(mon, "has_failing_checks", return_value=False)
+    def test_pr_with_mergeable_dirty_state_is_actionable(self, mock_failing):
+        """PR with mergeableState='dirty' should be marked actionable."""
+        # GitHub REST API can also return mergeableState as string "dirty"
+        sample_prs = [
+            {"repository": "repo/a", "number": 5, "title": "dirty state", "mergeableState": "dirty"},
+        ]
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=sample_prs):
+            actionable = self.monitor.list_actionable_prs(max_prs=10)
+
+        # Should be actionable because mergeableState="dirty" means conflicts
+        self.assertEqual(len(actionable), 1)
+        self.assertEqual(actionable[0]["number"], 5)
+
+    @patch.object(mon, "has_failing_checks", return_value=False)
+    def test_mixed_prs_filtered_correctly(self, mock_failing):
+        """Test that mixed PRs are filtered correctly."""
+        sample_prs = [
+            {"repository": "repo/a", "number": 1, "title": "conflicts", "mergeable": False},
+            {"repository": "repo/b", "number": 2, "title": "clean", "mergeable": True},
+            {"repository": "repo/c", "number": 3, "title": "failing", "mergeable": True},  # will have failing checks
+            {"repository": "repo/d", "number": 4, "title": "unknown", "mergeable": None},
+        ]
+
+        def fake_failing_checks(repo: str, pr_num: int) -> bool:
+            return pr_num == 3
+
+        with patch.object(self.monitor, "discover_open_prs", return_value=sample_prs), \
+             patch.object(mon, "has_failing_checks", fake_failing_checks):
+            actionable = self.monitor.list_actionable_prs(max_prs=10)
+
+        # Should have 2: #1 (conflicts) and #3 (failing checks)
+        self.assertEqual(len(actionable), 2)
+        self.assertEqual({pr["number"] for pr in actionable}, {1, 3})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/automation/pyproject.toml
+++ b/automation/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jleechanorg-pr-automation"
-version = "0.2.145"
+version = "0.2.157"
 description = "GitHub PR automation system with safety limits and actionable counting"
 authors = [
     { name = "jleechan", email = "jlee@jleechan.org" },
@@ -35,7 +35,7 @@ keywords = [
 requires-python = ">=3.11"
 dependencies = [
     "requests>=2.25.0",
-    "jleechanorg-orchestration>=0.1.18",
+    "jleechanorg-orchestration>=0.1.78",
     "playwright>=1.40.0",
     "playwright-stealth>=1.0.0",
     "aiohttp>=3.8.0",

--- a/automation/run_automation_cron_one_minute.sh
+++ b/automation/run_automation_cron_one_minute.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_SCRIPT="$SCRIPT_DIR/install_cron_entries.sh"
+RUN_MINUTES="${1:-1}"
+BACKUP_DIR="$HOME/.cron_backups"
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+BACKUP_FILE="$BACKUP_DIR/crontab_${TIMESTAMP}_one_minute_test.backup"
+CRONTAB_SNAPSHOT="$(mktemp)"
+
+if [[ ! "$RUN_MINUTES" =~ ^[0-9]+$ ]] || [[ "$RUN_MINUTES" -lt 1 ]]; then
+    echo "Usage: $0 [minutes]" >&2
+    echo "  minutes must be an integer >= 1" >&2
+    exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+CRONTAB_PRESENT=0
+if ! crontab -l >"$CRONTAB_SNAPSHOT" 2>&1; then
+    if ! grep -qi "no crontab for" "$CRONTAB_SNAPSHOT"; then
+        cat "$CRONTAB_SNAPSHOT" >&2
+        rm -f "$CRONTAB_SNAPSHOT"
+        echo "Failed to read current crontab" >&2
+        exit 1
+    fi
+    CRONTAB_PRESENT=0
+    rm -f "$CRONTAB_SNAPSHOT"
+else
+    mv "$CRONTAB_SNAPSHOT" "$BACKUP_FILE"
+    CRONTAB_PRESENT=1
+fi
+
+if [[ "$CRONTAB_PRESENT" -eq 0 ]]; then
+    echo "# No existing crontab" > "$BACKUP_FILE"
+fi
+
+restore_crontab() {
+    rm -f "$CRONTAB_SNAPSHOT"
+    echo
+    echo "Restoring original crontab from $BACKUP_FILE"
+    if [[ "$CRONTAB_PRESENT" -eq 1 ]]; then
+        if [[ -s "$BACKUP_FILE" ]]; then
+            crontab "$BACKUP_FILE"
+        else
+            crontab -r || true
+        fi
+    else
+        crontab -r || true
+    fi
+}
+trap restore_crontab EXIT
+
+chmod 600 "$BACKUP_FILE" 2>/dev/null || true
+echo "Backed up current crontab to $BACKUP_FILE"
+echo "Installing one-minute test schedule for managed automation jobs..."
+CRON_RUN_EVERY_MINUTE=1 "$INSTALL_SCRIPT"
+
+SECONDS_TO_WAIT=$(( (60 - 10#$(date +%S)) + (RUN_MINUTES * 60) ))
+if (( SECONDS_TO_WAIT < 70 )); then
+    SECONDS_TO_WAIT=70
+fi
+echo "Waiting $SECONDS_TO_WAIT seconds for jobs to run..."
+sleep "$SECONDS_TO_WAIT"
+echo "Test window complete. Restoring original crontab."

--- a/orchestration/hello.py
+++ b/orchestration/hello.py
@@ -1,0 +1,13 @@
+"""Simple hello module for pair programming session."""
+
+
+def say_hello(name: str = "World") -> str:
+    """Return a greeting message.
+
+    Args:
+        name: The name to greet
+
+    Returns:
+        A greeting string
+    """
+    return f"Hello, {name}!"

--- a/orchestration/pyproject.toml
+++ b/orchestration/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jleechanorg-orchestration"
-version = "0.1.63"
+version = "0.1.78"
 description = "AI Orchestration - tmux-based interactive AI CLI wrapper and multi-agent orchestration system"
 authors = [
     { name = "jleechan", email = "jlee@jleechan.org" },

--- a/orchestration/tests/test_cli_support.py
+++ b/orchestration/tests/test_cli_support.py
@@ -12,11 +12,18 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
-from orchestration.cli_validation import ValidationResult
+from orchestration.cli_validation import (
+    EXPECTED_VALIDATION_ANSWER,
+    ValidationResult,
+    _build_validation_answer_regex,
+    _normalize_validation_output_line,
+)
 from orchestration.task_dispatcher import (
     CLI_PROFILES,
     CURSOR_MODEL,
     GEMINI_MODEL,
+    apply_minimax_auth_env,
+    resolve_minimax_api_key,
     TaskDispatcher,
 )
 
@@ -137,6 +144,7 @@ class TestAgentCliSelection(unittest.TestCase):
         self.assertGreater(len(mock_write_text.call_args_list), 0)
         script_contents = mock_write_text.call_args_list[0][0][0]  # First positional arg is the content
         self.assertIn("codex exec --yolo", script_contents)
+        self.assertNotIn("--model ", script_contents)
         self.assertRegex(
             script_contents,
             r"< /tmp/agent_prompt_task-agent-codex-test[_0-9-]*\.txt",
@@ -680,6 +688,7 @@ class TestGeminiCliIntegration(unittest.TestCase):
             [
                 "ANTHROPIC_API_KEY",
                 "ANTHROPIC_BASE_URL",
+                "CLAUDECODE",
             ],
         )
         self.assertEqual(CLI_PROFILES["codex"]["env_unset"], ["OPENAI_API_KEY"])
@@ -689,6 +698,314 @@ class TestGeminiCliIntegration(unittest.TestCase):
     def test_claude_env_unset_preserves_auth_token(self):
         """Claude profile should preserve ANTHROPIC_AUTH_TOKEN for non-interactive auth."""
         self.assertNotIn("ANTHROPIC_AUTH_TOKEN", CLI_PROFILES["claude"]["env_unset"])
+
+    def test_claude_env_unset_includes_claudecode(self):
+        """Claude profile must unset CLAUDECODE to avoid nested-session guard when spawned from Claude Code."""
+        self.assertIn("CLAUDECODE", CLI_PROFILES["claude"]["env_unset"])
+
+class TestMinimaxCliEnvironment(unittest.TestCase):
+    """MiniMax uses claude CLI with MiniMax API endpoint — env isolation must be correct.
+
+    The minimax profile runs `claude --model MiniMax-M2.5 -p @prompt`.
+    When that subprocess is spawned from inside a Claude Code session, the parent's
+    CLAUDECODE env var is inherited and claude refuses to start:
+      'Claude Code cannot be launched inside another Claude Code session.'
+    CLAUDECODE must therefore be in env_unset so the preflight strips it.
+    """
+
+    def test_minimax_env_unset_includes_claudecode(self):
+        """MiniMax profile must unset CLAUDECODE so claude child avoids nested-session guard."""
+        self.assertIn(
+            "CLAUDECODE",
+            CLI_PROFILES["minimax"]["env_unset"],
+            "CLAUDECODE must be in minimax env_unset to prevent nested-session preflight failure",
+        )
+
+    def test_minimax_preflight_env_strips_claudecode(self):
+        """The env dict built for the minimax preflight subprocess must not contain CLAUDECODE.
+
+        Simulates jleechanorg_pr_monitor.py:1795:
+            env = {k: v for k, v in os.environ.items() if k not in profile.get('env_unset', [])}
+        """
+        profile = CLI_PROFILES["minimax"]
+        env_unset = profile.get("env_unset", [])
+        simulated_os_env = {
+            "PATH": "/usr/bin",
+            "HOME": "/Users/test",
+            "CLAUDECODE": "1",
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "ANTHROPIC_AUTH_TOKEN": "sk-ant-auth-test",
+            "MINIMAX_API_KEY": "sk-minimax-test",
+        }
+        preflight_env = {k: v for k, v in simulated_os_env.items() if k not in env_unset}
+        self.assertNotIn(
+            "CLAUDECODE",
+            preflight_env,
+            "CLAUDECODE must be stripped from preflight env to prevent nested-session error",
+        )
+
+    def test_minimax_preflight_env_strips_anthropic_keys(self):
+        """The preflight env must also strip both ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN."""
+        profile = CLI_PROFILES["minimax"]
+        env_unset = profile.get("env_unset", [])
+        simulated_os_env = {
+            "ANTHROPIC_API_KEY": "sk-ant-key",
+            "ANTHROPIC_AUTH_TOKEN": "sk-ant-auth",
+            "CLAUDECODE": "1",
+        }
+        preflight_env = {k: v for k, v in simulated_os_env.items() if k not in env_unset}
+        self.assertNotIn("ANTHROPIC_API_KEY", preflight_env)
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", preflight_env)
+
+    def test_minimax_binary_is_claude(self):
+        """MiniMax must use the claude binary (not a separate minimax binary)."""
+        self.assertEqual(CLI_PROFILES["minimax"]["binary"], "claude")
+
+    def test_minimax_env_set_points_to_minimax_endpoint(self):
+        """MiniMax env_set must redirect to MiniMax API proxy, not Anthropic."""
+        env_set = CLI_PROFILES["minimax"]["env_set"]
+        self.assertEqual(env_set["ANTHROPIC_BASE_URL"], "https://api.minimax.io/anthropic")
+
+
+class TestMinimaxAuthResolution(unittest.TestCase):
+    """MiniMax auth resolution should mirror the working local shell flow."""
+
+    def setUp(self):
+        self.dispatcher = TaskDispatcher()
+
+    def test_resolve_minimax_api_key_prefers_valid_env_key(self):
+        valid_key = "sk-env-key-1234567890"
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": valid_key}, clear=True):
+            self.assertEqual(resolve_minimax_api_key(), valid_key)
+
+    def test_resolve_minimax_api_key_falls_back_to_bashrc_when_env_invalid(self):
+        fallback_key = "sk-bashrc-key-1234567890"
+        with (
+            patch.dict(os.environ, {"MINIMAX_API_KEY": "not-a-real-key"}, clear=True),
+            patch("orchestration.task_dispatcher._read_exported_shell_var") as mock_read_shell_var,
+        ):
+            mock_read_shell_var.side_effect = [fallback_key, ""]
+            self.assertEqual(resolve_minimax_api_key(), fallback_key)
+
+    def test_resolve_minimax_api_key_does_not_use_anthropic_keys(self):
+        """Anthropic API keys must never be returned as MiniMax keys (credential leak)."""
+        anthropic_key = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz123456"
+        with (
+            patch.dict(
+                os.environ,
+                {"ANTHROPIC_API_KEY": anthropic_key, "ANTHROPIC_AUTH_TOKEN": anthropic_key},
+                clear=True,
+            ),
+            patch("orchestration.task_dispatcher._read_exported_shell_var", return_value=""),
+        ):
+            result = resolve_minimax_api_key()
+            self.assertNotEqual(result, anthropic_key, "Anthropic API key must not be used as MiniMax key")
+            self.assertEqual(result, "", "Should return empty string when no MiniMax key is available")
+
+    def test_resolve_minimax_api_key_rejects_anthropic_key_in_minimax_var(self):
+        """Anthropic-format sk-ant-... keys must be rejected even if stored in MINIMAX_API_KEY."""
+        anthropic_key = "sk-ant-api03-abcdefghijklmnopqrstuvwxyz123456"
+        with (
+            patch.dict(os.environ, {"MINIMAX_API_KEY": anthropic_key}, clear=True),
+            patch("orchestration.task_dispatcher._read_exported_shell_var", return_value=""),
+        ):
+            result = resolve_minimax_api_key()
+            self.assertEqual(result, "", "Anthropic sk-ant- key must be rejected even when set as MINIMAX_API_KEY")
+
+    def test_resolve_minimax_api_key_accepts_valid_minimax_format(self):
+        """Valid non-Anthropic sk- keys should be accepted."""
+        valid_key = "sk-mm-1234567890abc"
+        with (
+            patch.dict(os.environ, {"MINIMAX_API_KEY": valid_key}, clear=True),
+            patch("orchestration.task_dispatcher._read_exported_shell_var", return_value=""),
+        ):
+            self.assertEqual(resolve_minimax_api_key(), valid_key)
+
+    def test_apply_minimax_auth_env_sets_both_anthropic_keys(self):
+        minimax_key = "sk-auth-key-1234567890"
+        with patch("orchestration.task_dispatcher.resolve_minimax_api_key", return_value=minimax_key):
+            env = {}
+            updated = apply_minimax_auth_env(env)
+
+        self.assertIs(updated, env)
+        self.assertEqual(updated["ANTHROPIC_API_KEY"], minimax_key)
+        self.assertEqual(updated["ANTHROPIC_AUTH_TOKEN"], minimax_key)
+
+    def test_minimax_command_uses_token_env_placeholder(self):
+        agent_spec = {
+            "name": "task-agent-minimax-secret-test",
+            "focus": "Validate MiniMax token handling",
+            "prompt": "Do the work",
+            "capabilities": [],
+            "type": "development",
+            "cli": "minimax",
+        }
+        minimax_key = "sk-auth-key-1234567890"
+
+        with (
+            patch.object(self.dispatcher, "_cleanup_stale_prompt_files"),
+            patch.object(self.dispatcher, "_get_active_tmux_agents", return_value=set()),
+            patch.object(self.dispatcher, "_print_tmp_subdirectories"),
+            patch.object(
+                self.dispatcher,
+                "_create_worktree_at_location",
+                return_value=(
+                    "/tmp/task-agent-minimax-secret-test",
+                    MagicMock(returncode=0, stderr=""),
+                ),
+            ),
+            patch("os.makedirs"),
+            patch("os.chmod"),
+            patch("builtins.open", mock_open()),
+            patch("os.path.exists", return_value=False),
+            patch("orchestration.task_dispatcher.Path.write_text") as mock_write_text,
+            patch("orchestration.task_dispatcher.subprocess.run") as mock_run,
+            patch("orchestration.task_dispatcher.shutil.which") as mock_which,
+            patch.object(self.dispatcher, "_validate_cli_availability", return_value=True),
+            patch("orchestration.task_dispatcher.resolve_minimax_api_key", return_value=minimax_key),
+        ):
+
+            def which_side_effect(command):
+                known_binaries = {
+                    "claude": "/usr/bin/claude",
+                    "tmux": "/usr/bin/tmux",
+                }
+                return known_binaries.get(command)
+
+            mock_which.side_effect = which_side_effect
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = self.dispatcher.create_dynamic_agent(agent_spec)
+
+        self.assertTrue(result)
+        self.assertGreater(len(mock_write_text.call_args_list), 0)
+        script_contents = mock_write_text.call_args_list[0][0][0]
+        self.assertIn('export ANTHROPIC_AUTH_TOKEN="${MINIMAX_AUTH_TOKEN}"', script_contents)
+        self.assertIn('export ANTHROPIC_API_KEY="${MINIMAX_AUTH_TOKEN}"', script_contents)
+        self.assertNotIn(minimax_key, script_contents)
+
+        run_kwargs = mock_run.call_args.kwargs
+        self.assertIn("env", run_kwargs)
+        self.assertEqual(run_kwargs["env"].get("MINIMAX_AUTH_TOKEN"), minimax_key)
+
+    def test_non_minimax_cli_path_does_not_inject_minimax_placeholder(self):
+        agent_spec = {
+            "name": "task-agent-non-minimax-path-test",
+            "focus": "Ensure non-minimax CLI path unchanged",
+            "prompt": "Do the work",
+            "capabilities": [],
+            "type": "development",
+            "cli": "codex",
+        }
+
+        with (
+            patch.object(self.dispatcher, "_cleanup_stale_prompt_files"),
+            patch.object(self.dispatcher, "_get_active_tmux_agents", return_value=set()),
+            patch.object(self.dispatcher, "_print_tmp_subdirectories"),
+            patch.object(
+                self.dispatcher,
+                "_create_worktree_at_location",
+                return_value=(
+                    "/tmp/task-agent-non-minimax-path-test",
+                    MagicMock(returncode=0, stderr=""),
+                ),
+            ),
+            patch("os.makedirs"),
+            patch("os.chmod"),
+            patch("builtins.open", mock_open()),
+            patch("os.path.exists", return_value=False),
+            patch("orchestration.task_dispatcher.Path.write_text") as mock_write_text,
+            patch("orchestration.task_dispatcher.subprocess.run") as mock_run,
+            patch("orchestration.task_dispatcher.shutil.which") as mock_which,
+            patch.object(self.dispatcher, "_validate_cli_availability", return_value=True),
+            patch("orchestration.task_dispatcher.resolve_minimax_api_key", return_value="sk-auth-key-1234567890"),
+        ):
+
+            def which_side_effect(command):
+                known_binaries = {
+                    "codex": "/usr/bin/codex",
+                    "tmux": "/usr/bin/tmux",
+                }
+                return known_binaries.get(command)
+
+            mock_which.side_effect = which_side_effect
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = self.dispatcher.create_dynamic_agent(agent_spec)
+
+        self.assertTrue(result)
+        self.assertGreater(len(mock_write_text.call_args_list), 0)
+        script_contents = mock_write_text.call_args_list[0][0][0]
+        self.assertIn("codex exec --yolo", script_contents)
+        self.assertNotIn("MINIMAX_AUTH_TOKEN", script_contents)
+
+    def test_cli_chain_clears_minimax_env_before_non_minimax_fallback(self):
+        """MiniMax env vars must be unset before non-MiniMax fallback attempts."""
+        agent_spec = {
+            "name": "task-agent-minimax-fallback-test",
+            "focus": "Validate cleanup between CLI attempts",
+            "prompt": "Do the work",
+            "capabilities": [],
+            "type": "development",
+            "cli": "minimax",
+            "cli_chain": ["minimax", "codex"],
+        }
+        minimax_key = "sk-auth-key-1234567890"
+
+        with (
+            patch.object(self.dispatcher, "_cleanup_stale_prompt_files"),
+            patch.object(self.dispatcher, "_get_active_tmux_agents", return_value=set()),
+            patch.object(self.dispatcher, "_print_tmp_subdirectories"),
+            patch.object(
+                self.dispatcher,
+                "_create_worktree_at_location",
+                return_value=(
+                    "/tmp/task-agent-minimax-fallback-test",
+                    MagicMock(returncode=0, stderr=""),
+                ),
+            ),
+            patch("os.makedirs"),
+            patch("os.chmod"),
+            patch("builtins.open", mock_open()),
+            patch("os.path.exists", return_value=False),
+            patch("orchestration.task_dispatcher.Path.write_text") as mock_write_text,
+            patch("orchestration.task_dispatcher.subprocess.run") as mock_run,
+            patch("orchestration.task_dispatcher.shutil.which") as mock_which,
+            patch.object(self.dispatcher, "_validate_cli_availability", return_value=True),
+            patch("orchestration.task_dispatcher.resolve_minimax_api_key", return_value=minimax_key),
+        ):
+
+            def which_side_effect(command):
+                known_binaries = {
+                    "codex": "/usr/bin/codex",
+                    "claude": "/usr/bin/claude",
+                    "tmux": "/usr/bin/tmux",
+                }
+                return known_binaries.get(command)
+
+            mock_which.side_effect = which_side_effect
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+
+            result = self.dispatcher.create_dynamic_agent(agent_spec)
+
+        self.assertTrue(result)
+        self.assertGreater(len(mock_write_text.call_args_list), 0)
+        script_contents = mock_write_text.call_args_list[0][0][0]
+
+        attempt2_idx = script_contents.find("ATTEMPT_NUM=2")
+        self.assertNotEqual(attempt2_idx, -1)
+        attempt2_block = script_contents[attempt2_idx : attempt2_idx + 1200]
+        self.assertIn("ATTEMPT_CLI=codex", attempt2_block)
+        self.assertIn("unset ANTHROPIC_BASE_URL 2>/dev/null || true", attempt2_block)
+        self.assertIn("unset ANTHROPIC_AUTH_TOKEN 2>/dev/null || true", attempt2_block)
+        self.assertIn("unset ANTHROPIC_API_KEY 2>/dev/null || true", attempt2_block)
+
+    def test_resolve_minimax_api_key_rejects_invalid_candidates(self):
+        with (
+            patch.dict(os.environ, {"MINIMAX_API_KEY": "bad-key", "OTHER_ENV": "also-bad"}, clear=True),
+            patch("orchestration.task_dispatcher._read_exported_shell_var", return_value="still-bad"),
+        ):
+            self.assertEqual(resolve_minimax_api_key(), "")
 
 
 class TestCursorCliIntegration(unittest.TestCase):
@@ -1052,6 +1369,26 @@ class TestCliValidation(unittest.TestCase):
             result = self.dispatcher._validate_cli_availability("codex", "/usr/bin/codex", "test-agent")
             self.assertFalse(result)
 
+    def test_codex_validation_omits_model_when_unspecified(self):
+        """Codex preflight should omit explicit --model when no model is provided."""
+        with patch("orchestration.task_dispatcher.validate_cli_two_phase") as mock_validate:
+            mock_validate.return_value = ValidationResult(
+                success=True,
+                phase="execution",
+                message="codex execution test passed",
+            )
+            result = self.dispatcher._validate_cli_availability(
+                "codex",
+                "/usr/bin/codex",
+                "test-agent",
+                model=None,
+            )
+
+            self.assertTrue(result)
+            call_args = mock_validate.call_args
+            execution_cmd = call_args[1].get("execution_cmd", call_args[0][3] if len(call_args[0]) > 3 else [])
+            self.assertEqual(execution_cmd, ["exec", "--yolo", "--skip-git-repo-check"])
+
     def test_claude_validation_success_with_executable(self):
         """Claude validation should succeed when binary is executable and can write output."""
         with (
@@ -1186,40 +1523,47 @@ class TestCliValidation(unittest.TestCase):
                     f"Cursor validation should have MCP handling flag, got: {execution_cmd}")
 
     def test_strict_answer_matching_avoids_false_positives(self):
-        """Verify that '4' matching doesn't match HTTP 429, dates, or timestamps."""
-        # The regex used in cli_validation.py: r'(?<![0-9])4(?![0-9])'
-        strict_match_pattern = r'(?<![0-9])4(?![0-9])'
+        """Verify strict answer matching avoids false positives from numbers and dates."""
+        strict_match_pattern = _build_validation_answer_regex()
 
         # These should NOT match (false positives we want to avoid)
-        # Each case has "4" embedded in a number context where it should NOT be detected
+        # Ensure we only match the full answer when it is bounded by non-digit characters.
         false_positive_cases = [
-            ("HTTP 429 Too Many Requests", "429 rate limit"),
-            ("Error code: 429", "429 error code"),
-            ("2024-01-31", "year in date"),
-            ("14:30:00", "hour in timestamp"),
-            ("Quota: 14/100", "14 in quota"),
-            ("Rate limit: retry in 45 seconds", "45 seconds"),
-            ("Error 0x00000004", "hex code"),
+            (
+                f"prefix-{EXPECTED_VALIDATION_ANSWER}0-suffix",
+                "expected answer with trailing digit",
+            ),
+            (
+                f"prefix-0{EXPECTED_VALIDATION_ANSWER}-suffix",
+                "expected answer with leading digit",
+            ),
+            (
+                f"prefix-{EXPECTED_VALIDATION_ANSWER}99- suffix",
+                "expected answer followed by extra digits",
+            ),
+            (
+                f"prefix-11{EXPECTED_VALIDATION_ANSWER}22-suffix",
+                "expected answer nested inside larger digit token",
+            ),
         ]
 
         for case, description in false_positive_cases:
-            match = re.search(strict_match_pattern, case)
+            match = strict_match_pattern.search(case)
             self.assertIsNone(match, f"Should NOT match {description}: '{case}'")
 
-        # These SHOULD match (valid answers to 2+2)
+        # These SHOULD match (valid answers to the configured validation prompt)
+        # Note: The regex matches normalized answer, so we normalize before matching
         valid_cases = [
-            "4",              # Just the answer
-            "4.",             # With period
-            "The answer is 4",  # Sentence
-            "2+2=4",          # Equation
-            "Result: 4",      # Label
-            "   4   ",        # Whitespace
-            "4\n",            # Newline
+            EXPECTED_VALIDATION_ANSWER,  # Just the answer
+            f"{int(EXPECTED_VALIDATION_ANSWER):,}",  # Comma grouped
+            f"{int(EXPECTED_VALIDATION_ANSWER):_}",  # Underscore grouped
+            EXPECTED_VALIDATION_ANSWER,  # Exact canonical form
         ]
 
         for case in valid_cases:
-            match = re.search(strict_match_pattern, case)
-            self.assertIsNotNone(match, f"Valid answer should match: {case}")
+            normalized = _normalize_validation_output_line(case)
+            match = strict_match_pattern.fullmatch(normalized)
+            self.assertIsNotNone(match, f"Valid answer should match: '{case}' -> normalized: '{normalized}'")
 
 
 class TestAgentCreationWithValidation(unittest.TestCase):

--- a/orchestration/tests/test_hello.py
+++ b/orchestration/tests/test_hello.py
@@ -1,0 +1,24 @@
+"""Tests for hello module."""
+
+import pytest
+
+from orchestration.hello import say_hello
+
+
+class TestSayHello:
+    """Test cases for say_hello function."""
+
+    def test_say_hello_default(self):
+        """Test hello with default name."""
+        result = say_hello()
+        assert result == "Hello, World!"
+
+    def test_say_hello_with_name(self):
+        """Test hello with custom name."""
+        result = say_hello("Alice")
+        assert result == "Hello, Alice!"
+
+    def test_say_hello_returns_string(self):
+        """Test that result is a string."""
+        result = say_hello()
+        assert isinstance(result, str)

--- a/orchestration/tests/test_pairv2_harness.py
+++ b/orchestration/tests/test_pairv2_harness.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Test for harness pairv2 test task verification"""
+
+
+def test_harness_pairv2_responds():
+    """Test that verifies pairv2 harness responds correctly"""
+    # Simple test to verify the harness responds to ping
+    result = True
+    assert result is True, "Harness should respond"
+
+
+def test_coder_implementation():
+    """Test that verifies coder can implement features"""
+    # Simulate coder implementation check
+    implemented = True
+    assert implemented is True, "Coder should implement features"
+
+
+def test_verifier_can_verify():
+    """Test that verifier can verify implementation"""
+    # Simulate verification check
+    verified = True
+    assert verified is True, "Verifier should verify correctly"
+
+
+if __name__ == "__main__":
+    test_harness_pairv2_responds()
+    test_coder_implementation()
+    test_verifier_can_verify()
+    print("All harness tests passed!")

--- a/orchestration/tests/test_task_dispatcher_fix.py
+++ b/orchestration/tests/test_task_dispatcher_fix.py
@@ -357,6 +357,50 @@ class TestTaskDispatcherFix(unittest.TestCase):
         self.assertEqual(second_cmd[:3], ["git", "worktree", "add"])
         self.assertIn("/tmp/orchestration_worktrees/orch_repo/retry-agent-abc123", second_cmd)
 
+    def test_build_worktree_command_skips_b_flag_when_branch_already_exists(self):
+        """When create_new_branch=True but branch already exists (from partial failure), omit -b."""
+        with patch.object(self.dispatcher, "_branch_exists", return_value=True):
+            cmd = self.dispatcher._build_worktree_add_command(
+                agent_dir="/tmp/test-agent",
+                branch_name="fix/my-branch",
+                base_ref="main",
+                create_new_branch=True,
+            )
+
+        # Should NOT use -b since branch already exists
+        self.assertNotIn("-b", cmd)
+        self.assertEqual(cmd, ["git", "worktree", "add", "/tmp/test-agent", "fix/my-branch"])
+
+    def test_build_worktree_command_resets_existing_branch_when_base_ref_mismatch(self):
+        """When existing branch matches create_new_branch but stale base, force-reset it with -B."""
+        with (
+            patch.object(self.dispatcher, "_branch_exists", return_value=True),
+            patch.object(self.dispatcher, "_branch_matches_base_ref", return_value=False),
+        ):
+            cmd = self.dispatcher._build_worktree_add_command(
+                agent_dir="/tmp/test-agent",
+                branch_name="fix/my-branch",
+                base_ref="main",
+                create_new_branch=True,
+            )
+
+        self.assertEqual(
+            cmd,
+            ["git", "worktree", "add", "-B", "fix/my-branch", "/tmp/test-agent", "main"],
+        )
+
+    def test_build_worktree_command_uses_b_flag_for_new_branch(self):
+        """When create_new_branch=True and branch does not exist, use -b."""
+        with patch.object(self.dispatcher, "_branch_exists", return_value=False):
+            cmd = self.dispatcher._build_worktree_add_command(
+                agent_dir="/tmp/test-agent",
+                branch_name="fix/new-branch",
+                base_ref="main",
+                create_new_branch=True,
+            )
+
+        self.assertEqual(cmd, ["git", "worktree", "add", "-b", "fix/new-branch", "/tmp/test-agent", "main"])
+
     def test_create_worktree_skips_tmp_retry_for_non_path_errors(self):
         """Non-path git failures should not trigger /tmp retry."""
         failure_result = MagicMock(returncode=128, stderr="fatal: not a valid object name: 'main'")
@@ -365,6 +409,7 @@ class TestTaskDispatcherFix(unittest.TestCase):
             patch.object(self.dispatcher, "_calculate_agent_directory", return_value="/Users/test/orch/retry-agent"),
             patch.object(self.dispatcher, "_ensure_directory_exists"),
             patch.object(self.dispatcher, "_create_tmp_worktree_directory") as mock_tmp_dir,
+            patch.object(self.dispatcher, "_branch_exists", return_value=False),
             patch("orchestration.task_dispatcher.subprocess.run") as mock_run,
         ):
             mock_run.return_value = failure_result
@@ -378,6 +423,112 @@ class TestTaskDispatcherFix(unittest.TestCase):
         self.assertEqual(result.returncode, 128)
         self.assertEqual(mock_run.call_count, 1)
         mock_tmp_dir.assert_not_called()
+
+    def test_create_worktree_with_existing_local_branch_uses_local_checkout(self):
+        """Existing local branches should be added directly without creating a new branch."""
+        branch_name = "feature/local-branch"
+
+        with (
+            patch.object(self.dispatcher, "_calculate_agent_directory", return_value="/Users/test/orch/local-agent"),
+            patch.object(self.dispatcher, "_ensure_directory_exists"),
+            patch.object(self.dispatcher, "_branch_exists", return_value=True),
+            patch("orchestration.task_dispatcher.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            agent_dir, result = self.dispatcher._create_worktree_at_location(
+                {"name": "local-agent"},
+                branch_name,
+                create_new_branch=False,
+            )
+
+        self.assertEqual(agent_dir, "/Users/test/orch/local-agent")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(mock_run.call_args[0][0], [
+            "git",
+            "worktree",
+            "add",
+            "/Users/test/orch/local-agent",
+            branch_name,
+        ])
+
+    def test_create_worktree_with_existing_remote_branch_creates_local_tracking_branch(self):
+        """Remote-only existing branches should be checked out as local tracking branches."""
+        branch_name = "feature/remote-branch"
+
+        with (
+            patch.object(self.dispatcher, "_calculate_agent_directory", return_value="/Users/test/orch/remote-agent"),
+            patch.object(self.dispatcher, "_ensure_directory_exists"),
+            patch.object(self.dispatcher, "_branch_exists", return_value=False),
+            patch.object(self.dispatcher, "_remote_branch_exists", return_value=True),
+            patch("orchestration.task_dispatcher.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+            agent_dir, result = self.dispatcher._create_worktree_at_location(
+                {"name": "remote-agent"},
+                branch_name,
+                create_new_branch=False,
+            )
+
+        self.assertEqual(agent_dir, "/Users/test/orch/remote-agent")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(mock_run.call_args[0][0], [
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            "/Users/test/orch/remote-agent",
+            f"origin/{branch_name}",
+        ])
+
+    def test_create_worktree_retries_in_tmp_directory_with_remote_existing_branch(self):
+        """Retry path should preserve remote-branch tracking when default location fails."""
+        branch_name = "feature/remote-branch"
+
+        with (
+            patch.object(self.dispatcher, "_calculate_agent_directory", return_value="/Users/test/orch/remote-agent"),
+            patch.object(self.dispatcher, "_ensure_directory_exists"),
+            patch.object(
+                self.dispatcher,
+                "_create_tmp_worktree_directory",
+                return_value="/tmp/orchestration_worktrees/orch_repo/remote-agent-abc123",
+            ),
+            patch.object(self.dispatcher, "_branch_exists", return_value=False),
+            patch.object(self.dispatcher, "_remote_branch_exists", return_value=True),
+            patch("orchestration.task_dispatcher.subprocess.run") as mock_run,
+        ):
+            mock_run.side_effect = [
+                MagicMock(returncode=128, stderr="fatal: Permission denied"),
+                MagicMock(returncode=0, stdout="", stderr=""),
+            ]
+            agent_dir, result = self.dispatcher._create_worktree_at_location(
+                {"name": "remote-agent"},
+                branch_name,
+                create_new_branch=False,
+            )
+
+        self.assertEqual(agent_dir, "/tmp/orchestration_worktrees/orch_repo/remote-agent-abc123")
+        self.assertEqual(result.returncode, 0)
+        first_cmd = mock_run.call_args_list[0][0][0]
+        second_cmd = mock_run.call_args_list[1][0][0]
+        self.assertEqual(first_cmd, [
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            "/Users/test/orch/remote-agent",
+            f"origin/{branch_name}",
+        ])
+        self.assertEqual(second_cmd, [
+            "git",
+            "worktree",
+            "add",
+            "-b",
+            branch_name,
+            "/tmp/orchestration_worktrees/orch_repo/remote-agent-abc123",
+            f"origin/{branch_name}",
+        ])
 
     def test_create_worktree_cleans_tmp_dir_when_retry_fails(self):
         """Temporary fallback directory should be cleaned up when retry also fails."""

--- a/scripts/integrate.sh
+++ b/scripts/integrate.sh
@@ -48,6 +48,10 @@ YELLOW='\033[0;33m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
 
+# Absolute path to git hooks dir — used to bypass Husky during scripted checkouts
+# (relative paths in -c core.hooksPath can misbehave when invoked from a subdirectory)
+GIT_HOOKS_PATH="$(git rev-parse --show-toplevel)/.git/hooks"
+
 # Function to detect if commits were squash-merged into origin/main
 detect_squash_merged_commits() {
     local commit_count=$1
@@ -75,7 +79,7 @@ detect_squash_merged_commits() {
             # Search for similar commit message in recent origin/main commits (configurable depth)
             local search_depth="${DETECT_SQUASH_SEARCH_DEPTH:-200}"
             local similar_commit
-            similar_commit=$(git log origin/main --oneline "-${search_depth}" --fixed-strings --grep="$base_subject" 2>/dev/null | head -1)
+            similar_commit=$(git log origin/main --oneline "-${search_depth}" --fixed-strings --grep="$base_subject" 2>/dev/null | head -1 || true)
 
             if [ -n "$similar_commit" ]; then
                 local main_commit_hash=$(echo "$similar_commit" | cut -d' ' -f1)
@@ -231,6 +235,17 @@ cleanup_checkout_blockers() {
     done
 
     return "$had_error"
+}
+
+clear_tracked_beads_index_flags() {
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+    local tracked_file=.beads/issues.jsonl
+
+    if git -C "$repo_root" ls-files --error-unmatch "$tracked_file" >/dev/null 2>&1; then
+        git -C "$repo_root" update-index --no-assume-unchanged "$tracked_file" 2>/dev/null || true
+        git -C "$repo_root" update-index --no-skip-worktree "$tracked_file" 2>/dev/null || true
+    fi
 }
 
 # Utility function for safe command execution with fallback
@@ -408,13 +423,13 @@ if [ "$current_branch" != "main" ] && [ "$NEW_BRANCH_MODE" = false ]; then
             echo ""
             if [ "$local_commits" -gt 0 ]; then
                 echo "   📋 LOCAL-ONLY COMMITS:"
-                git log --oneline "$git_upstream"..HEAD | head -5 | sed 's/^/     /'
+                git log --oneline "$git_upstream"..HEAD | head -5 | sed 's/^/     /' || true
                 [ "$local_commits" -gt 5 ] && echo "     ...and $((local_commits - 5)) more commits"
                 echo ""
             fi
             if [ "$remote_commits" -gt 0 ]; then
                 echo "   📋 REMOTE-ONLY COMMITS:"
-                git log --oneline HEAD.."$git_upstream" | head -5 | sed 's/^/     /'
+                git log --oneline HEAD.."$git_upstream" | head -5 | sed 's/^/     /' || true
                 [ "$remote_commits" -gt 5 ] && echo "     ...and $((remote_commits - 5)) more commits"
                 echo ""
             fi
@@ -438,14 +453,17 @@ if [ "$current_branch" != "main" ] && [ "$NEW_BRANCH_MODE" = false ]; then
             echo -e "${RED}❌ HARD STOP: Branch '$current_branch' has $commit_count commit(s) not in origin/main:${NC}"
             echo ""
             echo "   📋 COMMIT SUMMARY:"
-            git log --oneline origin/main..HEAD | head -10 | sed 's/^/     /'
+            git log --oneline origin/main..HEAD | head -10 | sed 's/^/     /' || true
             echo ""
             echo "   📊 FILES CHANGED:"
-            git diff --name-only origin/main..HEAD | head -10 | sed 's/^/     /'
+            git diff --name-only origin/main..HEAD | head -10 | sed 's/^/     /' || true
             echo ""
 
-            # Check if commits were squash-merged before requiring --force
-            if detect_squash_merged_commits $commit_count; then
+            # Check if commits were squash-merged before requiring --force (skip in very large unmerged sets to avoid expensive O(n^2) scans)
+            if [ "$FORCE_MODE" = true ] && [ "$commit_count" -gt "${FORCE_SQUASH_CHECK_MAX:-1000}" ]; then
+                echo -e "${YELLOW}⚠️  FORCE MODE: Skipping squash merge detection for $commit_count commits (threshold ${FORCE_SQUASH_CHECK_MAX:-1000}).${NC}"
+                should_delete_branch=false
+            elif detect_squash_merged_commits "$commit_count"; then
                 echo -e "${GREEN}✅ Proceeding automatically - all commits were squash-merged into origin/main${NC}"
                 should_delete_branch=true
             elif [ "$FORCE_MODE" = true ]; then
@@ -469,7 +487,9 @@ fi
 
 echo -e "\n${GREEN}1. Switching to main branch...${NC}"
 checkout_err_file="$(mktemp -t integrate_checkout_err.XXXXXX)"
-if ! git checkout main 2>"$checkout_err_file"; then
+force_mode_checkout_restored=false
+force_mode_checkout_message=""
+if ! git -c core.hooksPath="$GIT_HOOKS_PATH" checkout main 2>"$checkout_err_file"; then
     if [ "$FORCE_MODE" = true ]; then
         echo -e "${RED}🚨 FORCE MODE: Checkout to main failed, attempting automatic recovery${NC}"
         if ! cleanup_checkout_blockers; then
@@ -482,11 +502,62 @@ if ! git checkout main 2>"$checkout_err_file"; then
             rm -f "$checkout_err_file"
             die 1 "Failed to stash changes during FORCE_MODE checkout recovery"
         fi
-        if ! git checkout main 2>>"$checkout_err_file"; then
-            echo "   Checkout error details:"
-            tail -n 20 "$checkout_err_file" || true
-            rm -f "$checkout_err_file"
-            die 1 "Failed to switch to main even after FORCE_MODE recovery"
+        if ! git -c core.hooksPath="$GIT_HOOKS_PATH" checkout main 2>>"$checkout_err_file"; then
+            echo -e "${YELLOW}⚠️  FORCE MODE: Normal checkout retry failed; trying forced checkout to override remaining blockers${NC}"
+            echo -e "${RED}⚠️  WARNING: git checkout -f will discard any uncommitted local changes and untracked blockers. Proceeding...${NC}"
+            if ! git -c core.hooksPath="$GIT_HOOKS_PATH" checkout -f main 2>>"$checkout_err_file"; then
+                repo_root="$(git rev-parse --show-toplevel)"
+                clean_cmd=(
+                    git
+                    -c
+                    core.hooksPath="$GIT_HOOKS_PATH"
+                    -C
+                    "$repo_root"
+                    clean
+                    -fd
+                )
+                echo -e "${RED}🚨 FORCE MODE: Destructive recovery is about to run${NC}"
+                echo -e "${RED}   This can permanently discard uncommitted local changes and delete untracked files.${NC}"
+                echo -e "${YELLOW}⚠️  FORCE MODE: Forced checkout failed; attempting hard reset + clean before one final forced attempt${NC}"
+                if ! clear_tracked_beads_index_flags; then
+                    echo "Could not clear tracked index flags for .beads/issues.jsonl during FORCE_MODE recovery." >>"$checkout_err_file"
+                fi
+
+                main_target=$(git rev-parse --verify origin/main 2>/dev/null || git rev-parse --verify main 2>/dev/null || echo HEAD)
+                if ! git -c core.hooksPath="$GIT_HOOKS_PATH" reset --hard "$main_target" 2>>"$checkout_err_file"; then
+                    echo "Failed to hard reset current branch to $main_target during FORCE_MODE recovery."
+                    echo "   Checkout error details:"
+                    tail -n 20 "$checkout_err_file" || true
+                    rm -f "$checkout_err_file"
+                    die 1 "Failed to switch to main even after FORCE_MODE recovery"
+                fi
+                if beads_daemon_running "$repo_root"; then
+                    clean_cmd+=( -e '.beads/beads.db-shm' -e '.beads/beads.db-wal' )
+                fi
+                if ! "${clean_cmd[@]}" 2>>"$checkout_err_file"; then
+                    echo "Failed to clean untracked files during FORCE_MODE recovery."
+                    echo "   Checkout error details:"
+                    tail -n 20 "$checkout_err_file" || true
+                    rm -f "$checkout_err_file"
+                    die 1 "Failed to switch to main even after FORCE_MODE recovery"
+                fi
+                if ! git -c core.hooksPath="$GIT_HOOKS_PATH" checkout -f main 2>>"$checkout_err_file"; then
+                    echo "   Checkout error details:"
+                    tail -n 20 "$checkout_err_file" || true
+                    rm -f "$checkout_err_file"
+                    die 1 "Failed to switch to main even after FORCE_MODE recovery"
+                fi
+                force_mode_checkout_message="✅ FORCE MODE: Hard reset + clean + forced checkout to main completed"
+            else
+                force_mode_checkout_message="✅ FORCE MODE: Forced checkout to main completed"
+            fi
+            force_mode_checkout_restored=true
+        else
+            force_mode_checkout_restored=true
+            force_mode_checkout_message="✅ FORCE MODE: Checkout to main completed"
+        fi
+        if [ "$force_mode_checkout_restored" = true ]; then
+            echo -e "${GREEN}${force_mode_checkout_message}${NC}"
         fi
     else
         echo "   Checkout error details:"
@@ -628,7 +699,7 @@ elif git merge-base --is-ancestor origin/main HEAD; then
         sync_branch="sync-main-$timestamp"
         echo "   Creating sync branch: $sync_branch"
 
-        if ! git checkout -b "$sync_branch"; then
+        if ! git -c core.hooksPath="$GIT_HOOKS_PATH" checkout -b "$sync_branch"; then
             die 1 "Failed to create sync branch"
         fi
 
@@ -644,7 +715,7 @@ elif git merge-base --is-ancestor origin/main HEAD; then
             if [ "$commit_count" -le "$commit_limit" ]; then
                 commit_list=$(git log --oneline origin/main..HEAD)
             else
-                commit_list=$(git log --oneline origin/main..HEAD | head -"$commit_limit")
+                commit_list=$(git log --oneline origin/main..HEAD | head -"$commit_limit" || true)
                 commit_list="$commit_list
    ...and $((commit_count - commit_limit)) more commits not shown"
             fi
@@ -696,14 +767,14 @@ else
 
     if [ "$local_only" -gt 0 ]; then
         echo "🔍 Recent local-only commits:"
-        git log --oneline origin/main..HEAD | head -5 | sed 's/^/   /'
+        git log --oneline origin/main..HEAD | head -5 | sed 's/^/   /' || true
         [ "$local_only" -gt 5 ] && echo "   ...and $((local_only - 5)) more commits"
         echo ""
     fi
 
     if [ "$remote_only" -gt 0 ]; then
         echo "🔍 Recent remote-only commits:"
-        git log --oneline HEAD..origin/main | head -5 | sed 's/^/   /'
+        git log --oneline HEAD..origin/main | head -5 | sed 's/^/   /' || true
         [ "$remote_only" -gt 5 ] && echo "   ...and $((remote_only - 5)) more commits"
         echo ""
     fi
@@ -765,7 +836,7 @@ else
 fi
 
 echo -e "\n${GREEN}5. Creating fresh branch from main...${NC}"
-git checkout -b "$branch_name"
+git -c core.hooksPath="$GIT_HOOKS_PATH" checkout -b "$branch_name"
 
 # Delete the old branch if it was clean (and not in --new-branch mode)
 if [ "$should_delete_branch" = true ] && [ "$current_branch" != "main" ] && [ "$NEW_BRANCH_MODE" = false ]; then

--- a/workflows/mcp-smoke-tests.yml
+++ b/workflows/mcp-smoke-tests.yml
@@ -21,6 +21,7 @@ permissions:
 # Smoke coverage:
 # - Mock API smoke tests on PR/push to main/dev, or after preview deploy completion (workflow_run)
 # - Real E2E preview smoke tests on /smoke comments or workflow_dispatch only
+# CI trigger noop: 2026-02-22T14:44:00Z
 on:
   issue_comment:
     types: [created]
@@ -355,7 +356,7 @@ jobs:
 
   preview-smoke-tests:
     name: MCP Smoke Tests [Preview E2E]
-    if: (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/smoke')) || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'issue_comment' && github.event.issue.pull_request && startsWith(github.event.comment.body, '/smoke') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
       GCP_REGION: us-central1
@@ -363,6 +364,8 @@ jobs:
       MCP_TEST_TIMEOUT_MS: ${{ vars.MCP_TEST_TIMEOUT_MS || '120000' }}
       MCP_TEST_MAX_ATTEMPTS: ${{ vars.MCP_TEST_MAX_ATTEMPTS || '3' }}
       MCP_TEST_RETRY_DELAY_MS: ${{ vars.MCP_TEST_RETRY_DELAY_MS || '2000' }}
+      STREAM_RESPONSE_SIGNING_SECRET: ${{ secrets.STREAM_RESPONSE_SIGNING_SECRET }}
+      SMOKE_TOKEN: ${{ secrets.SMOKE_TOKEN }}
 
     steps:
       - name: Post acknowledgment comment

--- a/workflows/pr-preview.yml
+++ b/workflows/pr-preview.yml
@@ -12,6 +12,8 @@
 
 name: Deploy PR Preview (Rotating Pool)
 
+# CI trigger noop: 2026-02-22T14:57:00Z
+
 # Cancel in-progress runs when new commits are pushed to same branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -166,7 +168,7 @@ jobs:
             --project="${{ env.GCP_PROJECT }}" \
             --platform=managed \
             --allow-unauthenticated \
-            --set-env-vars="FLASK_ENV=production,ENVIRONMENT=preview" \
+            --set-env-vars="FLASK_ENV=production,ENVIRONMENT=preview,PRODUCTION_MODE=true" \
             --set-secrets="GEMINI_API_KEY=gemini-api-key:latest,CEREBRAS_API_KEY=cerebras-api-key:latest,OPENROUTER_API_KEY=openrouter-api-key:latest" \
             --memory="$WORLDARCH_MEMORY" \
             --cpu="$WORLDARCH_CPU" \

--- a/workflows/presubmit.yml
+++ b/workflows/presubmit.yml
@@ -173,7 +173,6 @@ jobs:
       - name: Run ESLint
         run: |
           # ESLint installed via npm ci from package.json
-          # .eslintignore excludes frontend_v2 (has its own TypeScript ESLint config)
           # Lints both .js and .mjs files (ES modules)
           # Non-blocking for incremental adoption - shows errors but doesn't fail CI
           npx eslint . --ext .js,.mjs || true

--- a/workflows/self-hosted-mvp-shard1.yml
+++ b/workflows/self-hosted-mvp-shard1.yml
@@ -20,7 +20,11 @@ on:
       - "mvp_site/**"
       - "tests/**"
       - "run_tests.sh"
+      - "scripts/pr_autonomy_metrics.py"
+      - "scripts/trace_to_eval_case.py"
+      - "scripts/validate_prompt_tool_contracts.py"
       - "scripts/venv_utils.sh"
+      - "mvp_site/schemas/prompt_tool_contracts.json"
       - ".github/workflows/self-hosted-mvp-shard1.yml"
   workflow_dispatch:
 
@@ -34,6 +38,104 @@ permissions:
   pull-requests: read
 
 jobs:
+  harness-autonomy-self-hosted:
+    name: Harness autonomy checks (self hosted)
+    # Never run untrusted fork PR code on self-hosted infrastructure.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+    runs-on: [self-hosted, claude]
+    timeout-minutes: 20
+    outputs:
+      success: ${{ steps.mark-success.outputs.success }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1 # v4.1.1
+
+    - name: Run harness autonomy checks (self-hosted)
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_ACTIONS: "true"
+      run: |
+        source scripts/venv_utils.sh
+        ensure_venv
+        ensure_requirements_installed
+
+        python -m pytest \
+          tests/scripts/test_pr_autonomy_metrics.py \
+          tests/scripts/test_trace_to_eval_case.py \
+          tests/scripts/test_validate_prompt_tool_contracts.py
+
+        python scripts/validate_prompt_tool_contracts.py
+
+        python scripts/pr_autonomy_metrics.py \
+          --repo "${{ github.repository }}" \
+          --limit 20 \
+          --prompt-source claude_local_strict \
+          --no-persist \
+          --output-json /tmp/harness_metrics_ci.json
+
+    - name: Upload harness autonomy artifacts
+      if: always()
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: harness-autonomy-self-hosted
+        path: /tmp/harness_metrics_ci.json
+        retention-days: 30
+        if-no-files-found: ignore
+
+    - name: Mark successful completion
+      id: mark-success
+      if: success()
+      run: echo "success=true" >> $GITHUB_OUTPUT
+
+  harness-autonomy-fallback:
+    name: Harness autonomy checks (fallback)
+    needs: harness-autonomy-self-hosted
+    if: always() && needs.harness-autonomy-self-hosted.outputs.success != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1 # v4.1.1
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
+      with:
+        python-version: '3.11'
+
+    - name: Run harness autonomy checks (fallback)
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GITHUB_ACTIONS: "true"
+      run: |
+        source scripts/venv_utils.sh
+        ensure_venv
+        ensure_requirements_installed
+
+        python -m pytest \
+          tests/scripts/test_pr_autonomy_metrics.py \
+          tests/scripts/test_trace_to_eval_case.py \
+          tests/scripts/test_validate_prompt_tool_contracts.py
+
+        python scripts/validate_prompt_tool_contracts.py
+
+        python scripts/pr_autonomy_metrics.py \
+          --repo "${{ github.repository }}" \
+          --limit 20 \
+          --prompt-source claude_local_strict \
+          --no-persist \
+          --output-json /tmp/harness_metrics_ci.json
+
+    - name: Upload harness autonomy artifacts (fallback)
+      if: always()
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      with:
+        name: harness-autonomy-fallback
+        path: /tmp/harness_metrics_ci.json
+        retention-days: 30
+        if-no-files-found: ignore
+
   mvp-shard-1:
     name: Directory tests (core-mvp-1(self hosted))
     # Never run untrusted fork PR code on self-hosted infrastructure.

--- a/workflows/test.yml
+++ b/workflows/test.yml
@@ -656,7 +656,7 @@ jobs:
           # These get a reduced threshold until test coverage improves.
           # Standard files: 60% minimum, 80% recommended
           # Exception files: 30% minimum (still enforces SOME coverage)
-          LOW_COVERAGE_FILES="mvp_site/main.py mvp_site/start_flask.py"
+          LOW_COVERAGE_FILES="mvp_site/main.py mvp_site/start_flask.py mvp_site/llm_providers/openclaw_provider.py mvp_site/streaming_chunk_logger.py mvp_site/firestore_service.py mvp_site/llm_providers/provider_utils.py mvp_site/llm_service.py mvp_site/settings_validation.py mvp_site/world_logic.py"
           STANDARD_MIN=60
           STANDARD_REC=80
           REDUCED_MIN=30


### PR DESCRIPTION
**🚨 AUTOMATED EXPORT** with directory exclusions applied per requirements.

## 🎯 Directory Exclusions Applied
This export **excludes** the following project-specific directories:
- ❌ `analysis/` - Project-specific analytics and reporting
- ❌ `claude-bot-commands/` - Project-specific bot implementation
- ❌ `coding_prompts/` - Project-specific AI prompting templates
- ❌ `prototype/` - Project-specific experimental code

## ✅ Export Contents
- **📋 235 Commands**: Complete workflow orchestration system
- **📎 50 Hooks**: Essential Claude Code workflow automation
- **🚀 27 Scripts**: Development environment management (scripts/ directory)
- **🧠 85 Skills**: Reference knowledge exports (.claude/skills/)
- **⚙️  18 Workflows**: GitHub Actions examples (REQUIRE INTEGRATION)
- **🤖 Orchestration System**: Core multi-agent task delegation (WIP prototype)
- **📄 CLAUDE.md**: Filtered reference configuration for Claude Code
- **📄 AGENTS.md**: Filtered agent guidelines and conventions
- **📚 Complete Documentation**: Setup guide with adaptation examples

## Manual Installation
From your project root:
```bash
mkdir -p .claude/{commands,hooks,agents,skills}
mkdir -p scripts
cp -R commands/. .claude/commands/
cp -R hooks/. .claude/hooks/
cp -R agents/. .claude/agents/
cp -R skills/. .claude/skills/
# Optional scripts directory
cp -n scripts/* ./scripts/
```

## 🔄 Content Filtering Applied
- **Generic Paths**: mvp_site/ → $PROJECT_ROOT/
- **Generic Domain**: worldarchitect.ai → your-project.com
- **Generic User**: jleechan → $USER
- **Generic Commands**: TESTING=true vpython → TESTING=true python

## ⚠️ Reference Export
This is a filtered reference export. Commands may need adaptation for specific environments, but Claude Code excels at helping customize them for any workflow.

---
🤖 **Generated with [Claude Code](https://claude.ai/code)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies automation cron installation/execution and PR-monitor decision logic (mergeability detection, skip/retry behavior), which can change what jobs run and when PRs get reprocessed.
> 
> **Overview**
> This export refresh adds several new Claude Code commands/skills and updates core docs, including a compacted `CLAUDE.md`, new `AGENTS.md`, and updated `/pair` flow (Teams-native primary with `--scripted` fallbacks).
> 
> Automation behavior is tightened: cron templates now run `jleechanorg-pr-monitor` directly (MiniMax-only by default), `install_cron_entries.sh` resolves a canonical home, bootstraps a non-interactive bash env for cron, de-duplicates managed entries more safely, and optionally rewrites schedules for testing.
> 
> PR automation logic is made more robust by centralizing automation commit marker construction/detection (`codex_config.py`) and using it across Codex tasks and PR-monitor; PR-monitor also handles `mergeable` vs `mergeStateStatus` consistently, improves preflight logging, supports MiniMax auth env injection, and adds a `--bypass-fixpr-commit-limit` escape hatch. The export publisher switches PR creation from GitHub API tokens to `gh pr create` and now includes root `CLAUDE.md`/`AGENTS.md` in exports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a88155c9080ba92578be325d529f3e553b5a455. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->