### PR TITLE
feat(commands): add /harness slash command and harness-engineering skill

### DIFF
--- a/.claude/commands/harness.md
+++ b/.claude/commands/harness.md
@@ -1,0 +1,120 @@
+# /harness — Fix the harness, not just the symptom
+
+## Instructions for Claude
+
+When this command is invoked, analyze the current situation for harness-level gaps and propose/implement fixes that prevent the same class of mistake from recurring.
+
+**Skill reference**: `~/.claude/skills/harness-engineering.md`
+
+## Usage
+
+- `/harness` — Analyze the most recent mistake or user correction in this conversation and propose harness fixes
+- `/harness <description>` — Analyze a specific failure pattern and propose harness fixes
+- `/harness --fix` — Analyze AND implement fixes without waiting for approval
+- `/harness --audit` — Scan all instruction files for staleness, contradictions, or gaps
+
+## Execution
+
+### Default mode (`/harness` or `/harness <description>`)
+
+1. **Identify the trigger**: Look at the most recent user correction, failed test, or explicit description
+2. **Classify the failure**: Use the failure classes from the harness engineering skill
+3. **Check existing harness**: Read these files to see what's already covered:
+   - `~/.claude/CLAUDE.md` (global instructions)
+   - Repo-local `CLAUDE.md` (project instructions)
+   - `~/.codex/AGENTS.md` (Codex instructions)
+   - `~/.claude/skills/harness-engineering.md` (the skill itself)
+   - `~/.claude/projects/*/memory/` (relevant memories)
+4. **Run 5 Whys — Technical**: Ask "Why?" five times about the technical failure. Drill to root cause. **This is mandatory.**
+5. **Run 5 Whys — Agent path**: Ask "Why?" five times about why the agent (Claude Code or any coding LLM) went down the wrong path. **This is mandatory.** Focus on: Did the agent trust without verifying? Did it analyze at the wrong abstraction level? Was there no skill/instruction to redirect it?
+6. **Identify the gap**: What's missing or insufficient in the harness?
+7. **Propose fixes**: Output the structured plan from the skill protocol
+8. **Wait for approval** before implementing (unless `--fix` flag)
+
+### Fix mode (`/harness --fix`)
+
+Same as default but implement immediately after analysis. Still report what was changed.
+
+### Audit mode (`/harness --audit`)
+
+Scan all harness files for:
+- **Stale rules**: Instructions that reference files/tools/patterns that no longer exist
+- **Contradictions**: Rules in different files that conflict
+- **Gaps**: Known failure patterns (from memory) without corresponding instructions
+- **Duplication**: Same rule in multiple places (consolidate to most durable layer)
+
+Report findings as a table:
+
+```
+| Issue | File | Line | Recommendation |
+|-------|------|------|----------------|
+| Stale | ~/.claude/CLAUDE.md | 42 | Remove reference to deprecated tool X |
+| Gap | repo CLAUDE.md | - | Add rule about Y (corrected 3x in memory) |
+```
+
+## Output Format
+
+```
+## Harness Analysis
+
+**Trigger**: <what happened — user correction, failed test, or description>
+**Failure class**: <mislabeled artifact | wrong approach | missing validation | repeated manual fix | silent degradation | knowledge gap | LLM path error>
+
+### 5 Whys — Technical failure
+1. Why: <answer>
+2. Why: <answer>
+3. Why: <answer>
+4. Why: <answer>
+5. Why: <answer>
+→ Root cause: <single sentence>
+
+### 5 Whys — Agent path
+1. Why did the agent not catch/prevent this?
+2. Why did the agent reason or act that way?
+3. Why didn't the agent's instructions prevent that reasoning?
+4. Why wasn't there a skill, memory, or rule that redirected the agent?
+5. Why was the harness incomplete for this class of agent behavior?
+→ Agent root cause: <single sentence>
+
+### Existing coverage
+- [x] ~/.claude/CLAUDE.md — <relevant rule if exists>
+- [ ] repo CLAUDE.md — <gap identified>
+- [ ] ~/.claude/skills/ — <no skill covers this>
+- [x] memory — <relevant memory if exists>
+
+### Proposed fixes
+1. **[Instructions]** `<file>` — <what to add/change>
+2. **[Skill]** `<file>` — <what to create/update>
+3. **[Test]** `<file>` — <what test to add>
+
+### Verification
+<How to confirm the fix works>
+```
+
+## Examples
+
+**User says "don't mock the database in these tests"**:
+→ Failure class: wrong approach
+→ 5 Whys technical: mock used → no instructions prohibiting it → testing philosophy not documented → ...
+→ 5 Whys agent: agent defaulted to mock → common pattern in training data → no skill redirecting to real tests → ...
+→ Add instruction to CLAUDE.md, save feedback memory
+
+**Test labeled "e2e" but only does unit-level work**:
+→ Failure class: mislabeled artifact
+→ 5 Whys technical: E2E criteria not met → criteria not checked → no checklist for E2E → ...
+→ 5 Whys agent: agent named it e2e without verifying → no skill mandating verification → ...
+→ Add/update test classification rules in CLAUDE.md + AGENTS.md, update /validate-e2e skill
+
+**Same code review comment given 3 conversations in a row**:
+→ Failure class: repeated manual fix → mandatory harness fix, no exceptions
+→ Add instruction to CLAUDE.md, save memory, consider lint rule
+
+**Automation cleanup silently fails every cycle**:
+→ Failure class: silent degradation (harness layer present but broken)
+→ 5 Whys technical: cleanup fn uses wrong grep key → porcelain format not verified → no test for cleanup path → ...
+→ 5 Whys agent: agent said "cleanup present" without running it → assumed present = working → skill doesn't mandate verifying harness script correctness → ...
+→ Fix script, add verification step to skill, add integration test for cleanup path
+
+## Input
+
+$ARGUMENTS

--- a/.claude/skills/harness-engineering.md
+++ b/.claude/skills/harness-engineering.md
@@ -1,0 +1,147 @@
+# Harness Engineering Skill
+
+## Purpose
+
+When a mistake or failure pattern is identified, analyze whether the root cause is a gap in the **harness** (instructions, skills, tests, guardrails, automation) rather than just the code. Produce a concrete fix at the harness level so the same class of mistake cannot recur without human intervention.
+
+**Command**: `~/.claude/commands/harness.md`
+
+## Harness Layers (ordered by durability)
+
+| Layer | Files | What it prevents |
+|-------|-------|-----------------|
+| **Instructions** | `CLAUDE.md`, `AGENTS.md` (global + repo) | Wrong approach, wrong assumptions, wrong defaults |
+| **Skills** | `~/.claude/skills/*.md`, `~/.claude/commands/*.md` | Repeated manual workflows, forgotten validation steps |
+| **Memory** | `~/.claude/projects/*/memory/*.md` | Forgetting user preferences, past corrections, project context |
+| **Integration tests** | `tests/test_integration_*.py`, `tests/test_*_test.py` | Regressions in real behavior |
+| **CI gates** | `.github/workflows/*.yml`, pre-commit hooks | Merging broken code, mislabeled artifacts |
+| **Lint/validation rules** | `.pre-commit-config.yaml`, custom linters | Style drift, naming violations, structural problems |
+
+## Analysis Protocol
+
+When invoked, execute this sequence **in full, every time**:
+
+### Step 1: Identify the failure class
+
+Classify what went wrong:
+- **Mislabeled artifact** — something was called X but didn't meet X's criteria (e.g., "E2E test" that isn't E2E)
+- **Wrong approach** — took an approach the user has previously corrected
+- **Missing validation** — produced output without checking it meets requirements
+- **Repeated manual fix** — user had to manually correct the same type of issue more than once
+- **Silent degradation** — something broke but nothing flagged it (includes: harness layer present but broken)
+- **Knowledge gap** — didn't know about a constraint, convention, or tool
+- **LLM path error** — the agent reasoned toward a wrong solution despite having sufficient context
+
+### Step 2: 5 Whys — the technical problem
+
+Ask "Why?" five times about the technical failure, drilling into root cause:
+
+```
+Why 1: Why did the observable failure happen?
+Why 2: Why did the mechanism that caused Why 1 exist?
+Why 3: Why wasn't that mechanism caught or prevented?
+Why 4: Why wasn't there a guardrail at that level?
+Why 5: Why was the system designed without that guardrail?
+→ Root cause: <single sentence>
+```
+
+Stop earlier if you hit bedrock. Each answer should be more specific than the last.
+
+### Step 3: 5 Whys — the agent path
+
+Ask "Why?" five times about why **the LLM (Claude Code or any coding agent)** went down the wrong path. This is mandatory. Every harness failure has two dimensions: the technical problem AND the agent reasoning failure that let it slip through.
+
+```
+Why 1: Why did the agent not catch/prevent the failure?
+Why 2: Why did the agent reason or act that way?
+Why 3: Why didn't the agent's instructions prevent that reasoning?
+Why 4: Why wasn't there a skill, memory, or rule that would have redirected the agent?
+Why 5: Why was the harness incomplete for this class of agent behavior?
+→ Agent root cause: <single sentence>
+```
+
+Key questions to drive this:
+- Did the agent **trust existing code** without verifying it worked correctly?
+- Did the agent describe the problem correctly but at the wrong level of abstraction (high-level summary instead of exact code trace)?
+- Did the agent assume "present = working" when it should have verified?
+- Did the agent skip verification because the skill/instruction didn't mandate it?
+- Was there a confirmation bias: the agent found what looked like the expected pattern and stopped searching?
+
+### Step 4: Find the harness gap
+
+For each failure class, check which harness layers are missing or insufficient:
+
+1. **Read existing instructions** — `~/.claude/CLAUDE.md`, repo `CLAUDE.md`, `~/.codex/AGENTS.md`
+   - Is the rule already documented? If yes → it's an adherence problem, add a stronger enforcement instruction
+   - If no → add the rule
+2. **Check for existing skills** — `~/.claude/skills/`, `~/.claude/commands/`
+   - Is there a skill that should have caught this? If yes → update it
+   - If no and the pattern is repeatable → create a skill
+3. **Check memory** — `~/.claude/projects/*/memory/`
+   - Was this corrected before? If yes → the memory wasn't sufficient; strengthen it
+   - If no → save feedback memory
+4. **Check tests** — are there tests that would catch this regression?
+   - If no → propose an integration test
+5. **Check CI** — would CI have caught this before merge?
+   - If no → propose a CI gate or pre-commit hook
+
+**Critical check — harness layer present but broken:**
+For each harness layer that exists, verify it **actually works**, not just that it exists. A broken guardrail is as bad as a missing one and is harder to detect.
+
+### Step 5: Propose the fix
+
+Output a concrete action plan:
+
+```
+FAILURE CLASS: <classification>
+
+5 WHYS — TECHNICAL:
+1. <why>
+2. <why>
+3. <why>
+4. <why>
+5. <why>
+→ Root cause: <sentence>
+
+5 WHYS — AGENT PATH:
+1. <why>
+2. <why>
+3. <why>
+4. <why>
+5. <why>
+→ Agent root cause: <sentence>
+
+HARNESS FIXES (in order of priority):
+1. [LAYER] FILE: <path> — <what to add/change>
+2. [LAYER] FILE: <path> — <what to add/change>
+...
+
+VERIFICATION: <how to confirm the fix prevents recurrence>
+```
+
+### Step 6: Implement
+
+After user approval (or if invoked with `--fix`):
+- Apply all harness fixes
+- Run verification
+- Report what was changed
+
+## Decision Rules
+
+- **If the same correction has been given twice**: This is a mandatory harness fix. No exceptions.
+- **If the fix is a one-liner in code but the pattern could recur**: Harness fix first, code fix second.
+- **If unsure whether it's a harness gap or a one-off**: Ask the user. Don't assume one-off.
+- **Never add instructions that duplicate what's already documented**: Check first.
+- **Prefer the most durable layer**: Instructions > Skills > Memory > Tests > CI
+- **5 Whys are mandatory**: Never skip them. Short-circuit analysis produces shallow fixes.
+- **Agent path is mandatory**: Never analyze only the technical dimension. Always ask why the agent failed too.
+
+## Anti-patterns
+
+- Adding a memory entry when the fix should be an instruction (memory is per-project; instructions are global)
+- Writing a skill for a one-time operation
+- Adding an integration test without also fixing the instruction that led to the bug
+- Proposing CI gates for things that should be caught at the instruction level
+- Over-engineering: adding 5 harness layers when 1 instruction would suffice
+- Skipping the agent 5 Whys because "the technical fix is obvious"
+- Assuming a harness layer works because it exists — verify it


### PR DESCRIPTION
## Background
The `/harness` slash command and its companion skill `harness-engineering.md` exist locally in `~/.claude/` but were not synced to the claude-commands repo. This PR adds both so they are available across installations.

## Goals
- Add `.claude/commands/harness.md` — the `/harness` slash command
- Add `.claude/skills/harness-engineering.md` — the skill it references

## Tenets
- Minimal scope: only adding the two missing files, no other changes.

## High-level description of changes
`/harness` is invoked to analyze a failure and fix the harness (instructions, skills, tests, CI) rather than just the symptom. It runs two mandatory 5-Whys analyses (technical + agent path) and proposes concrete fixes at the most durable harness layer.

Modes:
- `/harness` — analyze most recent correction, propose fixes, wait for approval
- `/harness <description>` — analyze a specific pattern
- `/harness --fix` — analyze AND implement immediately
- `/harness --audit` — scan all instruction files for staleness/contradictions/gaps

The skill file (`harness-engineering.md`) contains the full protocol including the 6 harness layers, failure class taxonomy, decision rules, and anti-patterns.

## Testing
Manual — both files verified to match the locally-working versions.

## Low-level details
- **`.claude/commands/harness.md`**: New slash command definition. Invokes the harness-engineering skill, executes 5-Whys on both technical failure and agent path, outputs structured analysis.
- **`.claude/skills/harness-engineering.md`**: Full skill protocol. Defines harness layers (Instructions > Skills > Memory > Integration Tests > CI > Lint), failure classes, analysis steps, and decision rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds two new markdown-based command/skill definitions without modifying existing runtime code paths or automation behavior.
> 
> **Overview**
> Adds a new `/harness` slash command that guides failure analysis toward **harness-level fixes** (instructions/skills/tests/CI) instead of one-off symptom fixes, including `--fix` and `--audit` modes and a required dual *5 Whys* (technical + agent-path) workflow.
> 
> Introduces a companion `harness-engineering` skill defining the failure taxonomy, ordered harness layers, mandatory analysis protocol, and decision rules/anti-patterns used by the command.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 736d6176a576ae65f7e87bf156ceea6b9d19738f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->