### PR TITLE
fix(exportcommands): preserve target-only files, don't wipe on export

### DIFF
--- a/.claude/commands/exportcommands.md
+++ b/.claude/commands/exportcommands.md
@@ -482,10 +482,11 @@ cd "$REPO_DIR" && git checkout main
 export NEW_BRANCH="export-fresh-$(date +%Y%m%d-%H%M%S)"
 git checkout -b "$NEW_BRANCH"
 
-# CRITICAL: Clear existing directories for fresh export
+# NOTE: Do NOT wipe existing directories. Only overwrite files that exist in source.
+# Files present in the target repo but not in source are preserved intentionally
+# (e.g. /harness.md added directly via PR — we don't want exportcommands to delete it).
 
-rm -rf commands/* orchestration/* scripts/* || true
-echo "Cleared existing export directories for fresh sync"
+echo "Preserving existing files in target repo; only overwriting files present in source"
 ```
 
 **Pre-Export File Filtering**:


### PR DESCRIPTION
## Background
/exportcommands was doing rm -rf on directories before copying, silently deleting target-only files (e.g. harness.md added via PR).

## Goals
- Target-only files preserved; source files still overwrite target files.

## Changes
- Removed the rm -rf commands/* orchestration/* scripts/* block
- Added explanatory comment in its place
- No other changes

Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation/script-step change that prevents accidental deletion of files in the target export repo; no runtime code paths or security-sensitive logic are modified.
> 
> **Overview**
> Updates `/exportcommands` export instructions to **stop wiping target directories** before syncing.
> 
> Removes the `rm -rf commands/* orchestration/* scripts/*` cleanup step and replaces it with guidance + messaging to **preserve target-only files** while still overwriting files that exist in the source.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34ec0d59816e63186495364f68b3a7e13dd66898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->