### PR TITLE
[antig] Export /advice and other missing active commands/skills

### DIFF
--- a/.claude/commands/advice.md
+++ b/.claude/commands/advice.md
@@ -1,0 +1,6 @@
+---
+description: Token-efficient second opinion — fans out Opus subagent + /research + /secondo in parallel. Use instead of advisor() which ships the full conversation uncached.
+aliases: [smart-advisor]
+---
+
+Invoke the `smart-advisor` skill with the following argument: $ARGUMENTS

--- a/.claude/skills/advice/SKILL.md
+++ b/.claude/skills/advice/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: advice
+description: Token-efficient second opinion slash command /advice. Extracts decision point + artifact (≤150 lines), then fans out in parallel: (1) Opus subagent reviewer with fallback chain codex→agy→cursor, (2) /research on the decision topic, (3) /secondo multi-model opinion. Use instead of advisor() which ships the full conversation uncached.
+---
+
+# /advice — Token-Efficient Second Opinion
+
+**Replaces `advisor()`. Never call advisor() — use this instead.**
+
+## When invoked
+
+`/advice [optional: specific question]` — invoked manually or automatically at a decision point.
+
+## Step 1: Extract the artifact
+
+From the current conversation, extract:
+- **Decision** (3–5 sentences): what specifically needs a second opinion — be concrete about constraints and tradeoffs
+- **Artifact** (≤150 lines): the relevant code, plan, error, diff, or architecture sketch — nothing unrelated
+
+If no specific question was passed, infer from most recent context. If relevant context exceeds 150 lines, summarize the excess into 2–3 sentences prepended before the artifact.
+
+## Step 2: Fan out three reviewers in parallel
+
+Spawn all three in a single message:
+
+---
+
+**Reviewer A — Fallback chain (try in order, stop at first success):**
+
+**A1 — Opus subagent (primary):** Spawn an Agent:
+```
+You are a senior engineer giving a focused second opinion.
+
+DECISION:
+[decision, 3–5 sentences]
+
+ARTIFACT:
+[≤150 lines]
+
+Return exactly:
+VERDICT: [recommended approach, one line]
+REASONING: [3–4 sentences]
+RISK: [main risk, one sentence]
+CONFIDENCE: [high / medium / low]
+```
+
+**A2 — cursor (fallback if A1 errors):**
+```bash
+cursor agent -p --force "Senior engineer second opinion.\n\nDECISION:\n[decision]\n\nARTIFACT:\n[artifact]\n\nReturn VERDICT, REASONING (3-4 sentences), RISK, CONFIDENCE."
+```
+
+**A3 — agy (fallback if A2 errors):**
+```bash
+agy --print --dangerously-skip-permissions "Senior engineer second opinion.\n\nDECISION:\n[decision]\n\nARTIFACT:\n[artifact]\n\nReturn VERDICT, REASONING (3-4 sentences), RISK, CONFIDENCE."
+```
+Note: agy is the Antigravity CLI (reads CLAUDE.md on startup like any CC session, but starts fresh — no current conversation history). Independent perspective, slightly slower than cursor.
+
+**A4 — claude -p (fallback if A3 errors, or when /advice is invoked outside Claude Code):**
+```bash
+claude -p --dangerously-skip-permissions "Senior engineer second opinion.\n\nDECISION:\n[decision]\n\nARTIFACT:\n[artifact]\n\nReturn VERDICT, REASONING (3-4 sentences), RISK, CONFIDENCE."
+```
+Note: Same Claude Code context inheritance as agy. For a cleaner isolated call: add `--cwd /tmp`.
+
+If all four fail, note "Reviewer A unavailable" in the synthesis table.
+
+---
+
+**Reviewer B — Research:**
+
+Invoke `/research [decision topic distilled to 6 words]`
+
+---
+
+**Reviewer C — Secondo:**
+
+Invoke `/secondo` with the decision + artifact (same text as Reviewer A).
+
+---
+
+## Step 3: Synthesize
+
+Present:
+
+```
+| Reviewer  | Verdict              | Key concern         | Confidence |
+|-----------|----------------------|---------------------|------------|
+| A (source)| ...                  | ...                 | high/med/low |
+| Research  | [consensus finding]  | [main caveat]       | —          |
+| Secondo   | ...                  | ...                 | —          |
+```
+
+- 2+ agree → state recommended path, proceed
+- All three diverge → surface disagreement, ask user which axis matters most (speed / safety / cost)
+
+## Token budget
+
+| Reviewer | Tokens sent |
+|---|---|
+| Reviewer A | Decision + artifact ≈ 1,500–2,500 tokens |
+| /research | Web queries only |
+| /secondo | Decision + artifact ≈ 1,500–2,500 tokens |
+| **Total** | **~5,000 tokens vs ~80,000–140,000 for advisor()** |
+
+**96–97% fewer input tokens** per review cycle.
+
+## Fallback chain summary
+
+| Priority | CLI | When |
+|---|---|---|
+| A1 | Claude subagent (Opus) | Primary (inside Claude Code) |
+| A2 | `cursor agent -p --force` | Opus unavailable |
+| A3 | `agy --print --dangerously-skip-permissions` | cursor errors |
+| A4 | `claude -p --dangerously-skip-permissions` | agy errors, or when invoked outside Claude Code |
+
+Note: codex removed — gpt-4.5 unsupported with ChatGPT account + quota exhausted as of 2026-06-24.


### PR DESCRIPTION
## Background
Exporting the newly introduced `/advice` command and `advice` skill from the local user scope (`~/.claude/`) to the shared `claude-commands` repository so that they are version-controlled, distributed, and accessible across environments.

Following that, we identified and exported other missing active skills and commands from `~/.claude/` that were not yet tracked in this repository.

## Goals
- Add `.claude/commands/advice.md` defining the `/advice` command alias.
- Add `.claude/skills/advice/SKILL.md` containing the token-efficient second opinion smart-advisor skill workflow.
- Add the following missing active skills and commands:
  - `runtime-activation-claim` (skill)
  - `ponytail` (skill)
  - `self-hosted-runner-preflight` (skill)
  - `test-tui-claude-feature-via-cmux` (skill, including helper scripts/tests)
  - `fe.md` (command alias for `factory-evolve`)
  - `exportcommands.py` (exporter command script)

## Tenets
- **Token Efficiency**: Focus specifically on the decision point and relevant artifact (≤150 lines) rather than shipping the entire uncached history.
- **Resilience**: A multi-step fallback chain for the primary reviewer (Opus -> Cursor -> Agy -> Claude CLI).
- **Consensus**: Fanout parallel reviews across independent agents and search resources.

## High-Level Description
The `/advice` command/skill is a replacement for `advisor()`. It extracts a small decision context (≤150 lines) and fans out three parallel checks:
1. An Opus subagent reviewer (with fallback CLI runners).
2. `/research` on the distilled topic.
3. `/secondo` multi-model opinions.

We also added:
- **`runtime-activation-claim`**: Guidelines for asserting that a feature/cache is active, requiring clean-subprocess probe output.
- **`ponytail`**: Lazy senior-dev mode coding guidelines.
- **`self-hosted-runner-preflight`**: Diagnostic guidelines for self-hosted runner failures.
- **`test-tui-claude-feature-via-cmux`**: Guidelines and scripts to run interactive Claude TUI tests inside cmux instead of using `--print`.

## Testing
- Manual Verification: Confirmed file existence and content alignment in local user config.
- Checked YAML frontmatter headers for Codex loader compliance.

## Low-Level Details
- `.claude/commands/advice.md`: Registers the `/advice` command/alias.
- `.claude/skills/advice/SKILL.md`: The complete instruction set for the `smart-advisor` fallback and parallel fanout mechanism.
- `.claude/skills/ponytail/`: Lazy senior dev mode rules.
- `.claude/skills/runtime-activation-claim/`: Runtime probe requirements for feature checks.
- `.claude/skills/self-hosted-runner-preflight/`: Runner diagnostics and hooks.
- `.claude/skills/test-tui-claude-feature-via-cmux/`: CMUX-based Claude Code interactive testing files.
- `.claude/commands/fe.md`: Shortcut alias to `factory-evolve`.
- `.claude/commands/exportcommands.py`: Exporter automation script.

## User Stories
- N/A: Developer-only utility commands, not visible to end-users.

## Governing Design Doc
- N/A (Developer tooling config)

## Bead ID
- N/A (Developer tooling config)
