### PR TITLE
Claude Commands Export 2026-04-24

### DIFF
--- a/.claude/commands/_copilot_modules/base.py
+++ b/.claude/commands/_copilot_modules/base.py
@@ -37,7 +37,7 @@ class CopilotCommandBase(ABC):
 
         # No caching - always fetch fresh data from GitHub API
 
-    def _get_repo_info(self) -> Optional[str]:
+    def _get_repo_info(self) -> str:
         """Get repository info from GitHub CLI or git remote."""
         try:
             result = subprocess.run(
@@ -67,17 +67,10 @@ class CopilotCommandBase(ABC):
                         return "/".join(url.split("/")[-2:])
             except subprocess.CalledProcessError:
                 pass
-            # Default fallback — prefer GITHUB_REPOSITORY env var (set in CI/Actions)
-            repo = (
-                os.environ.get("GITHUB_REPOSITORY")
-                or os.environ.get("DEFAULT_REPO")
+            # Default fallback - use your-project.com as default repo
+            return os.environ.get(
+                "DEFAULT_REPO", os.environ.get("GITHUB_REPOSITORY", "your-project.com")
             )
-            if not repo:
-                raise ValueError(
-                    "Repository could not be determined. "
-                    "Set GITHUB_REPOSITORY or DEFAULT_REPO env var, or run in a git repo with gh CLI."
-                )
-            return repo
 
     def _get_current_branch(self) -> str:
         """Get current git branch for branch-specific file naming."""

--- a/.claude/commands/_copilot_modules/base.py
+++ b/.claude/commands/_copilot_modules/base.py
@@ -48,7 +48,7 @@ class CopilotCommandBase(ABC):
             )
             data = json.loads(result.stdout)
             return data["nameWithOwner"]
-        except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError):
+        except (subprocess.CalledProcessError, FileNotFoundError, json.JSONDecodeError, KeyError):
             # Fallback to git remote parsing
             try:
                 result = subprocess.run(
@@ -65,7 +65,7 @@ class CopilotCommandBase(ABC):
                         return url.split(":")[-1]
                     else:
                         return "/".join(url.split("/")[-2:])
-            except subprocess.CalledProcessError:
+            except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
             # Default fallback - prefer GITHUB_REPOSITORY (set in CI/Actions), then DEFAULT_REPO
             return os.environ.get(

--- a/.claude/commands/_copilot_modules/base.py
+++ b/.claude/commands/_copilot_modules/base.py
@@ -67,9 +67,9 @@ class CopilotCommandBase(ABC):
                         return "/".join(url.split("/")[-2:])
             except subprocess.CalledProcessError:
                 pass
-            # Default fallback - use your-project.com as default repo
+            # Default fallback - prefer GITHUB_REPOSITORY (set in CI/Actions), then DEFAULT_REPO
             return os.environ.get(
-                "DEFAULT_REPO", os.environ.get("GITHUB_REPOSITORY", "your-project.com")
+                "GITHUB_REPOSITORY", os.environ.get("DEFAULT_REPO", "your-project.com")
             )
 
     def _get_current_branch(self) -> str:

--- a/.claude/commands/_copilot_modules/base.py
+++ b/.claude/commands/_copilot_modules/base.py
@@ -67,10 +67,13 @@ class CopilotCommandBase(ABC):
                         return "/".join(url.split("/")[-2:])
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
-            # Default fallback - prefer GITHUB_REPOSITORY (set in CI/Actions), then DEFAULT_REPO
-            repo = os.environ.get("GITHUB_REPOSITORY") or os.environ.get("DEFAULT_REPO")
-            if repo and re.fullmatch(r"[^/\s]+/[^/\s]+", repo):
-                return repo
+            # Prefer GITHUB_REPOSITORY (CI/Actions), fall back to DEFAULT_REPO
+            github_repo = os.environ.get("GITHUB_REPOSITORY")
+            if github_repo and re.fullmatch(r"[^/\s]+/[^/\s]+", github_repo):
+                return github_repo
+            default_repo = os.environ.get("DEFAULT_REPO")
+            if default_repo and re.fullmatch(r"[^/\s]+/[^/\s]+", default_repo):
+                return default_repo
             raise ValueError(
                 "Repository could not be determined. Set GITHUB_REPOSITORY or DEFAULT_REPO as 'owner/repo'."
             )

--- a/.claude/commands/_copilot_modules/base.py
+++ b/.claude/commands/_copilot_modules/base.py
@@ -68,8 +68,11 @@ class CopilotCommandBase(ABC):
             except (subprocess.CalledProcessError, FileNotFoundError):
                 pass
             # Default fallback - prefer GITHUB_REPOSITORY (set in CI/Actions), then DEFAULT_REPO
-            return os.environ.get(
-                "GITHUB_REPOSITORY", os.environ.get("DEFAULT_REPO", "your-project.com")
+            repo = os.environ.get("GITHUB_REPOSITORY") or os.environ.get("DEFAULT_REPO")
+            if repo and re.fullmatch(r"[^/\s]+/[^/\s]+", repo):
+                return repo
+            raise ValueError(
+                "Repository could not be determined. Set GITHUB_REPOSITORY or DEFAULT_REPO as 'owner/repo'."
             )
 
     def _get_current_branch(self) -> str:

--- a/.claude/commands/auton.md
+++ b/.claude/commands/auton.md
@@ -149,7 +149,11 @@ for pr_json in $(gh api "repos/jleechanorg/agent-orchestrator/pulls?state=open" 
 
   # Get last commit date
   last_commit=$(gh api "repos/jleechanorg/agent-orchestrator/pulls/$number/commits" --jq '.[-1].commit.committer.date' 2>/dev/null)
-  commit_epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$last_commit" +%s 2>/dev/null || echo 0)
+  commit_epoch=$(
+    date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$last_commit" +%s 2>/dev/null \
+      || date -u -d "$last_commit" +%s 2>/dev/null \
+      || echo 0
+  )
   gap_mins=$(( (current_epoch - commit_epoch) / 60 ))
 
   # Get review state
@@ -255,7 +259,7 @@ for sess in $(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '(ao
   case "$sess" in
     ao-*) repo="jleechanorg/agent-orchestrator" ;;
     jc-*) repo="jleechanorg/jleechanclaw" ;;
-    wa-*) repo="${GITHUB_REPOSITORY:-$GITHUB_REPOSITORY}"  ;; # set GITHUB_REPOSITORY or hardcode your wa-* repo here
+    wa-*) repo="${GITHUB_REPOSITORY:-${DEFAULT_REPO}}"  ;; # set GITHUB_REPOSITORY or DEFAULT_REPO, or hardcode your wa-* repo here
     wc-*) repo="jleechanorg/worldai_claw" ;;
     *) continue ;;
   esac

--- a/.claude/commands/auton.md
+++ b/.claude/commands/auton.md
@@ -149,7 +149,7 @@ for pr_json in $(gh api "repos/jleechanorg/agent-orchestrator/pulls?state=open" 
 
   # Get last commit date
   last_commit=$(gh api "repos/jleechanorg/agent-orchestrator/pulls/$number/commits" --jq '.[-1].commit.committer.date' 2>/dev/null)
-  commit_epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$last_commit" +%s 2>/dev/null || date -u -d "$last_commit" +%s 2>/dev/null || echo 0)
+  commit_epoch=$(date -j -u -f "%Y-%m-%dT%H:%M:%SZ" "$last_commit" +%s 2>/dev/null || echo 0)
   gap_mins=$(( (current_epoch - commit_epoch) / 60 ))
 
   # Get review state
@@ -255,7 +255,7 @@ for sess in $(tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -E '(ao
   case "$sess" in
     ao-*) repo="jleechanorg/agent-orchestrator" ;;
     jc-*) repo="jleechanorg/jleechanclaw" ;;
-    wa-*) repo="${GITHUB_REPOSITORY:-owner/worldarchitect.ai}" ;;  # set GITHUB_REPOSITORY or hardcode your repo
+    wa-*) repo="${GITHUB_REPOSITORY:-$GITHUB_REPOSITORY}"  ;; # set GITHUB_REPOSITORY or hardcode your wa-* repo here
     wc-*) repo="jleechanorg/worldai_claw" ;;
     *) continue ;;
   esac

--- a/.claude/commands/wiki-evolve.md
+++ b/.claude/commands/wiki-evolve.md
@@ -38,8 +38,13 @@ CONCEPTS=$(ls $HOME/llm_wiki/wiki/concepts/*.md 2>/dev/null | wc -l)
 
 echo "=== RATIO CHECK ==="
 echo "Sources: $SOURCES, Entities: $ENTITIES, Concepts: $CONCEPTS"
-echo "Entity ratio: $(echo "scale=2; $ENTITIES * 100 / $SOURCES" | bc)%"
-echo "Concept ratio: $(echo "scale=2; $CONCEPTS * 100 / $SOURCES" | bc)%"
+if [ "$SOURCES" -gt 0 ]; then
+  echo "Entity ratio: $(echo "scale=2; $ENTITIES * 100 / $SOURCES" | bc)%"
+  echo "Concept ratio: $(echo "scale=2; $CONCEPTS * 100 / $SOURCES" | bc)%"
+else
+  echo "Entity ratio: N/A (no sources)"
+  echo "Concept ratio: N/A (no sources)"
+fi
 
 # Index quality check
 echo "=== INDEX QUALITY ==="

--- a/.claude/hooks/allow-claude-dir.sh
+++ b/.claude/hooks/allow-claude-dir.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Auto-approve all PermissionRequest events (config file / protected dir prompts).
+# Workaround for anthropics/claude-code#35718 / #37253:
+# "protected directory" check fires even with dangerouslySkipPermissions=true.
+printf '%s' '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"allow","permissionDecisionReason":"Auto-approved"}}'
+exit 0

--- a/.claude/hooks/allow-claude-dir.sh
+++ b/.claude/hooks/allow-claude-dir.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
-# Auto-approve all PermissionRequest events (config file / protected dir prompts).
-# Workaround for anthropics/claude-code#35718 / #37253:
+# Auto-approve only .claude directory PermissionRequest events.
+# Workaround for anthropics/claude-code#35718 / `#37253`:
 # "protected directory" check fires even with dangerouslySkipPermissions=true.
-printf '%s' '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"allow","permissionDecisionReason":"Auto-approved"}}'
+payload="$(cat)"
+
+if grep -Eq '"hookEventName"\s*:\s*"PermissionRequest"' <<<"$payload" \
+  && grep -Eq '"\(\.?\/)?\.claude(\/|\")' <<<"$payload"; then
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"allow","permissionDecisionReason":"Auto-approved for .claude only"}}'
+else
+  printf '%s' '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","permissionDecision":"deny","permissionDecisionReason":"Only .claude path is auto-approved"}}'
+fi
 exit 0

--- a/.claude/hooks/autoapprove.py
+++ b/.claude/hooks/autoapprove.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+autoapprove.py — Claude Code PreToolUse hook
+
+Unconditionally approves every tool call.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+        request = json.loads(raw)
+    except Exception:
+        return 0
+
+    tool_name = request.get("name", "")
+    print(json.dumps({"decision": "approve", "reason": f"autoapprove: {tool_name}"}))
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/hooks/autoapprove.py
+++ b/.claude/hooks/autoapprove.py
@@ -2,12 +2,15 @@
 """
 autoapprove.py — Claude Code PreToolUse hook
 
-Unconditionally approves every tool call.
+Auto-approves tool calls only when CLAUDE_AUTOAPPROVE=1 is set.
+Without the flag, always deny to preserve the permission boundary.
 """
 from __future__ import annotations
 
 import json
+import os
 import sys
+
 
 def main() -> int:
     try:
@@ -16,9 +19,15 @@ def main() -> int:
     except Exception:
         return 0
 
+    if os.getenv("CLAUDE_AUTOAPPROVE") != "1":
+        tool_name = request.get("name", "")
+        print(json.dumps({"decision": "block", "reason": f"manual approval required: {tool_name}"}))
+        return 0
+
     tool_name = request.get("name", "")
-    print(json.dumps({"decision": "approve", "reason": f"autoapprove: {tool_name}"}))
+    print(json.dumps({"decision": "approve", "reason": f"autoapprove (env-gated): {tool_name}"}))
     return 0
+
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/.claude/hooks/mem0_recall.py
+++ b/.claude/hooks/mem0_recall.py
@@ -73,3 +73,26 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+ip()
+            score = r.get("score", 0)
+            if mem:
+                lines.append(f"- [{score:.2f}] {mem}")
+
+        context = "\n".join(lines)
+
+        # Return as additionalContext (quiet injection, not shown as hook output)
+        print(json.dumps({
+            "hookSpecificOutput": {
+                "hookEventName": "UserPromptSubmit",
+                "additionalContext": context,
+            }
+        }))
+
+    except Exception:
+        pass  # Never block the prompt
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/hooks/mem0_recall.py
+++ b/.claude/hooks/mem0_recall.py
@@ -73,26 +73,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-ip()
-            score = r.get("score", 0)
-            if mem:
-                lines.append(f"- [{score:.2f}] {mem}")
-
-        context = "\n".join(lines)
-
-        # Return as additionalContext (quiet injection, not shown as hook output)
-        print(json.dumps({
-            "hookSpecificOutput": {
-                "hookEventName": "UserPromptSubmit",
-                "additionalContext": context,
-            }
-        }))
-
-    except Exception:
-        pass  # Never block the prompt
-
-    sys.exit(0)
-
-
-if __name__ == "__main__":
-    main()

--- a/.claude/hooks/pre-commit-detached-guard.sh
+++ b/.claude/hooks/pre-commit-detached-guard.sh
@@ -11,12 +11,12 @@ set -euo pipefail
 
 # Read tool input from stdin
 INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.name // ""' 2>/dev/null)
+TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""' 2>/dev/null)
 
 # Only intercept Bash tool
 [[ "$TOOL_NAME" != "Bash" ]] && { echo "$INPUT"; exit 0; }
 
-COMMAND=$(echo "$INPUT" | jq -r '.input.command // ""' 2>/dev/null)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 
 # Only act on git commit commands (not git commit --amend --no-edit in loops, etc.)
 # Match: git commit, git -C <path> commit

--- a/.claude/skills/_archive/loose-md/claude-code-schema-validation.md
+++ b/.claude/skills/_archive/loose-md/claude-code-schema-validation.md
@@ -7,7 +7,7 @@
 As of **September 29, 2025**, Anthropic provides official JSON Schema validation for Claude Code settings.
 
 ### Official Schema URL
-```
+```text
 https://json.schemastore.org/claude-code-settings.json
 ```
 

--- a/.claude/skills/_archive/loose-md/claude-code-schema-validation.md
+++ b/.claude/skills/_archive/loose-md/claude-code-schema-validation.md
@@ -565,23 +565,20 @@ class TestClaudeCodeConfig(unittest.TestCase):
                 # Check required fields
                 self.assertRegex(
                     frontmatter,
-                    r'^name:\s*.+$',
-                    f"{agent_file.name}: Missing name field",
-                    flags=re.MULTILINE
+                    r'(?m)^name:\s*.+$',
+                    f"{agent_file.name}: Missing name field"
                 )
                 self.assertRegex(
                     frontmatter,
-                    r'^description:\s*.+$',
-                    f"{agent_file.name}: Missing description field",
-                    flags=re.MULTILINE
+                    r'(?m)^description:\s*.+$',
+                    f"{agent_file.name}: Missing description field"
                 )
 
                 # Check values are unquoted
                 self.assertNotRegex(
                     frontmatter,
-                    r'^(name|description):\s*["\']',
-                    f"{agent_file.name}: Values should be unquoted",
-                    flags=re.MULTILINE
+                    r'(?m)^(name|description):\s*["\']',
+                    f"{agent_file.name}: Values should be unquoted"
                 )
 
 if __name__ == '__main__':


### PR DESCRIPTION
Automated export. Source files overwrite target; target-only files preserved.

Changed:  482 files changed, 71953 insertions(+), 2585 deletions(-)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new auto-approval hooks that affect tool permission decisions, which can impact safety if misconfigured. Other changes are mostly robustness improvements to repo detection and shell-script edge cases.
> 
> **Overview**
> Tightens and hardens Claude command tooling by improving repository detection in `CopilotCommandBase` (handles missing `gh`/`git`, validates `owner/repo` env vars, and fails fast when repo can’t be determined).
> 
> Adds new hooks for permissions: `allow-claude-dir.sh` auto-allows only `.claude`-scoped `PermissionRequest`s, and `autoapprove.py` provides an env-gated (`CLAUDE_AUTOAPPROVE=1`) tool-call auto-approve mode.
> 
> Fixes a few operational scripts/docs: stalled-PR date parsing is made more robust, `wiki-evolve` avoids divide-by-zero when no sources exist, `pre-commit-detached-guard.sh` updates to the new hook payload field names, and schema-validation docs/tests tweak regex/codeblock formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da0ef2419d05eae15d9fd26b98ec4f345fe9e9e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-approve mode for hook requests (env-gated).
  * Auto-allow permission requests that target the .claude directory.

* **Bug Fixes**
  * More reliable repository detection with additional fallbacks and stricter validation.
  * More robust stalled-PR date parsing with safe fallbacks.
  * Ratio reporting now shows "N/A (no sources)" when no sources exist.
  * Hook payload field handling corrected so commit-detached checks detect commands reliably.

* **Documentation**
  * Updated schema validation docs with official schema reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->