### PR TITLE
[antig] Export additional active commands/skills and fix /advice fallback chain

### DIFF
--- a/.claude/commands/advice.md
+++ b/.claude/commands/advice.md
@@ -1,0 +1,6 @@
+---
+description: Token-efficient second opinion — fans out Opus subagent + /research + /secondo in parallel. Use instead of advisor() which ships the full conversation uncached.
+aliases: [smart-advisor]
+---
+
+Invoke the `smart-advisor` skill with the following argument: $ARGUMENTS

--- a/.claude/commands/exportcommands.py
+++ b/.claude/commands/exportcommands.py
@@ -1,0 +1,2361 @@
+#!/usr/bin/env python3
+"""
+Claude Commands Exporter
+Exports Claude Code command system to GitHub repository with automatic PR creation
+"""
+
+import os
+import time
+import subprocess
+import tempfile
+import shutil
+import re
+import json
+import requests
+import fnmatch
+from pathlib import Path
+from export_config import get_exportable_components
+
+# Constants for file limits
+MAX_FILE_SAMPLE_SIZE = 3
+MAX_DIRECTORY_PREVIEW_SIZE = 10
+MAX_FILE_CONTENT_PREVIEW_SIZE = 50
+
+
+# Custom exceptions for better error handling
+class ExportError(Exception):
+    """Base exception for export operations"""
+
+    pass
+
+
+class GitRepositoryError(ExportError):
+    """Raised when git repository operations fail"""
+
+    pass
+
+
+class GitHubAPIError(ExportError):
+    """Raised when GitHub API operations fail"""
+
+    pass
+
+
+class DirectoryOperationError(ExportError):
+    """Raised when directory operations fail"""
+
+    pass
+
+
+class ClaudeCommandsExporter:
+    # Patterns that indicate hardcoded user/project paths (should be filtered)
+    HARDCODED_PATH_PATTERNS = [
+        (r"/Users/jleechan/", "hardcoded /Users/jleechan/ - use $HOME/"),
+        (r"/Users/\$USER/projects/worktree_ralph", "hardcoded worktree_ralph - use $PROJECT_ROOT"),
+        (r"/Users/\$USER/projects_other/ralph-orchestrator", "hardcoded ralph-orchestrator - use $RALPH_REPO"),
+        (r"projects_other/ralph-orchestrator", "hardcoded projects_other - use $RALPH_REPO"),
+        (r"projects/worktree_ralph", "hardcoded worktree_ralph - use $PROJECT_ROOT"),
+        (r"orch_worldai_ralph", "project-specific orch path - use $PROJECT_ROOT"),
+        (r"worldai_genesis2|worldai_ralph2", "project-specific clone dir - use generic"),
+        (r"worldarchitect-ci", "hardcoded worldarchitect-ci - use ${PROJECT_NAME:-your-project}-ci"),
+    ]
+
+    def __init__(self):
+        self.project_root = self._get_project_root()
+        self.export_dir = os.path.join(
+            tempfile.gettempdir(), f"claude_commands_export_{int(time.time())}"
+        )
+        self.repo_dir = os.path.join(
+            tempfile.gettempdir(), f"claude_commands_repo_{int(time.time())}"
+        )
+        self.export_branch = f"export-{time.strftime('%Y%m%d-%H%M%S')}"
+        self.github_token = os.environ.get("GITHUB_TOKEN")
+
+        # Export configuration - uses shared config from .claude/commands/export_config.py
+        # This ensures both /localexportcommands and /exportcommands export the same directories
+        # Shared config defines: commands, hooks, agents, scripts, skills, settings.json
+        # Note: 'orchestration' is added here specifically for GitHub export
+        base_components = get_exportable_components()
+        # Remove 'settings.json' from subdirs list (it's a file, not a directory)
+        self.EXPORT_SUBDIRS = [c for c in base_components if c != "settings.json"]
+        # Add orchestration for GitHub export
+        if "orchestration" not in self.EXPORT_SUBDIRS:
+            self.EXPORT_SUBDIRS.append("orchestration")
+        # Add automation for GitHub export
+        if "automation" not in self.EXPORT_SUBDIRS:
+            self.EXPORT_SUBDIRS.append("automation")
+        # Add ralph (PRD-driven autonomous workflow toolkit)
+        if "ralph" not in self.EXPORT_SUBDIRS:
+            self.EXPORT_SUBDIRS.append("ralph")
+
+        # Commands to skip during export (project-specific and user-specified exclusions)
+        self.COMMANDS_SKIP_LIST = [
+            "testi.sh",
+            "run_tests.sh",
+            "copilot_inline_reply_example.sh",  # project-specific
+            "converge.md",
+            "converge.py",
+            "orchc.md",
+            "orchc.py",  # orchestration commands to exclude
+            "conv.md",
+            "orchconverge.md",  # additional orchestration exclusions
+            "copilotc.md",
+            "fixprc.md",  # new autonomous composition commands
+            "gen.md",
+            "gene.md",
+            "pgen.md",
+            "pgene.md",
+            "proto_genesis.md",  # proto genesis commands (project-specific)
+            "pairv2",  # Pair v2 command - project-specific workflow
+            "pairv2.md",  # Pair v2 command file
+            "pairv2-usage.md",  # Pair v2 usage guide
+        ]
+
+        # Counters for summary
+        self.commands_count = 0
+        self.hooks_count = 0
+        self.agents_count = 0
+        self.scripts_count = 0
+        self.skills_count = 0
+        self.workflows_count = 0
+
+        # Versioning is now handled by LLM in exportcommands.md
+        # These are kept for backward compatibility but not actively used
+        self.current_version = None
+        self.change_summary = ""
+
+        # Data-driven directory export configuration
+        # Single source of truth for all directory exports
+        self.EXPORT_DIRECTORIES = {
+            'commands': {
+                'source': '.claude/commands',
+                'exclude_dirs': [],
+                'exclude_files': self.COMMANDS_SKIP_LIST,
+            },
+            'hooks': {
+                'source': '.claude/hooks',
+                'exclude_dirs': ['.claude'],  # Avoid nested .claude directories
+                'exclude_files': [],
+            },
+            'orchestration': {
+                'source': 'orchestration',
+                'exclude_dirs': ['analysis', 'claude-bot-commands', 'coding_prompts', 'prototype', 'tasks', 'task-agent-create-autono-slash'],
+                'exclude_files': [],
+            },
+            'automation': {
+                'source': 'automation',
+                'exclude_dirs': ['__pycache__', '.pytest_cache', 'dist', 'build', '*.egg-info', 'testing_util'],
+                'exclude_files': ['*.pyc', '*.pyo', '*.swp', '*.tmp', 'simple_pr_batch.sh'],
+            },
+            'ralph': {
+                'source': 'ralph',
+                'exclude_dirs': ['archive'],
+                'exclude_files': ['.last-branch'],
+            },
+            'servers': {
+                'source': '.claude/servers',
+                'exclude_dirs': ['__pycache__', '.pytest_cache'],
+                'exclude_files': [],
+            },
+        }
+
+    def _get_project_root(self):
+        """Get the project root directory"""
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            raise GitRepositoryError("Not in a git repository")
+        return result.stdout.strip()
+
+    def _export_directory(self, name, config, staging_dir):
+        """Generic directory export with rsync or manual fallback.
+
+        Args:
+            name: Display name for the directory (e.g., 'commands', 'hooks')
+            config: Export configuration dict with keys:
+                - source: Source directory relative to project root
+                - exclude_dirs: List of directory names to exclude
+                - exclude_files: List of file patterns to exclude
+            staging_dir: Target staging directory for export
+        """
+        source_dir = os.path.join(self.project_root, config['source'])
+
+        if not os.path.exists(source_dir):
+            print(f"⚠️  {name.title()} directory not found - skipping")
+            return
+
+        target_dir = os.path.join(staging_dir, name)
+        os.makedirs(target_dir, exist_ok=True)
+
+        exclude_dirs = config.get('exclude_dirs', [])
+        exclude_files = config.get('exclude_files', [])
+
+        # Try rsync first for better performance
+        try:
+            # Build exclusion patterns
+            exclude_patterns = []
+            for exc_dir in exclude_dirs:
+                if exc_dir.endswith('.egg-info'):
+                    exclude_patterns.append('--exclude=*.egg-info/')
+                else:
+                    exclude_patterns.append(f'--exclude={exc_dir}/')
+
+            for exc_file in exclude_files:
+                if exc_file.startswith('*.'):
+                    exclude_patterns.append(f'--exclude={exc_file}')
+                else:
+                    exclude_patterns.append(f'--exclude={exc_file}')
+
+            cmd = ['rsync', '-av'] + exclude_patterns + [f"{source_dir}/", f"{target_dir}/"]
+            result = subprocess.run(cmd, capture_output=True, text=True)
+
+            if result.returncode != 0:
+                print(f"⏭ rsync failed for {name}, using manual copy")
+                raise FileNotFoundError("rsync failed")
+
+            print(f"✅ {name.title()} exported using rsync")
+
+        except (FileNotFoundError, PermissionError):
+            # Fallback to manual copy for Windows or when rsync unavailable
+            self._manual_directory_copy(source_dir, target_dir, exclude_dirs, exclude_files)
+            print(f"✅ {name.title()} exported using manual copy")
+
+    def _manual_directory_copy(self, source_dir, target_dir, exclude_dirs, exclude_files):
+        """Manual directory copy with exclusions for cross-platform compatibility.
+
+        Args:
+            source_dir: Source directory path
+            target_dir: Target directory path
+            exclude_dirs: List of directory names to exclude
+            exclude_files: List of file patterns to exclude (supports wildcards)
+        """
+        # Normalize exclude_dirs to handle .egg-info pattern
+        normalized_exclude_dirs = set()
+        for exc_dir in exclude_dirs:
+            if exc_dir == '*.egg-info':
+                normalized_exclude_dirs.add('*.egg-info')
+            else:
+                normalized_exclude_dirs.add(exc_dir)
+
+        for root, dirs, files in os.walk(source_dir):
+            # Filter directories in-place to prevent walking into excluded dirs
+            dirs[:] = [
+                d for d in dirs
+                if d not in normalized_exclude_dirs
+                and not d.endswith('.egg-info')
+            ]
+
+            rel_path = os.path.relpath(root, source_dir)
+            target_root = os.path.join(target_dir, rel_path) if rel_path != '.' else target_dir
+            os.makedirs(target_root, exist_ok=True)
+
+            for file in files:
+                # Check if file should be excluded
+                should_exclude = False
+
+                # Check against exclude_files patterns
+                for pattern in exclude_files:
+                    if pattern.startswith('*.'):
+                        # Wildcard pattern
+                        if fnmatch.fnmatch(file, pattern):
+                            should_exclude = True
+                            break
+                    else:
+                        # Exact match
+                        if file == pattern:
+                            should_exclude = True
+                            break
+
+                if not should_exclude:
+                    src_file = os.path.join(root, file)
+                    dst_file = os.path.join(target_root, file)
+                    shutil.copy2(src_file, dst_file)
+
+    def export(self):
+        """Main export workflow"""
+        try:
+            print("🚀 Starting Claude Commands Export...")
+            print("=" * 50)
+
+            self.phase1_local_export()
+            pr_url = self.phase2_github_publish()
+            self.report_success(pr_url)
+
+        except Exception as e:
+            self.handle_error(e)
+            raise ExportError(f"Export failed: {e}") from e
+
+    def phase1_local_export(self):
+        """Phase 1: Create local export with directory exclusions and user confirmation"""
+        print("\n📂 Phase 1: Creating Local Export...")
+        print("-" * 40)
+
+        print(
+            "🔍 Using comprehensive directory export (commands, hooks, agents, scripts, skills, orchestration, automation)"
+        )
+
+        # Create staging directory
+        staging_dir = os.path.join(self.export_dir, "staging")
+        os.makedirs(staging_dir, exist_ok=True)
+
+        print(f"📁 Created export directory: {self.export_dir}")
+
+        # Create subdirectories for confirmed exports
+        for subdir in self.EXPORT_SUBDIRS:
+            os.makedirs(os.path.join(staging_dir, subdir), exist_ok=True)
+
+        # Export commands
+        self._export_commands(staging_dir)
+
+        # Export hooks
+        self._export_hooks(staging_dir)
+
+        # Export agents
+        self._export_agents(staging_dir)
+
+        # Export scripts
+        self._export_scripts(staging_dir)
+
+        # Export .claude/scripts directory
+        self._export_claude_scripts(staging_dir)
+
+        # Export .claude/skills directory
+        self._export_skills(staging_dir)
+
+        # Export settings.json
+        self._export_settings(staging_dir)
+
+        # Export package.json and package-lock.json (for secondo command dependencies)
+        self._export_dependencies(staging_dir)
+
+        # Export orchestration (with exclusions)
+        self._export_orchestration(staging_dir)
+
+        # Export automation (GitHub PR automation system)
+        self._export_automation(staging_dir)
+
+        # Export ralph (PRD-driven autonomous workflow toolkit)
+        self._export_ralph(staging_dir)
+
+        # Export GitHub Actions workflows (as examples)
+        self._export_github_workflows(staging_dir)
+
+        # Export root-level reference docs (CLAUDE.md and AGENTS.md)
+        self._export_claude_md(staging_dir)
+        self._export_agents_md(staging_dir)
+
+        # Generate README
+        self._generate_readme()
+
+        # Create archive
+        self._create_archive()
+
+        print("✅ Phase 1 complete - Local export created")
+
+    def _export_commands(self, staging_dir):
+        """Export command definitions with whole directory copying and user confirmation"""
+        print("📋 Exporting command definitions...")
+
+        commands_dir = os.path.join(self.project_root, ".claude", "commands")
+        if not os.path.exists(commands_dir):
+            print("⚠️  Warning: .claude/commands directory not found")
+            return
+
+        target_dir = os.path.join(staging_dir, "commands")
+        os.makedirs(target_dir, exist_ok=True)
+
+        # First, copy entire .claude/commands directory structure
+        self._copy_directory_with_filtering(commands_dir, target_dir)
+
+        # Also stage .claude_reference/commands/ if it exists (maps to repo/.claude_reference/commands/ in phase2)
+        ref_commands_dir = os.path.join(self.project_root, ".claude_reference", "commands")
+        if os.path.exists(ref_commands_dir):
+            ref_target_dir = os.path.join(staging_dir, "reference_commands")
+            os.makedirs(ref_target_dir, exist_ok=True)
+            self._copy_directory_with_filtering(ref_commands_dir, ref_target_dir)
+            print(f"   📁 Staged .claude_reference/commands/ → reference_commands/")
+
+        # Count all files for summary (matching actual copy logic)
+        for root, dirs, files in os.walk(target_dir):
+            for file in files:
+                # Use same file extension check as copying logic
+                if file.endswith((".sh", ".py", ".md", ".json", ".toml", ".txt")):
+                    # Skip files in the centralized skip list (same as copying logic)
+                    if file not in self.COMMANDS_SKIP_LIST:
+                        self.commands_count += 1
+                        rel_path = os.path.relpath(os.path.join(root, file), target_dir)
+                        print(f"   • {rel_path}")
+
+        print(f"✅ Exported {self.commands_count} commands (whole directory structure)")
+
+    def _export_hooks(self, staging_dir):
+        """Export Claude Code hooks with proper permissions, avoiding duplicates"""
+        print("📎 Exporting Claude Code hooks...")
+
+        # Use generic export with hooks configuration
+        self._export_directory("hooks", self.EXPORT_DIRECTORIES["hooks"], staging_dir)
+
+        # Post-processing: filter to only .sh/.py/.md files, apply content filtering, set permissions, and count
+        target_dir = os.path.join(staging_dir, "hooks")
+        if not os.path.exists(target_dir):
+            return
+
+        allowed_extensions = (".sh", ".py", ".md")
+
+        for root, dirs, files in os.walk(target_dir):
+            for file in files:
+                file_path = os.path.join(root, file)
+
+                # Remove files that don't match allowed extensions
+                if not file.endswith(allowed_extensions):
+                    os.remove(file_path)
+                    continue
+
+                # Process allowed files
+                self._apply_content_filtering(file_path)
+
+                # Ensure scripts are executable (with Windows compatibility)
+                if file.endswith((".sh", ".py")):
+                    try:
+                        os.chmod(file_path, 0o755)
+                    except (OSError, NotImplementedError):
+                        # On Windows or unsupported filesystems, ignore chmod errors
+                        pass
+
+                self.hooks_count += 1
+                rel_path = os.path.relpath(file_path, target_dir)
+                print(f"   📎 {rel_path}")
+
+        print(f"✅ Exported {self.hooks_count} hooks")
+
+    def _copy_directory_with_filtering(self, src_dir, dst_dir):
+        """Copy directory recursively with file filtering and content transformation"""
+        for root, dirs, files in os.walk(src_dir):
+            # Skip nested .claude directories and test directories that might contain sensitive data
+            dirs[:] = [d for d in dirs if d != ".claude"]
+
+            # Create relative path structure
+            rel_path = os.path.relpath(root, src_dir)
+            target_root = (
+                os.path.join(dst_dir, rel_path) if rel_path != "." else dst_dir
+            )
+            os.makedirs(target_root, exist_ok=True)
+
+            for file in files:
+                # Only copy relevant file types
+                if file.endswith((".sh", ".py", ".md", ".json", ".toml", ".txt")):
+                    # Skip files in the centralized skip list
+                    if file in self.COMMANDS_SKIP_LIST:
+                        print(f"   ⏭ Skipping {file} (project-specific/orchestration)")
+                        continue
+
+                    src_file = os.path.join(root, file)
+                    dst_file = os.path.join(target_root, file)
+                    shutil.copy2(src_file, dst_file)
+
+                    # Apply content filtering to copied file
+                    self._apply_content_filtering(dst_file)
+
+                    # Make scripts executable if needed
+                    if file.endswith((".sh", ".py")):
+                        try:
+                            os.chmod(dst_file, 0o755)
+                        except (OSError, NotImplementedError):
+                            pass  # Windows compatibility
+
+    def _export_agents(self, staging_dir):
+        """Export Claude Code agent definitions"""
+        print("🤖 Exporting Claude Code agents...")
+
+        agents_dir = os.path.join(self.project_root, ".claude", "agents")
+        if not os.path.exists(agents_dir):
+            print("⚠️  Warning: .claude/agents directory not found")
+            return
+
+        target_dir = os.path.join(staging_dir, "agents")
+        for file_path in Path(agents_dir).glob("*"):
+            if file_path.is_file() and file_path.suffix == ".md":
+                # Copy file
+                shutil.copy2(file_path, target_dir)
+                self.agents_count += 1
+                print(f"   🤖 {file_path.name}")
+
+                # Apply content filtering if needed
+                target_file = os.path.join(target_dir, file_path.name)
+                self._apply_content_filtering(target_file)
+
+        print(f"✅ Exported {self.agents_count} agents")
+
+    def _get_scripts_from_settings(self):
+        """Parse settings.json to find all referenced scripts"""
+        settings_file = os.path.join(self.project_root, ".claude", "settings.json")
+        scripts_from_settings = set()
+
+        if not os.path.exists(settings_file):
+            return scripts_from_settings
+
+        try:
+            with open(settings_file, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            # Find all script references in settings.json
+            # Match patterns like: scripts/filename.sh or scripts/filename.py
+            import_pattern = r"scripts/([a-zA-Z0-9_\-]+\.(sh|py))"
+            matches = re.findall(import_pattern, content)
+
+            for match in matches:
+                script_name = match[0]  # filename.sh or filename.py
+                scripts_from_settings.add(script_name)
+
+            print(
+                f"   📋 Found {len(scripts_from_settings)} scripts referenced in settings.json"
+            )
+            for script in sorted(scripts_from_settings):
+                print(f"      • {script}")
+
+        except Exception as e:
+            print(
+                f"   ⚠️  Warning: Could not parse settings.json for script references: {e}"
+            )
+
+        return scripts_from_settings
+
+    def _export_scripts(self, staging_dir):
+        """Export reusable scripts (both Claude Code specific and generally useful development tools)"""
+        print("🚀 Exporting scripts...")
+
+        target_dir = os.path.join(staging_dir, "scripts")
+
+        # Ensure target directory exists
+        os.makedirs(target_dir, exist_ok=True)
+
+        script_patterns = [
+            # Claude Code infrastructure (generally useful for Claude Code users)
+            "claude_start.sh",
+            "install_mcp_servers.sh",
+            # Generally useful git/development workflow scripts
+            "integrate.sh",
+            "resolve_conflicts.sh",
+            "sync_branch.sh",
+            "create_worktree.sh",
+            # Code analysis and metrics
+            "codebase_loc.sh",
+            "coverage.sh",
+            "loc.sh",
+            "loc_simple.sh",
+            # Testing infrastructure
+            "run_tests_with_coverage.sh",
+            "run_lint.sh",
+            # CI/CD and infrastructure
+            "setup-github-runner.sh",
+            "setup_email.sh",
+            # Development environment
+            "create_snapshot.sh",
+            "schedule_branch_work.sh",
+            "push.sh",
+        ]
+
+        # MCP helper scripts (required by install_mcp_servers.sh) - must be from scripts/ subdirectory
+        mcp_helper_scripts = ["mcp_common.sh", "load_tokens.sh"]
+
+        # Secondo command scripts (multi-model AI feedback system)
+        secondo_scripts = ["auth-cli.mjs", "secondo-cli.sh", "test_secondo_pr.sh"]
+
+        # GitHub runner setup scripts (from self-hosted/scripts/ top-level directory)
+        # Now exported from top-level self-hosted/ directory, not scripts/ subdirectory
+        runner_scripts_dir = os.path.join(self.project_root, "self-hosted", "scripts")
+
+        # Get scripts referenced in settings.json
+        settings_scripts = self._get_scripts_from_settings()
+
+        for script_name in script_patterns:
+            script_path = os.path.join(self.project_root, script_name)
+            if os.path.exists(script_path):
+                target_path = os.path.join(target_dir, script_name)
+                shutil.copy2(script_path, target_path)
+                self._apply_content_filtering(target_path)
+
+                print(f"   • {script_name}")
+                self.scripts_count += 1
+
+        # Export MCP helper scripts from scripts/ subdirectory
+        scripts_subdir = os.path.join(self.project_root, "scripts")
+        for script_name in mcp_helper_scripts:
+            script_path = os.path.join(scripts_subdir, script_name)
+            if os.path.exists(script_path):
+                target_path = os.path.join(target_dir, script_name)
+                shutil.copy2(script_path, target_path)
+                self._apply_content_filtering(target_path)
+
+                print(f"   • scripts/{script_name}")
+                self.scripts_count += 1
+            else:
+                print(
+                    f"   ⚠️  Warning: Required MCP helper script not found: scripts/{script_name}"
+                )
+
+        # Export secondo command scripts from scripts/ subdirectory
+        for script_name in secondo_scripts:
+            script_path = os.path.join(scripts_subdir, script_name)
+            if os.path.exists(script_path):
+                target_path = os.path.join(target_dir, script_name)
+                shutil.copy2(script_path, target_path)
+                self._apply_content_filtering(target_path)
+
+                print(f"   • scripts/{script_name} (secondo)")
+                self.scripts_count += 1
+            else:
+                print(f"   ⚠️  Warning: Secondo script not found: scripts/{script_name}")
+
+        # Export all runner setup scripts from self-hosted/scripts/ directory
+        if os.path.exists(runner_scripts_dir):
+            for script_name in os.listdir(runner_scripts_dir):
+                if script_name.endswith(('.sh', '.md', '.txt')):
+                    script_path = os.path.join(runner_scripts_dir, script_name)
+                    if os.path.isfile(script_path):
+                        # Create self-hosted/scripts/ subdirectory in target
+                        runner_target_dir = os.path.join(target_dir, "self-hosted", "scripts")
+                        os.makedirs(runner_target_dir, exist_ok=True)
+                        target_path = os.path.join(runner_target_dir, script_name)
+                        shutil.copy2(script_path, target_path)
+                        self._apply_content_filtering(target_path)
+
+                        print(f"   • self-hosted/scripts/{script_name} (runner setup)")
+                        self.scripts_count += 1
+        else:
+            print(f"   ⚠️  Warning: self-hosted/scripts/ directory not found")
+
+        # Export scripts referenced in settings.json from scripts/ subdirectory
+        for script_name in settings_scripts:
+            # Skip if already exported (MCP helpers or root-level patterns)
+            if script_name in mcp_helper_scripts:
+                continue
+
+            script_path = os.path.join(scripts_subdir, script_name)
+            if os.path.exists(script_path):
+                target_path = os.path.join(target_dir, script_name)
+                shutil.copy2(script_path, target_path)
+                self._apply_content_filtering(target_path)
+
+                print(f"   • settings: scripts/{script_name}")
+                self.scripts_count += 1
+            else:
+                print(
+                    f"   ⚠️  Warning: Script referenced in settings.json not found: scripts/{script_name}"
+                )
+
+        print(f"✅ Exported {self.scripts_count} scripts")
+
+    def _export_claude_scripts(self, staging_dir):
+        """Export .claude/scripts directory and aggregate MCP launchers."""
+        print("📜 Exporting .claude/scripts directory...")
+
+        source_dir = Path(self.project_root) / ".claude" / "scripts"
+        target_dir = Path(staging_dir) / "claude_scripts"
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        scripts_count = 0
+        copied_names = set()
+
+        def copy_script(path: Path):
+            nonlocal scripts_count
+            if not path.exists() or not path.is_file():
+                return
+
+            destination = target_dir / path.name
+            shutil.copy2(path, destination)
+            self._apply_content_filtering(str(destination))
+
+            # Fix REPO_ROOT path for scripts exported to .claude/scripts/
+            # Source scripts/ needs ".." to reach repo root
+            # Export .claude/scripts/ needs "../.." to reach repo root
+            self._fix_repo_root_path(str(destination))
+
+            if destination.suffix == ".sh":
+                try:
+                    os.chmod(destination, 0o755)
+                except OSError:
+                    pass
+
+            copied_names.add(path.name)
+            scripts_count += 1
+            print(f"   📜 {path.name}")
+
+        # Export native Claude scripts (.claude/scripts)
+        if source_dir.exists():
+            for pattern in ("*.py", "*.sh"):
+                for file_path in source_dir.glob(pattern):
+                    if file_path.name in copied_names:
+                        continue
+                    copy_script(file_path)
+        else:
+            print(
+                "⚠️  Warning: .claude/scripts directory not found; attempting legacy MCP locations"
+            )
+
+        # Backfill MCP launchers/utilities that remain outside .claude/scripts
+        legacy_candidates = {
+            "install_mcp_servers.sh": [
+                Path(self.project_root) / "scripts" / "install_mcp_servers.sh",
+                Path(self.project_root) / "install_mcp_servers.sh",
+            ],
+            "mcp_common.sh": [
+                Path(self.project_root) / "scripts" / "mcp_common.sh",
+                Path(self.project_root) / "mcp_common.sh",
+            ],
+            "mcp_dual_background.sh": [
+                Path(self.project_root) / "scripts" / "mcp_dual_background.sh",
+                Path(self.project_root) / "mcp_dual_background.sh",
+            ],
+            "start_mcp_production.sh": [
+                Path(self.project_root) / "scripts" / "start_mcp_production.sh",
+                Path(self.project_root) / "start_mcp_production.sh",
+            ],
+            "start_mcp_server.sh": [
+                Path(self.project_root) / "scripts" / "start_mcp_server.sh",
+                Path(self.project_root) / "start_mcp_server.sh",
+            ],
+            "mcp_stdio_wrapper.py": [
+                Path(self.project_root) / "scripts" / "mcp_stdio_wrapper.py",
+                Path(self.project_root) / "mcp_stdio_wrapper.py",
+            ],
+        }
+
+        for script_name, candidates in legacy_candidates.items():
+            if script_name in copied_names:
+                continue
+            for legacy_path in candidates:
+                if legacy_path.exists():
+                    copy_script(legacy_path)
+                    break
+
+        if scripts_count == 0:
+            print("⚠️  Warning: No scripts were exported from available locations")
+            return
+
+        print(
+            f"✅ Exported {scripts_count} .claude/scripts files (including MCP launchers)"
+        )
+
+    def _export_skills(self, staging_dir):
+        """Export .claude/skills directory for reference skills"""
+        print("🧠 Exporting .claude/skills directory...")
+
+        source_dir = os.path.join(self.project_root, ".claude", "skills")
+        if not os.path.exists(source_dir):
+            print("⚠️  Warning: .claude/skills directory not found")
+            return
+
+        target_dir = os.path.join(staging_dir, "skills")
+        os.makedirs(target_dir, exist_ok=True)
+
+        # Reuse directory copy helper for filtering and transformations
+        self._copy_directory_with_filtering(source_dir, target_dir)
+
+        allowed_extensions = (".sh", ".py", ".md", ".json", ".toml", ".txt")
+        for root, dirs, files in os.walk(target_dir):
+            for file in files:
+                if file.endswith(allowed_extensions):
+                    self.skills_count += 1
+                    rel_path = os.path.relpath(os.path.join(root, file), target_dir)
+                    print(f"   🧠 {rel_path}")
+
+        print(f"✅ Exported {self.skills_count} skills")
+
+    def _export_settings(self, staging_dir):
+        """Export settings.json file"""
+        print("⚙️  Exporting settings.json...")
+
+        settings_file = os.path.join(self.project_root, ".claude", "settings.json")
+        if not os.path.exists(settings_file):
+            print("⚠️  Warning: settings.json not found")
+            return
+
+        # Create settings_file in staging (will map to .claude/settings.json in repo)
+        target_file = os.path.join(staging_dir, "settings_json")
+        shutil.copy2(settings_file, target_file)
+        self._apply_content_filtering(target_file)
+
+        print("✅ Exported settings.json")
+
+    def _export_dependencies(self, staging_dir):
+        """Export package.json and package-lock.json for secondo command dependencies"""
+        print("📦 Exporting Node.js dependencies...")
+
+        # Export package.json
+        package_json = os.path.join(self.project_root, "package.json")
+        if os.path.exists(package_json):
+            target_file = os.path.join(staging_dir, "package.json")
+            shutil.copy2(package_json, target_file)
+            self._apply_content_filtering(target_file)
+            print("   • package.json")
+        else:
+            print(
+                "   ⚠️  Warning: package.json not found (required for secondo auth-cli.mjs)"
+            )
+
+        # Export package-lock.json for reproducible builds
+        package_lock = os.path.join(self.project_root, "package-lock.json")
+        if os.path.exists(package_lock):
+            target_file = os.path.join(staging_dir, "package-lock.json")
+            shutil.copy2(package_lock, target_file)
+            self._apply_content_filtering(target_file)
+            print("   • package-lock.json")
+
+        print("✅ Exported Node.js dependencies")
+
+    def _export_claude_md(self, staging_dir):
+        """Export filtered CLAUDE.md to the staging directory"""
+        print("📄 Exporting CLAUDE.md...")
+
+        source_file = os.path.join(self.project_root, "CLAUDE.md")
+        if not os.path.exists(source_file):
+            print("⚠️  Warning: CLAUDE.md not found")
+            return
+
+        with open(source_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Prepend adaptation header
+        header = """# 📚 Reference Export - Adaptation Guide
+
+**Note**: This is a reference export from a working Claude Code project. You may need to
+personally debug some configurations, but Claude Code can easily adjust for your specific needs.
+
+These configurations may include:
+- Project-specific paths and settings that need updating for your environment
+- Setup assumptions and dependencies specific to the original project
+- References to particular GitHub repositories and project structures
+
+Feel free to use these as a starting point - Claude Code excels at helping you adapt and
+customize them for your specific workflow.
+
+---
+
+"""
+        full_content = header + content
+
+        target_file = os.path.join(staging_dir, "CLAUDE.md")
+        with open(target_file, "w", encoding="utf-8") as f:
+            f.write(full_content)
+
+        self._apply_content_filtering(target_file)
+        print("✅ Exported CLAUDE.md")
+
+    def _export_agents_md(self, staging_dir):
+        """Export filtered AGENTS.md to the staging directory"""
+        print("📄 Exporting AGENTS.md...")
+
+        source_file = os.path.join(self.project_root, "AGENTS.md")
+        if not os.path.exists(source_file):
+            print("⚠️  Warning: AGENTS.md not found")
+            return
+
+        with open(source_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Prepend adaptation header
+        header = """# 📚 Reference Export - Agents Configuration
+
+**Note**: This is a reference export from a working Claude Code project. These agent
+configurations and guidelines may contain project-specific references that need adaptation.
+
+Customize the following for your project:
+- Project-specific paths (mvp_site/ → your main source directory)
+- Repository and domain references
+- CI commands and test runner paths
+
+---
+
+"""
+        full_content = header + content
+
+        target_file = os.path.join(staging_dir, "AGENTS.md")
+        with open(target_file, "w", encoding="utf-8") as f:
+            f.write(full_content)
+
+        self._apply_content_filtering(target_file)
+        print("✅ Exported AGENTS.md")
+
+    def _export_orchestration(self, staging_dir):
+        """Export orchestration system with directory exclusions"""
+        print("🤖 Exporting orchestration system (with exclusions)...")
+        self._export_directory(
+            "orchestration", self.EXPORT_DIRECTORIES["orchestration"], staging_dir
+        )
+
+    def _export_automation(self, staging_dir):
+        """Export automation system (GitHub PR automation)"""
+        print("🤖 Exporting automation system...")
+        self._export_directory(
+            "automation", self.EXPORT_DIRECTORIES["automation"], staging_dir
+        )
+
+    def _export_ralph(self, staging_dir):
+        """Export Ralph PRD-driven autonomous workflow toolkit"""
+        print("🐺 Exporting ralph...")
+        self._export_directory(
+            "ralph", self.EXPORT_DIRECTORIES["ralph"], staging_dir
+        )
+
+    def _export_github_workflows(self, staging_dir):
+        """Export GitHub Actions workflows with project-specific filtering.
+
+        🚨 IMPORTANT: These are EXAMPLES ONLY that need to be integrated into your codebase.
+        They cannot be used as-is because they contain project-specific:
+        - Repository references
+        - GCP project IDs
+        - Service account configurations
+        - Environment-specific variables
+        """
+        print("⚙️  Exporting GitHub Actions workflows (examples only)...")
+
+        source_dir = os.path.join(self.project_root, ".github", "workflows")
+        if not os.path.exists(source_dir):
+            print("⚠️  Warning: .github/workflows directory not found")
+            return
+
+        target_dir = os.path.join(staging_dir, "workflows")
+        os.makedirs(target_dir, exist_ok=True)
+
+        # Counter for workflows
+        workflows_count = 0
+
+        # Copy workflow files with filtering
+        for workflow_file in sorted(os.listdir(source_dir)):
+            if workflow_file.endswith((".yml", ".yaml")):
+                src_file = os.path.join(source_dir, workflow_file)
+                dst_file = os.path.join(target_dir, workflow_file)
+
+                # Copy the file
+                shutil.copy2(src_file, dst_file)
+
+                # Apply content filtering to make it more generic
+                self._apply_workflow_filtering(dst_file)
+
+                workflows_count += 1
+                print(f"   ⚙️  {workflow_file}")
+
+        # Create README.md for the workflows directory
+        self._create_workflows_readme(target_dir, workflows_count)
+
+        # Store count for summary
+        self.workflows_count = workflows_count
+        print(f"✅ Exported {workflows_count} workflow examples")
+
+    def _apply_workflow_filtering(self, file_path):
+        """Apply project-specific filtering to workflow files."""
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            # Replace project-specific values with placeholders
+            # Order matters: match more specific patterns first to avoid partial matches
+            content = re.sub(
+                r"jleechanorg/worldarchitect\.ai", "$GITHUB_REPOSITORY", content
+            )
+            content = re.sub(r"worldarchitecture-ai", "$GCP_PROJECT_ID", content)
+            content = re.sub(r"worldarchitect\.ai", "your-project.com", content)
+            content = re.sub(r"worldarchitect-ci", "${PROJECT_NAME:-your-project}-ci", content)
+            content = re.sub(r"jleechanorg", "$GITHUB_OWNER", content)
+            content = re.sub(r"\bjleechan\b", "$USER", content)
+
+            # Replace runner-control-plane with inline stub (action not exported to claude-commands)
+            _runner_cp_pattern = (
+                r"(- name: Runner control plane\s*\n\s+id: control-plane\s*\n)\s+uses: \.\/\.github\/actions\/runner-control-plane\s*\n"
+            )
+            _runner_cp_repl = r'''\1        run: |
+          echo "preflight_exit_code=0" >> "$GITHUB_OUTPUT"
+          echo "infra_failure_class=" >> "$GITHUB_OUTPUT"
+          echo "preflight_json=${RUNNER_TEMP:-/tmp}/runner_health.json" >> "$GITHUB_OUTPUT"
+          echo "quarantined=false" >> "$GITHUB_OUTPUT"
+          echo "score=0" >> "$GITHUB_OUTPUT"
+          echo "::notice::Runner control plane skipped - add .github/actions/runner-control-plane for full preflight"
+
+'''
+            content = re.sub(_runner_cp_pattern, _runner_cp_repl, content)
+
+            # Update outdated GitHub Actions to latest secure versions
+            # actions/checkout v4.1.1 (Dec 2023) → v4.3.1 (Nov 2024)
+            content = re.sub(
+                r"actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11",
+                "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1",
+                content
+            )
+
+            # Add header comment to the file indicating it's an example
+            header = """# ⚠️ EXAMPLE WORKFLOW - REQUIRES INTEGRATION
+# This workflow was exported from a working project and serves as an EXAMPLE ONLY.
+# You MUST adapt the following before using:
+# - $GCP_PROJECT_ID → Your Google Cloud project ID
+# - $GITHUB_REPOSITORY → Your repository (owner/repo)
+# - $GITHUB_OWNER → Your GitHub username or org
+# - Service account configurations and secrets
+# - Environment-specific variables and paths
+#
+# See workflows/README.md for integration instructions.
+# ---
+
+"""
+            # Only add header if not already present
+            if "⚠️ EXAMPLE WORKFLOW" not in content:
+                content = header + content
+
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+        except Exception as e:
+            print(f"⚠️  Warning: Workflow filtering failed for {file_path}: {e}")
+            # Remove partially written file to avoid exporting broken workflows
+            try:
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+                    print(
+                        f"   Removed broken workflow file: {os.path.basename(file_path)}"
+                    )
+            except Exception as cleanup_error:
+                print(
+                    f"⚠️  Warning: Failed to remove broken workflow file {file_path}: {cleanup_error}"
+                )
+
+    def _fix_repo_root_path(self, file_path):
+        """Fix REPO_ROOT path calculation for scripts exported to .claude/scripts/.
+
+        Scripts from scripts/ directory use ".." to reach repo root.
+        When exported to .claude/scripts/, they need "../.." instead.
+        """
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            # Fix REPO_ROOT path: scripts/ uses ".." but .claude/scripts/ needs "../.."
+            # Match pattern: REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+            # Replace with: REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+            content = re.sub(
+                r'REPO_ROOT="\$\(cd "\$\{SCRIPT_DIR\}/\.\." && pwd\)"',
+                'REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"',
+                content,
+            )
+
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+        except Exception as e:
+            print(f"⚠️  Warning: REPO_ROOT path fix failed for {file_path}: {e}")
+
+    def _create_workflows_readme(self, workflows_dir, count):
+        """Create a README.md explaining workflows are examples only."""
+        readme_content = f"""# GitHub Actions Workflows - EXAMPLES ONLY
+
+⚠️ **IMPORTANT: These workflows are EXAMPLES and require integration into your codebase.**
+
+## What This Directory Contains
+
+This directory contains **{count} GitHub Actions workflow examples** exported from a working Claude Code project. These serve as reference implementations and templates for common CI/CD patterns.
+
+## ⚠️ Why These Cannot Be Used As-Is
+
+These workflows contain project-specific configurations that **must be adapted** before use:
+
+1. **GCP Project IDs**: References to `$GCP_PROJECT_ID` need your actual Google Cloud project
+2. **Repository References**: `$GITHUB_REPOSITORY` placeholders need your `owner/repo`
+3. **Service Accounts**: Workload Identity Federation and service account configurations are project-specific
+4. **Secrets**: Workflow secrets (API keys, tokens) must be configured in your repository
+5. **Environment Variables**: Project-specific env vars need customization
+6. **Path References**: Some paths may be specific to the original project structure
+
+## How to Integrate These Workflows
+
+### Step 1: Create Your Workflows Directory
+```bash
+mkdir -p .github/workflows
+```
+
+### Step 2: Copy and Adapt Workflows
+For each workflow you want to use:
+
+1. Copy the workflow file to `.github/workflows/`
+2. Replace ALL placeholder values:
+   - `$GCP_PROJECT_ID` → Your GCP project ID (e.g., `my-project-123`)
+   - `$GITHUB_REPOSITORY` → Your repo (e.g., `myorg/myrepo`)
+   - `$GITHUB_OWNER` → Your GitHub username or organization
+   - `$USER` → Your username if applicable
+
+3. Configure required secrets in your repository settings:
+   - `GITHUB_TOKEN` (usually automatic)
+   - `GCP_SERVICE_ACCOUNT` if using GCP deployments
+   - Any API keys referenced in the workflow
+
+### Step 3: Validate Before Committing
+```bash
+# Check YAML syntax
+yamllint .github/workflows/*.yml
+
+# Or use actionlint for GitHub Actions specific validation
+actionlint
+```
+
+## Workflow Categories
+
+### CI/CD Workflows
+- **test.yml** - Run tests on push/PR
+- **deploy-*.yml** - Deployment workflows
+- **presubmit.yml** - Pre-merge validation
+
+### Automation Workflows
+- **pr-cleanup.yml** - Automatic PR maintenance
+- **auto-deploy-*.yml** - Automatic deployment triggers
+- **slash-dispatch.yml** - Slash command dispatching
+
+### Code Quality
+- **hook-tests.yml** - Claude Code hook validation
+- **doc-size-check.yml** - Documentation size limits
+
+## Common Adaptations
+
+### For Google Cloud Deployments
+```yaml
+# Replace this:
+env:
+  GCP_PROJECT: $GCP_PROJECT_ID
+
+# With your actual project:
+env:
+  GCP_PROJECT: my-actual-project-id
+```
+
+### For Repository References
+```yaml
+# Replace this:
+repository: $GITHUB_REPOSITORY
+
+# With your repo:
+repository: myorg/myrepo
+```
+
+### For Service Account Authentication
+Set up Workload Identity Federation or use a service account key:
+```yaml
+- uses: google-github-actions/auth@v2
+  with:
+    workload_identity_provider: projects/YOUR_PROJECT_NUMBER/locations/global/workloadIdentityPools/YOUR_POOL/providers/YOUR_PROVIDER
+    service_account: YOUR_SA@YOUR_PROJECT.iam.gserviceaccount.com
+```
+
+## Need Help?
+
+Claude Code can assist with adapting these workflows to your specific project. Just describe your CI/CD requirements and ask for help customizing the relevant workflow files.
+
+---
+
+**Source**: Exported from [WorldArchitect.AI](https://github.com/jleechanorg/worldarchitect.ai) Claude Code configuration
+"""
+
+        readme_path = os.path.join(workflows_dir, "README.md")
+        with open(readme_path, "w", encoding="utf-8") as f:
+            f.write(readme_content)
+
+        print("   📝 Created workflows/README.md with integration instructions")
+
+    def _apply_content_filtering(self, file_path):
+        """Apply content transformations to files"""
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            # Skip transformations for files that should preserve patterns
+            filename = os.path.basename(file_path)
+            # Skip ALL transformations for:
+            # - exportcommands.py (contains regex patterns that should not be transformed)
+            # - Python test files (contain literal assertion strings that must be preserved)
+            # - loc_simple.sh (uses relative paths intentionally)
+            # Compare by filename because the staging copy lives in a different directory than the source file.
+            # Normalize path for cross-platform compatibility (Windows uses backslashes)
+            normalized_path = file_path.replace(os.sep, '/')
+            is_test_file = filename.startswith("test_") and filename.endswith(".py") and "/tests/" in normalized_path
+            skip_all_transforms = filename == Path(__file__).name or is_test_file
+            skip_mvp_transform = filename == "loc_simple.sh"
+
+            # Apply transformations - Enhanced for portability
+            # Skip all transformations for exportcommands.py to preserve regex patterns
+            if skip_all_transforms:
+                # Don't apply any transformations to exportcommands.py
+                pass
+            else:
+                if not skip_mvp_transform:
+                    # Replace mvp_site/ with $PROJECT_ROOT/ only if not already prefixed with $PROJECT_ROOT
+                    # This prevents: $PROJECT_ROOT/mvp_site/ → $PROJECT_ROOT/$PROJECT_ROOT/
+                    if "$PROJECT_ROOT/" not in content:
+                        content = re.sub(r"mvp_site/", "$PROJECT_ROOT/", content)
+                content = re.sub(r"worldarchitect\.ai", "your-project.com", content)
+                content = re.sub(
+                    r"worldarchitect-ci", "${PROJECT_NAME:-your-project}-ci", content
+                )
+                content = re.sub(r"\bjleechan\b", "$USER", content)
+                content = re.sub(
+                    r"TESTING=true vpython", "TESTING=true python", content
+                )
+                content = re.sub(r"WorldArchitect\.AI", "Your Project", content)
+
+                # New portable patterns
+                content = re.sub(
+                    r"~/worldarchitect\.ai", "$(git rev-parse --show-toplevel)", content
+                )
+                content = re.sub(
+                    r"~/your-project\.com", "$(git rev-parse --show-toplevel)", content
+                )
+                content = re.sub(
+                    r"jleechantest@gmail\.com", "<your-email@gmail.com>", content
+                )
+
+                # NOTE: AI Universe Firebase credentials are intentionally NOT scrubbed
+                # Firebase API keys are safe to expose publicly (protected by domain restrictions, not secrecy)
+                # AI Universe is a shared service - users should use actual credentials
+                # See PR #4291 for rationale
+
+                content = re.sub(
+                    r"/tmp/worldarchitectai", "/tmp/$PROJECT_NAME", content
+                )
+                content = re.sub(
+                    r"/tmp/worldarchitect\.ai", "/tmp/$PROJECT_NAME", content
+                )
+
+                # Hardcoded user/project paths → generic placeholders
+                # Order: specific paths first, then broad.
+                content = re.sub(
+                    r'/Users/\$USER/projects/worktree_ralph(?=/|"|\s|$)',
+                    "$PROJECT_ROOT",
+                    content,
+                )
+                content = re.sub(
+                    r'\$HOME/projects/worktree_ralph(?=/|"|\s|$)',
+                    "$PROJECT_ROOT",
+                    content,
+                )
+                content = re.sub(
+                    r'/Users/\$USER/projects_other/ralph-orchestrator(?=/|"|\s|$)',
+                    "$RALPH_REPO",
+                    content,
+                )
+                content = re.sub(
+                    r'\$HOME/projects_other/ralph-orchestrator(?=/|"|\s|$)',
+                    "$RALPH_REPO",
+                    content,
+                )
+                # Medium-specific paths before broad /Users/$USER/ replacement
+                content = re.sub(
+                    r'/Users/\$USER/projects_other(?=/|"|\s|$)',
+                    "$HOME/projects",
+                    content,
+                )
+                content = re.sub(
+                    r'/Users/\$USER/projects(?=/|"|\s|$)',
+                    "$HOME/projects",
+                    content,
+                )
+                # Broad pattern last - catches remaining /Users/$USER/ occurrences
+                content = re.sub(r"/Users/\$USER/", "$HOME/", content)
+                # Handle GitHub URLs in echo statements with proper quote termination (consolidated pattern)
+                content = re.sub(
+                    r'https://github\.com/jleechanorg/[^/\s"]+(?:\.git)?(?=\${NC}\")',
+                    "$(git config --get remote.origin.url)",
+                    content,
+                )
+
+                # SOURCE_DIR variable patterns - improved matching
+                content = re.sub(
+                    r'\bfind\s+["\']?(?:\./)?mvp_site["\']?',
+                    'find "$SOURCE_DIR"',
+                    content,
+                )
+                content = re.sub(
+                    r'\bcd\s+["\']?(?:\./)?mvp_site["\']?', 'cd "$SOURCE_DIR"', content
+                )
+
+                # Add SOURCE_DIR initialization to scripts that reference mvp_site but don't define it
+                if (
+                    "SOURCE_DIR" in content
+                    and not re.search(r"^\s*SOURCE_DIR=", content, re.MULTILINE)
+                    and "mvp_site" in content
+                ):
+                    # Insert SOURCE_DIR definition after PROJECT_ROOT or early in script
+                    if "PROJECT_ROOT=" in content:
+                        content = re.sub(
+                            r"(PROJECT_ROOT=[^\n]*\n)",
+                            r'\1\n# Source directory for project files\nSOURCE_DIR="$PROJECT_ROOT"\n',
+                            content,
+                        )
+                    else:
+                        # Insert after shebang and initial comments (flexible for any shebang)
+                        content = re.sub(
+                            r"(#![^\n]*\n(?:#[^\n]*\n)*)",
+                            r'\1\n# Source directory for project files\nSOURCE_DIR="$PROJECT_ROOT"\n',
+                            content,
+                        )
+                content = re.sub(
+                    r'if\s+\[\s*!\s*-d\s*["\']mvp_site["\']\s*\]',
+                    'if [ ! -d "$SOURCE_DIR" ]',
+                    content,
+                )
+
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(content)
+
+        except Exception as e:
+            print(f"⚠️  Warning: Content filtering failed for {file_path}: {e}")
+
+    def _determine_version_and_changes(self):
+        """DEPRECATED - Version determination is now handled by LLM in exportcommands.md"""
+        # This method is kept for backward compatibility but is not called
+        # The LLM in exportcommands.md now intelligently determines version and changes
+        # based on git history, recent commits, and actual changes being exported
+        pass
+
+    def _detect_version(self):
+        """Intelligently detect version number using multiple strategies"""
+        try:
+            # Strategy 1: Try to get latest git tag that looks like a version
+            result = subprocess.run(
+                ["git", "describe", "--tags", "--abbrev=0"],
+                capture_output=True,
+                text=True,
+                cwd=self.project_root,
+            )
+            if result.returncode == 0:
+                tag = result.stdout.strip()
+                # Extract version from tag (handle v1.2.3 or 1.2.3 formats)
+                version_match = re.search(r"v?(\d+\.\d+\.\d+)", tag)
+                if version_match:
+                    version = version_match.group(1)
+                    print(f"   📋 Found git tag version: {version}")
+                    return self._increment_version(version)
+        except (subprocess.CalledProcessError, OSError, AttributeError) as e:
+            print(f"   ⚠️ Git tag version detection failed: {e}")
+            pass
+
+        try:
+            # Strategy 2: Try reading VERSION file
+            version_file = os.path.join(self.project_root, "VERSION")
+            if os.path.exists(version_file):
+                with open(version_file, "r") as f:
+                    version = f.read().strip()
+                    print(f"   📋 Found VERSION file: {version}")
+                    return self._increment_version(version)
+        except (FileNotFoundError, OSError, IOError) as e:
+            print(f"   ⚠️ VERSION file not found or unreadable: {e}")
+            pass
+
+        try:
+            # Strategy 3: Try reading package.json version
+            package_json = os.path.join(self.project_root, "package.json")
+            if os.path.exists(package_json):
+                with open(package_json, "r") as f:
+                    data = json.load(f)
+                    if "version" in data:
+                        version = data["version"]
+                        print(f"   📋 Found package.json version: {version}")
+                        return self._increment_version(version)
+        except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError) as e:
+            print(f"   ⚠️ package.json version detection failed: {e}")
+            pass
+
+        # Strategy 4: Check target repository for existing version and increment
+        try:
+            # Try to get existing version from target repository README
+            existing_version = self._get_existing_version_from_target()
+            if existing_version:
+                version = self._increment_version(existing_version)
+                print(
+                    f"   📋 Incremented from existing version: {existing_version} → {version}"
+                )
+                return version
+        except Exception as e:
+            print(f"   ⚠️ GitHub repository version detection failed: {e}")
+            pass
+
+        # For this specific export, we want to use v1.1.0 for today's changes
+        # regardless of what's in the target repository
+        version = "1.1.0"
+        print("   📋 Using v1.1.0 for command count consistency fixes")
+        return version
+
+    def _get_existing_version_from_target(self):
+        """Get the latest version from target repository README"""
+        try:
+            url = "https://raw.githubusercontent.com/jleechanorg/claude-commands/main/README.md"
+            response = requests.get(url, timeout=10)
+            if response.status_code == 200:
+                content = response.text
+                # Look for version patterns like ### v1.2.3
+                versions = re.findall(r"### v(\d+\.\d+\.\d+)", content)
+                if versions:
+                    # Return the latest version (first one found, assuming newest first)
+                    latest = versions[0]
+                    print(f"   📋 Found existing version in target: v{latest}")
+                    return latest
+        except Exception as e:
+            print(f"   ⚠️ Could not fetch existing version: {e}")
+        return None
+
+    def _get_existing_version_history(self, content):
+        """Extract existing version history from target repository content"""
+        try:
+            url = "https://raw.githubusercontent.com/jleechanorg/claude-commands/main/README.md"
+            response = requests.get(url, timeout=10)
+            if response.status_code == 200:
+                existing_content = response.text
+                # Extract the version history section
+                version_section_match = re.search(
+                    r"## 📚 Version History\s*\n\n(.*?)(?=\n---|\nGenerated with|\Z)",
+                    existing_content,
+                    re.DOTALL,
+                )
+                if version_section_match:
+                    existing_history = version_section_match.group(1).strip()
+                    if existing_history and not existing_history.startswith("<!--"):
+                        print(
+                            f"   📋 Found existing version history ({len(existing_history)} chars)"
+                        )
+                        return existing_history
+        except Exception as e:
+            print(f"   ⚠️ Could not fetch existing version history: {e}")
+        return None
+
+    def _increment_version(self, version):
+        """Increment minor version for new export (patch for small changes)"""
+        try:
+            major, minor, patch = map(int, version.split("."))
+            # Increment minor version for this update
+            new_version = f"{major}.{minor + 1}.0"
+            print(f"   📋 Incremented version: {version} → {new_version}")
+            return new_version
+        except (ValueError, AttributeError, IndexError) as e:
+            print(f"   ⚠️ Version parsing failed: {e}")
+            return version  # Return original if parsing fails
+
+    def _replace_llm_placeholders(self, content):
+        """Replace LLM placeholders with actual version information and dynamic command counts"""
+        print("🤖 Generating version information with LLM intelligence...")
+
+        # Replace dynamic placeholders in template BEFORE version processing
+        content = self._replace_dynamic_placeholders(content)
+
+        # Get current date for version
+        current_date = time.strftime("%Y-%m-%d")
+
+        # Intelligently detect version number using multiple strategies
+        version = self._detect_version()
+
+        # Generate new version entry for this release
+        new_version_entry = f"""### v{version} ({current_date})
+
+**Export Statistics**:
+- **{self.commands_count} Commands**: Complete workflow orchestration system
+- **{self.hooks_count} Hooks**: Claude Code automation and workflow hooks
+- **{self.scripts_count} Scripts**: Development and automation tools (scripts/ directory)
+- **{self.skills_count} Skills**: Shared knowledge references (.claude/skills/)
+
+**Major Changes**:
+- **Script Allowlist Expansion**: Added 12 generally useful development scripts to the scripts export
+- **Development Workflow Tools**: Now includes git workflow, code analysis, testing, and CI/CD scripts
+- **Enhanced Export Utility**: Broader coverage of reusable development infrastructure
+
+**New Scripts Included**:
+- **Git Workflow**: create_worktree.sh, push.sh for branch management
+- **Code Analysis**: codebase_loc.sh, loc.sh, loc_simple.sh for metrics
+- **Testing Utilities**: run_tests_with_coverage.sh, run_lint.sh
+- **CI/CD Tools**: setup-github-runner.sh, setup_email.sh
+- **Development Environment**: create_snapshot.sh, schedule_branch_work.sh
+
+**Technical Improvements**:
+- Expanded script_patterns list from 5 to 15 generally useful scripts
+- Better categorization of Claude Code specific vs universally useful tools
+- Enhanced documentation for script adaptability across projects
+
+**Documentation**:
+- Updated scripts export description
+- Clear separation between project-specific and generally useful scripts
+- Improved adaptation guidance for cross-project usage"""
+
+        # Try to get existing version history to preserve it
+        existing_history = self._get_existing_version_history(content)
+
+        # Create full version history (new entry + existing entries)
+        if existing_history:
+            version_entry = new_version_entry + "\n\n" + existing_history
+        else:
+            # Fallback: include previous v1.0.0 entry if no existing history found
+            version_entry = (
+                new_version_entry
+                + """
+
+### v1.0.0 (2025-08-14)
+
+**Export Statistics**:
+- **118 Commands**: Complete workflow orchestration system
+- **21 Hooks**: Claude Code automation and workflow hooks
+- **5 Scripts**: Development and automation tools (scripts/ directory)
+
+**Major Changes**:
+- **Enhanced Export System**: Fixed LLM placeholder replacement for proper version generation
+- **Improved README Processing**: Intelligent version information generation with consistent counting
+- **Template Processing**: Proper template-to-final-README conversion with dynamic content
+- **Version Format**: Maintained v1.x versioning as requested for consistency
+
+**Technical Improvements**:
+- Fixed LLM_VERSION placeholder replacement in README generation
+- Enhanced export statistics tracking with accurate command counting
+- Improved error handling in template processing
+- Consistent version numbering in v1.x format
+
+**Bug Fixes**:
+- Resolved README template placeholder not being replaced with actual content
+- Fixed export command to properly process templates instead of just copying
+- Corrected version information display with consistent command counts
+- Addressed version format concerns (keeping v1.x instead of date-based)
+
+**Documentation**:
+- Updated export workflow documentation with accurate statistics
+- Enhanced template system documentation
+- Improved troubleshooting guides for export issues"""
+            )
+
+        # Replace the LLM placeholder section (with whitespace tolerance)
+        llm_pattern = r"<!--\s*LLM_VERSION_START\s*-->.*?<!--\s*LLM_VERSION_END\s*-->"
+        replacement = version_entry
+
+        content = re.sub(llm_pattern, replacement, content, flags=re.DOTALL)
+
+        return content
+
+    def _replace_dynamic_placeholders(self, content):
+        """Replace dynamic placeholders in template with actual runtime values"""
+        print("🔧 Replacing dynamic placeholders with runtime values...")
+
+        # Define replacement mappings
+        replacements = {
+            # Command count - handles various formats
+            r"\*\*144 commands\*\*": f"**{self.commands_count} commands**",
+            r"\*\*118 commands\*\*": f"**{self.commands_count} commands**",  # Handle legacy counts
+            r"144 commands": f"{self.commands_count} commands",
+            r"118 commands": f"{self.commands_count} commands",  # Handle legacy counts
+            # Export statistics - make them dynamic
+            r"\*\*(\d+) Commands\*\*": f"**{self.commands_count} Commands**",
+            r"\*\*(\d+) Hooks\*\*": f"**{self.hooks_count} Hooks**",
+            r"\*\*(\d+) Scripts\*\*": f"**{self.scripts_count} Scripts**",
+            r"\*\*(\d+) Agents\*\*": f"**{self.agents_count} Agents**",
+            r"\*\*(\d+) Skills\*\*": f"**{self.skills_count} Skills**",
+            r"\*\*(\d+) skills\*\*": f"**{self.skills_count} skills**",
+        }
+
+        # Apply all replacements
+        for pattern, replacement in replacements.items():
+            content = re.sub(pattern, replacement, content)
+
+        print(
+            f"   📊 Dynamic counts: {self.commands_count} commands, {self.hooks_count} hooks, {self.scripts_count} scripts, {self.agents_count} agents, {self.skills_count} skills"
+        )
+        return content
+
+    def _generate_readme(self):
+        """Generate README with LLM placeholder replacement"""
+        # Look for README_EXPORT_TEMPLATE.md in the commands directory
+        readme_template_path = os.path.join(
+            self.project_root, ".claude", "commands", "README_EXPORT_TEMPLATE.md"
+        )
+
+        if os.path.exists(readme_template_path):
+            print("📖 Processing README_EXPORT_TEMPLATE.md with LLM version generation")
+            readme_dest = os.path.join(self.export_dir, "README.md")
+
+            # Read template content
+            with open(readme_template_path, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            # Replace LLM placeholders with actual version information
+            content = self._replace_llm_placeholders(content)
+
+            # Write processed README
+            with open(readme_dest, "w", encoding="utf-8") as f:
+                f.write(content)
+
+            print("✅ Generated README.md with LLM version information")
+        else:
+            print(
+                f"Warning: README_EXPORT_TEMPLATE.md not found at {readme_template_path}"
+            )
+            print("Falling back to basic README generation...")
+            self._generate_fallback_readme()
+
+    def _generate_fallback_readme(self):
+        """Fallback README generation if template not found"""
+        readme_content = f"""# Claude Commands - Command Composition System
+
+⚠️ **REFERENCE EXPORT** - This is a reference export from a working Claude Code project.
+
+## Export Contents
+
+- **{self.commands_count} commands** workflow orchestration commands
+- **{self.hooks_count} hooks** Claude Code automation hooks
+- **{self.scripts_count} scripts** reusable automation scripts (scripts/)
+- **{self.skills_count} skills** shared knowledge references (.claude/skills/)
+
+## MANUAL INSTALLATION
+
+Run these from the export directory (the one containing the `staging/` folder), targeting your project repository as the current working directory:
+
+Copy the exported commands and hooks to your project's `.claude/` directory:
+- Commands → `.claude/commands/`
+- Hooks → `.claude/hooks/`
+- Agents → `.claude/agents/`
+- Scripts → `scripts/` in your project root
+- Skills → `.claude/skills/`
+
+## 📊 **Export Contents**
+
+This comprehensive export includes:
+- **📋 {self.commands_count} Command Definitions** - Complete workflow orchestration system (.claude/commands/)
+- **📎 {self.hooks_count} Claude Code Hooks** - Essential workflow automation (.claude/hooks/)
+- **🤖 {self.agents_count} Agent Definitions** - Specialized task agents for autonomous workflows (.claude/agents/)
+- **🧠 {self.skills_count} Skills** - Knowledge base exports (.claude/skills/)
+- **🔧 {self.scripts_count} Scripts** - Development environment management (scripts/)
+- **🤖 Orchestration System** - Core multi-agent task delegation (project-specific parts excluded)
+- **📚 Complete Documentation** - Setup guide with adaptation examples
+
+🚨 **DIRECTORY EXCLUSIONS APPLIED**: This export excludes the following project-specific directories:
+- ❌ `analysis/` - Project-specific analytics
+- ❌ `claude-bot-commands/` - Project-specific bot implementation
+- ❌ `coding_prompts/` - Project-specific AI prompting templates
+- ❌ `prototype/` - Project-specific experimental code
+
+## 🎯 The Magic: Simple Hooks → Powerful Workflows
+
+### Command Chaining Examples
+```bash
+# Multi-command composition
+"/arch /thinku /devilsadvocate /diligent"  # → comprehensive code analysis
+
+# Sequential workflow chains
+"/think about auth then /execute the solution"  # → analysis → implementation
+
+# Conditional execution flows
+"/test login flow and if fails /fix then /pr"  # → test → fix → create PR
+```
+
+## 📎 **Enhanced Hook System**
+
+This export includes **{self.hooks_count} Claude Code hooks** that provide essential workflow automation with nested directory support and NUL-delimited processing for whitespace-safe file handling.
+
+## 🔧 Setup & Usage
+
+### Quick Start
+```bash
+# 1. Clone this repository to your project
+git clone https://github.com/jleechanorg/claude-commands.git
+
+# 2. Copy commands and hooks to your .claude directory
+cp -r claude-commands/commands/* .claude/commands/
+cp -r claude-commands/hooks/* .claude/hooks/
+cp -r claude-commands/agents/* .claude/agents/
+cp -r claude-commands/skills/* .claude/skills/
+
+# 3. Start Claude Code with MCP servers
+./claude_start.sh
+
+# 4. Begin using composition commands
+/execute "implement user authentication"
+/pr "fix performance issues"
+/copilot  # Fix any PR issues
+```
+
+## 🎯 Adaptation Guide
+
+### Project-Specific Placeholders
+
+Commands contain placeholders that need adaptation:
+- `$PROJECT_ROOT/` → Your project's main directory
+- `your-project.com` → Your domain/project name
+- `$USER` → Your username
+- `TESTING=true python` → Your test execution pattern
+
+### Example Adaptations
+
+**Before** (exported):
+```bash
+TESTING=true python $PROJECT_ROOT/test_file.py
+```
+
+**After** (adapted):
+```bash
+npm test src/components/test_file.js
+```
+
+## ⚠️ Important Notes
+
+### Reference Export
+This is a filtered reference export from a working Claude Code project. Commands may need adaptation for your specific environment, but Claude Code excels at helping you customize them.
+
+### Requirements
+- **Claude Code CLI** - Primary requirement for command execution
+- **Git Repository Context** - Commands operate within git repositories
+- **MCP Server Setup** - Some commands require MCP (Model Context Protocol) servers
+- **Project-Specific Adaptation** - Paths and commands need customization for your environment
+
+---
+
+🚀 **Generated with [Claude Code](https://claude.ai/code)**
+
+**Co-Authored-By: Claude <noreply@anthropic.com>**
+"""
+
+        # Ensure export directory exists
+        os.makedirs(self.export_dir, exist_ok=True)
+
+        readme_path = os.path.join(self.export_dir, "README.md")
+        with open(readme_path, "w") as f:
+            f.write(readme_content)
+
+        print("✅ Generated README.md based on current export state")
+
+    def _create_archive(self):
+        """Create compressed archive of export"""
+        archive_name = f"claude_commands_export_{time.strftime('%Y%m%d_%H%M%S')}.tar.gz"
+        archive_path = os.path.join(self.export_dir, archive_name)
+
+        cmd = [
+            "tar",
+            "-czf",
+            archive_path,
+            "-C",
+            self.export_dir,
+            "staging/",
+            "README.md",
+        ]
+
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            print(f"⚠️  Archive creation failed: {result.stderr}")
+        else:
+            print(f"✅ Created archive: {archive_name}")
+
+    def phase2_github_publish(self):
+        """Phase 2: Publish to GitHub with automatic PR creation"""
+        print("\n🚀 Phase 2: Publishing to GitHub...")
+        print("-" * 40)
+
+        if not self.github_token:
+            raise GitHubAPIError("GITHUB_TOKEN environment variable not set")
+
+        # Clone repository
+        self._clone_repository()
+
+        # Create and switch to export branch
+        self._create_export_branch()
+
+        # Copy exported content
+        self._copy_to_repository()
+
+        # Verify exclusions
+        self._verify_exclusions()
+
+        # Validate no hardcoded paths slipped through
+        self._validate_no_hardcoded_paths()
+
+        # Commit and push
+        self._commit_and_push()
+
+        # Create PR
+        pr_url = self._create_pull_request()
+
+        return pr_url
+
+    def _clone_repository(self):
+        """Clone the target repository"""
+        print("Cloning target repository...")
+
+        # Use system PATH to find gh command with fallback for common locations
+        gh_cmd = shutil.which("gh")
+        if not gh_cmd:
+            # Try common locations for gh (Linux and Windows)
+            common_paths = [
+                os.path.expanduser("~/.local/bin/gh"),  # Linux user install
+                "/usr/local/bin/gh",  # Linux system install
+                os.path.join(
+                    os.path.expanduser("~"), "bin", "gh"
+                ),  # Windows/Linux user bin
+                "C:\\Program Files\\GitHub CLI\\gh.exe",
+                "C:\\Program Files (x86)\\GitHub CLI\\gh.exe",
+            ]
+            for path in common_paths:
+                if os.path.exists(path):
+                    gh_cmd = path
+                    break
+
+            if not gh_cmd:
+                raise GitHubAPIError(
+                    "GitHub CLI (gh) not found in PATH or common locations. Please install GitHub CLI."
+                )
+
+        cmd = [gh_cmd, "repo", "clone", "jleechanorg/claude-commands", self.repo_dir]
+        result = subprocess.run(cmd, capture_output=True, text=True)
+        if result.returncode != 0:
+            raise GitRepositoryError(f"Repository clone failed: {result.stderr}")
+
+        # Configure git to use GITHUB_TOKEN for authentication
+        if self.github_token:
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(self.repo_dir)
+                self._configure_authenticated_remote()
+            except subprocess.CalledProcessError as exc:
+                masked_cmd = []
+                for arg in exc.cmd if hasattr(exc, "cmd") else []:
+                    arg_str = str(arg)
+                    if self.github_token in arg_str:
+                        masked_cmd.append(arg_str.replace(self.github_token, "***"))
+                    else:
+                        masked_cmd.append(arg_str)
+                raise GitRepositoryError(
+                    f"Failed to configure authenticated remote: {' '.join(masked_cmd) or 'git remote set-url origin <redacted>'}"
+                ) from None
+            finally:
+                os.chdir(original_cwd)
+
+        print("✅ Repository cloned")
+
+    def _configure_authenticated_remote(self):
+        """Configure remote to use token authentication without leaking credentials"""
+
+        if not self.github_token:
+            return
+
+        # Use token as password per GitHub requirements
+        remote_url = "https://x-access-token:{token}@github.com/jleechanorg/claude-commands.git".format(
+            token=self.github_token
+        )
+        subprocess.run(["git", "remote", "set-url", "origin", remote_url], check=True)
+
+    def _create_export_branch(self):
+        """Create and switch to export branch"""
+        print(f"🌟 Creating export branch: {self.export_branch}")
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(self.repo_dir)
+
+            # Ensure we're on main and up to date
+            subprocess.run(["git", "checkout", "main"], check=True)
+            subprocess.run(["git", "pull", "origin", "main"], check=True)
+
+            # Create export branch
+            subprocess.run(["git", "checkout", "-b", self.export_branch], check=True)
+
+            print("✅ Export branch created")
+        finally:
+            os.chdir(original_cwd)
+
+    def _copy_to_repository(self):
+        """Copy exported content to repository with proper .claude/ structure"""
+        print("📋 Copying exported content to proper .claude/ directory structure...")
+
+        # 🚨 FIXED: Copy to proper .claude/ directories instead of repository root
+        # Create .claude/ directory structure in target repository
+        claude_dir = os.path.join(self.repo_dir, ".claude")
+        os.makedirs(claude_dir, exist_ok=True)
+
+        # Create target directories with proper .claude/ structure
+        dirs_mapping = {
+            "commands": os.path.join(claude_dir, "commands"),
+            "hooks": os.path.join(claude_dir, "hooks"),
+            "agents": os.path.join(claude_dir, "agents"),
+            "claude_scripts": os.path.join(
+                claude_dir, "scripts"
+            ),  # .claude/scripts directory
+            "skills": os.path.join(claude_dir, "skills"),  # .claude/skills directory
+            "settings_json": os.path.join(
+                claude_dir, "settings.json"
+            ),  # .claude/settings.json file
+            "orchestration": "orchestration",  # Goes to repo root
+            "automation": "automation",  # Goes to repo root
+            "ralph": "ralph",  # PRD-driven autonomous workflow toolkit - goes to repo root
+            "scripts": None,  # Goes to repo root within scripts/
+            "workflows": "workflows",  # GitHub workflows - goes to repo root as examples
+            "CLAUDE.md": "CLAUDE.md",  # Reference doc - goes to repo root
+            "AGENTS.md": "AGENTS.md",  # Reference doc - goes to repo root
+            "reference_commands": os.path.join(self.repo_dir, ".claude_reference", "commands"),  # Archived non-active commands
+        }
+
+        # Create the .claude/ subdirectories (but not for files like settings.json)
+        for local_name, target_path in dirs_mapping.items():
+            # Create directory only if target_path is a directory (no file extension)
+            if (
+                target_path
+                and (target_path.startswith(claude_dir) or local_name == "reference_commands")
+                and not Path(target_path).suffix
+            ):
+                os.makedirs(target_path, exist_ok=True)
+
+        # Copy content with proper directory mapping
+        staging_dir = os.path.join(self.export_dir, "staging")
+        for item in os.listdir(staging_dir):
+            src = os.path.join(staging_dir, item)
+
+            # Map to correct target location
+            if item in dirs_mapping:
+                target_path = dirs_mapping[item]
+                if target_path is None:
+                    # Handle scripts specially - copy to scripts/ directory in repo root
+                    if item == "scripts" and os.path.isdir(src):
+                        scripts_dir = os.path.join(self.repo_dir, "scripts")
+                        os.makedirs(scripts_dir, exist_ok=True)
+
+                        for script_file in sorted(os.listdir(src)):
+                            script_src = os.path.join(src, script_file)
+                            script_dst = os.path.join(scripts_dir, script_file)
+                            if os.path.isfile(script_src):
+                                shutil.copy2(script_src, script_dst)
+                                # Ensure executability for shell/python scripts (Windows-safe)
+                                if script_file.endswith((".sh", ".py")):
+                                    try:
+                                        os.chmod(script_dst, 0o755)
+                                    except (OSError, NotImplementedError):
+                                        pass
+                                print(f"   • Added/Updated: scripts/{script_file}")
+                    continue
+                elif target_path.startswith(claude_dir):
+                    # Copy to .claude/ subdirectory
+                    dst = target_path
+                else:
+                    # Copy to repo root (for orchestration)
+                    dst = os.path.join(self.repo_dir, item)
+            else:
+                # Default: copy to repo root
+                dst = os.path.join(self.repo_dir, item)
+
+            if os.path.isdir(src):
+                # Copy directory contents, preserving existing files
+                self._copy_directory_additive(src, dst)
+            else:
+                # Copy individual files (overwrites if exists, preserves others)
+                shutil.copy2(src, dst)
+
+        # Copy README (this can overwrite)
+        shutil.copy2(os.path.join(self.export_dir, "README.md"), self.repo_dir)
+
+        print("✅ Content copied to proper .claude/ directory structure")
+
+    def _copy_directory_additive(self, src_dir, dst_dir):
+        """Copy directory contents while preserving existing files"""
+        os.makedirs(dst_dir, exist_ok=True)
+
+        for item in os.listdir(src_dir):
+            src_item = os.path.join(src_dir, item)
+            dst_item = os.path.join(dst_dir, item)
+
+            # Skip virtual environments, node_modules, and broken symlinks
+            if item in ("venv", "node_modules", "__pycache__", ".git"):
+                continue
+            if os.path.islink(src_item) and not os.path.exists(src_item):
+                print(f"   ⏭ Skipping broken symlink: {item}")
+                continue
+
+            if os.path.isdir(src_item):
+                self._copy_directory_additive(src_item, dst_item)
+            else:
+                # Copy file (overwrites if exists, but preserves other files in directory)
+                shutil.copy2(src_item, dst_item)
+                print(f"   • Added/Updated: {item}")
+
+        print("✅ Content copied to repository")
+
+    def _verify_exclusions(self):
+        """Verify that excluded directories are not present"""
+        print("🔍 Verifying directory exclusions...")
+
+        excluded_dirs = [
+            "analysis",
+            "claude-bot-commands",
+            "coding_prompts",
+            "prototype",
+        ]
+        found_excluded = []
+
+        for dir_name in excluded_dirs:
+            if os.path.exists(os.path.join(self.repo_dir, dir_name)):
+                found_excluded.append(dir_name)
+
+        if found_excluded:
+            print(f"❌ ERROR: Excluded directories found: {', '.join(found_excluded)}")
+            # Clean them up
+            for dir_name in found_excluded:
+                shutil.rmtree(os.path.join(self.repo_dir, dir_name))
+            print("✅ Cleaned up excluded directories")
+        else:
+            print("✅ Confirmed: No excluded directories in export")
+
+    def _validate_no_hardcoded_paths(self):
+        """Scan exported content for hardcoded user/project paths; warn if found."""
+        print("🔍 Validating export for hardcoded path patterns...")
+        found = []
+        for root, _dirs, files in os.walk(self.repo_dir):
+            # Skip only the actual .git directory
+            if ".git" in Path(root).parts:
+                continue
+            for name in files:
+                # Skip exportcommands.py (contains pattern literals → false positives)
+                if name == "exportcommands.py":
+                    continue
+                if not name.endswith((".md", ".py", ".sh", ".yml", ".yaml")):
+                    continue
+                path = os.path.join(root, name)
+                try:
+                    with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                        content = f.read()
+                except OSError:
+                    continue
+                rel = os.path.relpath(path, self.repo_dir)
+                for pattern, description in self.HARDCODED_PATH_PATTERNS:
+                    if re.search(pattern, content):
+                        found.append((rel, pattern, description))
+        if found:
+            print("⚠️  WARNING: Possible hardcoded paths detected (add to export filter):")
+            for rel, _pat, desc in found[:15]:  # Cap at 15 to avoid noise
+                print(f"   • {rel}: {desc}")
+            if len(found) > 15:
+                print(f"   ... and {len(found) - 15} more")
+        else:
+            print("✅ No hardcoded user paths detected in export")
+
+    def _commit_and_push(self):
+        """Commit changes and push branch"""
+        print("💾 Committing and pushing changes...")
+
+        original_cwd = os.getcwd()
+        os.chdir(self.repo_dir)
+
+        try:
+            # Configure git user for commit (needed in clean clone)
+            subprocess.run(
+                ["git", "config", "user.email", "claude-export@anthropic.com"],
+                check=True,
+            )
+            subprocess.run(["git", "config", "user.name", "Claude Export"], check=True)
+            # Disable commit signing (may not be configured in cloned repo)
+            subprocess.run(["git", "config", "commit.gpgsign", "false"], check=True)
+
+            # Add all changes with error handling
+            try:
+                subprocess.run(["git", "add", "."], check=True)
+            except subprocess.CalledProcessError:
+                # Fallback: add files individually if bulk add fails
+                print("   Bulk git add failed, adding files individually...")
+                for root, dirs, files in os.walk("."):
+                    for file in files:
+                        try:
+                            subprocess.run(
+                                ["git", "add", os.path.join(root, file)], check=True
+                            )
+                        except subprocess.CalledProcessError:
+                            print(
+                                f"   Warning: Could not add {os.path.join(root, file)}"
+                            )
+
+            # Create commit message
+            commit_message = f"""Fresh Claude Commands Export {time.strftime("%Y-%m-%d")}
+
+🚨 DIRECTORY EXCLUSIONS APPLIED:
+- Excluded: analysis/, claude-bot-commands/, coding_prompts/, prototype/
+- These project-specific directories are filtered from exports per requirements
+
+✅ EXPORT CONTENTS:
+- 📋 Commands: {self.commands_count} command definitions with content filtering
+- 📎 Hooks: {self.hooks_count} Claude Code hooks with nested structure
+- 🚀 Scripts: {self.scripts_count} reusable automation scripts (scripts/ directory)
+- 🧠 Skills: {self.skills_count} shared knowledge references (.claude/skills/)
+- ⚙️  Workflows: {self.workflows_count} GitHub Actions workflow examples (require integration)
+- 🤖 Orchestration: Multi-agent task delegation system (core components only)
+- 📚 Documentation: Complete README with installation guide and adaptation examples
+
+🔄 CONTENT TRANSFORMATIONS:
+- mvp_site/ → $PROJECT_ROOT/ (generic project paths)
+- worldarchitect.ai → your-project.com (generic domain)
+- jleechan → $USER (generic username)
+- TESTING=true vpython → TESTING=true python (generic test commands)
+
+Starting MANUAL INSTALLATION: Copy commands to .claude/commands/ and hooks to .claude/hooks/
+
+⚠️ Reference export - requires adaptation for other projects
+🤖 Generated with Claude Code CLI"""
+
+            subprocess.run(["git", "commit", "-m", commit_message], check=True)
+
+            # Push branch
+            subprocess.run(
+                ["git", "push", "-u", "origin", self.export_branch], check=True
+            )
+
+            print("✅ Changes committed and pushed")
+        finally:
+            if self.github_token:
+                try:
+                    self._reset_remote_to_default()
+                except subprocess.CalledProcessError:
+                    print("⚠️  Warning: Could not reset remote to tokenless URL")
+            os.chdir(original_cwd)
+
+    def _reset_remote_to_default(self):
+        """Remove inlined token from git remote configuration"""
+
+        if not getattr(self, "repo_dir", None) or not os.path.exists(self.repo_dir):
+            return
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(self.repo_dir)
+            subprocess.run(
+                [
+                    "git",
+                    "remote",
+                    "set-url",
+                    "origin",
+                    "https://github.com/jleechanorg/claude-commands.git",
+                ],
+                check=True,
+            )
+        finally:
+            os.chdir(original_cwd)
+
+    def _create_pull_request(self):
+        """Create pull request using gh CLI (preferred per CLAUDE.md GitHub protocol)"""
+        print("📝 Creating pull request via gh CLI...")
+
+        pr_title = f"Claude Commands Export {time.strftime('%Y-%m-%d')}: Directory Exclusions Applied"
+        pr_body = f"""**🚨 AUTOMATED EXPORT** with directory exclusions applied per requirements.
+
+## 🎯 Directory Exclusions Applied
+This export **excludes** the following project-specific directories:
+- ❌ `analysis/` - Project-specific analytics and reporting
+- ❌ `claude-bot-commands/` - Project-specific bot implementation
+- ❌ `coding_prompts/` - Project-specific AI prompting templates
+- ❌ `prototype/` - Project-specific experimental code
+
+## ✅ Export Contents
+- **📋 {self.commands_count} Commands**: Complete workflow orchestration system
+- **📎 {self.hooks_count} Hooks**: Essential Claude Code workflow automation
+- **🚀 {self.scripts_count} Scripts**: Development environment management (scripts/ directory)
+- **🧠 {self.skills_count} Skills**: Reference knowledge exports (.claude/skills/)
+- **⚙️  {self.workflows_count} Workflows**: GitHub Actions examples (REQUIRE INTEGRATION)
+- **🤖 Orchestration System**: Core multi-agent task delegation (WIP prototype)
+- **📄 CLAUDE.md**: Filtered reference configuration for Claude Code
+- **📄 AGENTS.md**: Filtered agent guidelines and conventions
+- **📚 Complete Documentation**: Setup guide with adaptation examples
+
+## Manual Installation
+From your project root:
+```bash
+mkdir -p .claude/{{commands,hooks,agents,skills}}
+mkdir -p scripts
+cp -R commands/. .claude/commands/
+cp -R hooks/. .claude/hooks/
+cp -R agents/. .claude/agents/
+cp -R skills/. .claude/skills/
+# Optional scripts directory
+cp -n scripts/* ./scripts/
+```
+
+## 🔄 Content Filtering Applied
+- **Generic Paths**: mvp_site/ → $PROJECT_ROOT/
+- **Generic Domain**: worldarchitect.ai → your-project.com
+- **Generic User**: jleechan → $USER
+- **Generic Commands**: TESTING=true vpython → TESTING=true python
+
+## ⚠️ Reference Export
+This is a filtered reference export. Commands may need adaptation for specific environments, but Claude Code excels at helping customize them for any workflow.
+
+---
+🤖 **Generated with [Claude Code](https://claude.ai/code)**"""
+
+        # Locate gh CLI (same search as _clone_repository)
+        gh_cmd = shutil.which("gh")
+        if not gh_cmd:
+            common_paths = [
+                os.path.expanduser("~/.local/bin/gh"),
+                "/usr/local/bin/gh",
+                os.path.join(os.path.expanduser("~"), "bin", "gh"),
+            ]
+            for path in common_paths:
+                if os.path.exists(path):
+                    gh_cmd = path
+                    break
+
+        if not gh_cmd:
+            raise GitHubAPIError(
+                "GitHub CLI (gh) not found. Install from https://cli.github.com/ or "
+                "run: curl -sL https://github.com/cli/cli/releases/download/v2.40.1/"
+                "gh_2.40.1_linux_amd64.tar.gz | tar -xz -C /tmp && "
+                "mkdir -p ~/.local/bin && cp /tmp/gh_2.40.1_linux_amd64/bin/gh ~/.local/bin/"
+            )
+
+        # Write PR body to temp file to avoid shell quoting issues
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".md", delete=False, encoding="utf-8"
+        ) as body_file:
+            body_file.write(pr_body)
+            body_file_path = body_file.name
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(self.repo_dir)
+            result = subprocess.run(
+                [
+                    gh_cmd,
+                    "pr",
+                    "create",
+                    "--title", pr_title,
+                    "--body-file", body_file_path,
+                    "--base", "main",
+                    "--repo", "jleechanorg/claude-commands",
+                ],
+                capture_output=True,
+                text=True,
+            )
+        finally:
+            os.chdir(original_cwd)
+            try:
+                os.unlink(body_file_path)
+            except OSError:
+                pass
+
+        if result.returncode != 0:
+            raise GitHubAPIError(f"PR creation failed: {result.stderr}")
+
+        # gh pr create prints the PR URL as the last line of stdout
+        pr_url = result.stdout.strip().splitlines()[-1].strip()
+        if not pr_url.startswith("https://"):
+            raise GitHubAPIError(
+                f"Unexpected gh pr create output (no URL found): {result.stdout}"
+            )
+
+        print(f"✅ Pull request created: {pr_url}")
+        return pr_url
+
+    def report_success(self, pr_url):
+        """Report successful export completion"""
+        print("\n🎉 EXPORT COMPLETE!")
+        print("=" * 50)
+        print(f"📂 Local Export: {self.export_dir}")
+        archive_files = [
+            f for f in os.listdir(self.export_dir) if f.endswith(".tar.gz")
+        ]
+        if archive_files:
+            print(f"📦 Archive: {archive_files[0]}")
+        print(f"🌟 Branch: {self.export_branch}")
+        print(f"🔗 Pull Request: {pr_url}")
+        print("\n📊 Export Summary:")
+        print(f"   Commands: {self.commands_count}")
+        print(f"   Hooks: {self.hooks_count}")
+        print(f"   Agents: {self.agents_count}")
+        print(f"   Scripts: {self.scripts_count}")
+        print(f"   Skills: {self.skills_count}")
+        print(f"   Workflows: {self.workflows_count} (examples only)")
+        print(
+            "   Excluded: analysis/, claude-bot-commands/, coding_prompts/, prototype/"
+        )
+        print("\n🎯 The export has been published and is ready for review!")
+
+    def handle_error(self, error):
+        """Handle export errors gracefully"""
+        print(f"\n❌ Export failed: {error}")
+        print(f"📂 Partial export may be available at: {self.export_dir}")
+        if hasattr(self, "repo_dir") and os.path.exists(self.repo_dir):
+            print(f"🗂️  Repository clone: {self.repo_dir}")
+            if self.github_token:
+                try:
+                    self._reset_remote_to_default()
+                except subprocess.CalledProcessError:
+                    print(
+                        "⚠️  Warning: Could not reset remote to tokenless URL during error handling"
+                    )
+        print("\n🔧 Debug information:")
+        print(f"   Project root: {self.project_root}")
+        print(f"   GitHub token set: {'Yes' if self.github_token else 'No'}")
+
+
+def sync_files_differential(source_dir, target_dir):
+    """
+    Synchronize files between source and target directories using differential sync.
+    Deletes files/directories in target that don't exist in source.
+    Preserves files that exist in both directories.
+    """
+    source_path = Path(source_dir)
+    target_path = Path(target_dir)
+
+    # Get all relative paths from source .claude/ directory
+    claude_source_dir = source_path / ".claude"
+    if not claude_source_dir.exists():
+        # If no .claude directory, delete everything in target
+        if target_path.exists():
+            for item in target_path.iterdir():
+                try:
+                    if item.is_file():
+                        item.unlink()
+                    else:
+                        shutil.rmtree(item)
+                except (PermissionError, OSError):
+                    pass  # Skip items we can't delete
+        return
+
+    source_files = set()
+    source_dirs = set()
+
+    for root, dirs, files in os.walk(claude_source_dir):
+        rel_root = Path(root).relative_to(claude_source_dir)
+        for file in files:
+            rel_file_path = rel_root / file if rel_root != Path(".") else Path(file)
+            source_files.add(rel_file_path)
+        for dir in dirs:
+            rel_dir_path = rel_root / dir if rel_root != Path(".") else Path(dir)
+            source_dirs.add(rel_dir_path)
+        # Add intermediate directory paths
+        if rel_root != Path("."):
+            source_dirs.add(rel_root)
+
+    # Track what to delete in target
+    dirs_to_delete = []
+    files_to_delete = []
+
+    # Walk through target directory
+    for root, dirs, files in os.walk(target_dir):
+        rel_root = Path(root).relative_to(target_path)
+
+        # Check files for deletion
+        for file in files:
+            rel_file_path = rel_root / file if rel_root != Path(".") else Path(file)
+            if rel_file_path not in source_files:
+                files_to_delete.append(Path(root) / file)
+
+        # Check directories for deletion
+        for dir in dirs:
+            rel_dir_path = rel_root / dir if rel_root != Path(".") else Path(dir)
+            if rel_dir_path not in source_dirs:
+                dirs_to_delete.append(Path(root) / dir)
+
+    # Delete files first
+    for file_path in files_to_delete:
+        try:
+            file_path.unlink()
+        except (PermissionError, OSError):
+            pass  # Skip files we can't delete due to permissions
+
+    # Delete directories (in reverse order to handle nested dirs)
+    for dir_path in sorted(dirs_to_delete, reverse=True):
+        try:
+            shutil.rmtree(dir_path)
+        except (PermissionError, OSError):
+            pass  # Skip directories we can't delete due to permissions
+
+
+if __name__ == "__main__":
+    exporter = ClaudeCommandsExporter()
+    exporter.export()

--- a/.claude/commands/fe.md
+++ b/.claude/commands/fe.md
@@ -1,0 +1,34 @@
+---
+description: "/fe — alias for /factory-evolve; analyzes cold-review vs in-pipeline reviewer gaps, opens PRs end-to-end, drives each through /green, merges with explicit MERGE APPROVED"
+type: llm-orchestration
+execution_mode: immediate
+aliases: [factory-evolve]
+---
+
+# /fe — Factory Evolve (alias for /factory-evolve)
+
+Dispatches to the **`factory-evolve` skill** at
+`~/.claude/skills/factory-evolve/SKILL.md`. Single writer for the
+workflow is `~/.claude/commands/factory-evolve.md`; this file is a
+thin alias so the multi-phase orchestration (history search → subagent
+fanout → G1+G2 audit → proposals doc → open PRs → /green → merge) is
+identical for both entry points.
+
+**Usage**:
+
+```
+/fe                                  # scan last 7 days, open + drive PRs to /green + merge
+/fe --days 14                        # widen lookback window
+/fe --pr 26                          # audit one specific PR (cold review vs factory wiring)
+/fe --taxonomy                       # structural G1+G2 audit only (no history, no PRs)
+/fe --no-pr                          # write proposals doc only; don't open PRs
+```
+
+**History search MUST use `/history`** (per `~/.claude/CLAUDE.md`
+"History search" rule). Never hand-coded `rg` — the rg pattern misses
+`nohup`/`tee`/multiline invocations.
+
+**Merge is operator-gated.** "MERGE APPROVED" is the only valid merge
+trigger; do not auto-merge.
+
+Equivalent to: `/factory-evolve $ARGUMENTS`

--- a/.claude/skills/advice/SKILL.md
+++ b/.claude/skills/advice/SKILL.md
@@ -55,13 +55,13 @@ agy --print --dangerously-skip-permissions "Senior engineer second opinion.\n\nD
 ```
 Note: agy is the Antigravity CLI (reads CLAUDE.md on startup like any CC session, but starts fresh — no current conversation history). Independent perspective, slightly slower than cursor.
 
-**A4 — claude -p (fallback if A3 errors, or when /advice is invoked outside Claude Code):**
+**A1.1 — `claude -p` (first-class choice when invoked outside Claude Code; fallback if A3 errors):**
 ```bash
 claude -p --dangerously-skip-permissions "Senior engineer second opinion.\n\nDECISION:\n[decision]\n\nARTIFACT:\n[artifact]\n\nReturn VERDICT, REASONING (3-4 sentences), RISK, CONFIDENCE."
 ```
 Note: Same Claude Code context inheritance as agy. For a cleaner isolated call: add `--cwd /tmp`.
 
-If all four fail, note "Reviewer A unavailable" in the synthesis table.
+If all options fail, note "Reviewer A unavailable" in the synthesis table.
 
 ---
 
@@ -108,8 +108,8 @@ Present:
 | Priority | CLI | When |
 |---|---|---|
 | A1 | Claude subagent (Opus) | Primary (inside Claude Code) |
+| A1.1 | `claude -p --dangerously-skip-permissions` | First-class choice when invoked outside Claude Code; fallback if A3/agy errors |
 | A2 | `cursor agent -p --force` | Opus unavailable |
 | A3 | `agy --print --dangerously-skip-permissions` | cursor errors |
-| A4 | `claude -p --dangerously-skip-permissions` | agy errors, or when invoked outside Claude Code |
 
 Note: codex removed — gpt-4.5 unsupported with ChatGPT account + quota exhausted as of 2026-06-24.

--- a/.claude/skills/advice/SKILL.md
+++ b/.claude/skills/advice/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: advice
+description: Token-efficient second opinion slash command /advice. Extracts decision point + artifact (≤150 lines), then fans out in parallel: (1) Opus subagent reviewer with fallback chain codex→agy→cursor, (2) /research on the decision topic, (3) /secondo multi-model opinion. Use instead of advisor() which ships the full conversation uncached.
+---
+
+# /advice — Token-Efficient Second Opinion
+
+**Replaces `advisor()`. Never call advisor() — use this instead.**
+
+## When invoked
+
+`/advice [optional: specific question]` — invoked manually or automatically at a decision point.
+
+## Step 1: Extract the artifact
+
+From the current conversation, extract:
+- **Decision** (3–5 sentences): what specifically needs a second opinion — be concrete about constraints and tradeoffs
+- **Artifact** (≤150 lines): the relevant code, plan, error, diff, or architecture sketch — nothing unrelated
+
+If no specific question was passed, infer from most recent context. If relevant context exceeds 150 lines, summarize the excess into 2–3 sentences prepended before the artifact.
+
+## Step 2: Fan out three reviewers in parallel
+
+Spawn all three in a single message:
+
+---
+
+**Reviewer A — Fallback chain (try in order, stop at first success):**
+
+**A1 — Opus subagent (primary):** Spawn an Agent:
+```
+You are a senior engineer giving a focused second opinion.
+
+DECISION:
+[decision, 3–5 sentences]
+
+ARTIFACT:
+[≤150 lines]
+
+Return exactly:
+VERDICT: [recommended approach, one line]
+REASONING: [3–4 sentences]
+RISK: [main risk, one sentence]
+CONFIDENCE: [high / medium / low]
+```
+
+**A2 — cursor (fallback if A1 errors):**
+```bash
+cursor agent -p --force "Senior engineer second opinion.\n\nDECISION:\n[decision]\n\nARTIFACT:\n[artifact]\n\nReturn VERDICT, REASONING (3-4 sentences), RISK, CONFIDENCE."
+```
+
+**A3 — agy (fallback if A2 errors):**
+```bash
+agy --print --dangerously-skip-permissions "Senior engineer second opinion.\n\nDECISION:\n[decision]\n\nARTIFACT:\n[artifact]\n\nReturn VERDICT, REASONING (3-4 sentences), RISK, CONFIDENCE."
+```
+Note: agy is the Antigravity CLI (reads CLAUDE.md on startup like any CC session, but starts fresh — no current conversation history). Independent perspective, slightly slower than cursor.
+
+**A4 — claude -p (fallback if A3 errors, or when /advice is invoked outside Claude Code):**
+```bash
+claude -p --dangerously-skip-permissions "Senior engineer second opinion.\n\nDECISION:\n[decision]\n\nARTIFACT:\n[artifact]\n\nReturn VERDICT, REASONING (3-4 sentences), RISK, CONFIDENCE."
+```
+Note: Same Claude Code context inheritance as agy. For a cleaner isolated call: add `--cwd /tmp`.
+
+If all four fail, note "Reviewer A unavailable" in the synthesis table.
+
+---
+
+**Reviewer B — Research:**
+
+Invoke `/research [decision topic distilled to 6 words]`
+
+---
+
+**Reviewer C — Secondo:**
+
+Invoke `/secondo` with the decision + artifact (same text as Reviewer A).
+
+---
+
+## Step 3: Synthesize
+
+Present:
+
+```
+| Reviewer  | Verdict              | Key concern         | Confidence |
+|-----------|----------------------|---------------------|------------|
+| A (source)| ...                  | ...                 | high/med/low |
+| Research  | [consensus finding]  | [main caveat]       | —          |
+| Secondo   | ...                  | ...                 | —          |
+```
+
+- 2+ agree → state recommended path, proceed
+- All three diverge → surface disagreement, ask user which axis matters most (speed / safety / cost)
+
+## Token budget
+
+| Reviewer | Tokens sent |
+|---|---|
+| Reviewer A | Decision + artifact ≈ 1,500–2,500 tokens |
+| /research | Web queries only |
+| /secondo | Decision + artifact ≈ 1,500–2,500 tokens |
+| **Total** | **~5,000 tokens vs ~80,000–140,000 for advisor()** |
+
+**96–97% fewer input tokens** per review cycle.
+
+## Fallback chain summary
+
+| Priority | CLI | When |
+|---|---|---|
+| A1 | Claude subagent (Opus) | Primary (inside Claude Code) |
+| A2 | `cursor agent -p --force` | Opus unavailable |
+| A3 | `agy --print --dangerously-skip-permissions` | cursor errors |
+| A4 | `claude -p --dangerously-skip-permissions` | agy errors, or when invoked outside Claude Code |
+
+Note: codex removed — gpt-4.5 unsupported with ChatGPT account + quota exhausted as of 2026-06-24.

--- a/.claude/skills/ponytail/SKILL.md
+++ b/.claude/skills/ponytail/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: ponytail
+description: Lazy senior-dev mode — the seven-rung ladder that decides whether to write code at all, whether to reuse code that already exists, and whether to prefer stdlib/platform/installed deps over a new dependency. Use before writing any code, every PR diff, every fix, every feature. Source attribution included.
+source: https://github.com/DietrichGebert/ponytail/blob/main/.github/copilot-instructions.md
+---
+
+# Ponytail — Lazy Senior Dev Mode
+
+> "The best code is the code never written."
+> — Dietrich Gebert's [ponytail](https://github.com/DietrichGebert/ponytail) `.github/copilot-instructions.md`, adapted as a Claude/Codex skill.
+
+**Lazy means efficient, not careless.** Before writing any code, stop at the first rung that holds.
+
+## The seven-rung ladder
+
+Run these in order, AFTER you understand the problem — not instead of it. Read the task, trace the real flow end-to-end, then climb.
+
+1. **Does this need to be built at all?** (YAGNI)
+2. **Does it already exist in this codebase?** Reuse the helper, util, or pattern that's already here. Don't re-write it.
+3. **Does the standard library already do this?** Use it.
+4. **Does a native platform feature cover it?** Use it.
+5. **Does an already-installed dependency solve it?** Use it.
+6. **Can this be one line?** Make it one line.
+7. **Only then:** write the minimum code that works.
+
+The ladder runs *after* you understand the problem. A small diff you don't understand is just laziness dressed up as efficiency — a second bug in a smaller package.
+
+## Bug fix = root cause, not symptom
+
+A report names a **symptom**. Find the shared function, fix it once.
+
+- Grep every caller of the function you touch.
+- One guard at the shared function is a smaller diff than one guard per caller.
+- Patching only the path the ticket names leaves a sibling caller still broken.
+
+This is the same discipline as `~/.claude/skills/root-cause-first/SKILL.md` — patch the upstream cause, not the surface symptom.
+
+## Hard rules
+
+- **No abstractions that weren't explicitly requested.** Boring over clever. Fewest files possible.
+- **No new dependency if it can be avoided.** Reuse what's installed first.
+- **No boilerplate nobody asked for.** Deletion over addition.
+- **Shortest working diff wins** — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- **Question complex requests.** "Do you actually need X, or does Y cover it?"
+- **Pick the edge-case-correct option** when two stdlib approaches are the same size. Lazy means *less code*, not the *flimsier* algorithm.
+- **Mark intentional simplifications** with a `ponytail:` comment. If the shortcut has a known ceiling (global lock, O(n²) scan, naive heuristic), the comment names the ceiling and the upgrade path.
+
+## Not lazy about
+
+You stay rigorous on:
+
+- **Understanding the problem** — read it fully, trace the real flow before picking a rung.
+- **Input validation at trust boundaries.**
+- **Error handling that prevents data loss.**
+- **Security and accessibility.**
+- **Hardware calibration** — the platform is never the spec ideal. A clock drifts. A sensor reads off.
+- **Anything explicitly requested.**
+
+## Lazy code without its check is unfinished
+
+Non-trivial logic leaves **ONE runnable check** behind:
+
+- The smallest thing that fails if the logic breaks.
+- An assert-based demo / self-check, OR one small test file.
+- No frameworks, no fixtures.
+
+Trivial one-liners need no test.
+
+## When to load this skill
+
+Load `ponytail` BEFORE:
+
+- Writing any new function, helper, or module.
+- Picking a dependency.
+- Adding a layer of indirection.
+- Starting a PR diff.
+- Touching a function more than one caller depends on.
+
+If you find yourself reaching for a new dependency, abstraction, or framework — re-read rung 2 ("already in this codebase?") before rung 5 ("already-installed dependency?"). Order matters: in-tree reuse beats a new package.
+
+## Origin and attribution
+
+- Source: <https://github.com/DietrichGebert/ponytail/blob/main/.github/copilot-instructions.md>
+- License: see the upstream repo.
+- Local copy also exposed to Codex at `~/.codex/skills/ponytail/SKILL.md`.
+
+## Related skills (read alongside)
+
+- `~/.claude/skills/root-cause-first/SKILL.md` — patch the upstream cause, not the symptom. Ponytail's "fix the shared function once" rule and root-cause-first are two sides of the same coin.
+- `~/.claude/skills/zero-framework-cognition/SKILL.md` — never invent heuristic/keyword/regex classification; delegate to a model. Complements ponytail's "no abstractions that weren't asked for."
+- `~/.claude/skills/code-centralization/SKILL.md` — prefer one source of truth over scattered projections. Ponytail rung 2 ("reuse what's here") lives here.
+- `~/.claude/skills/code-standards/SKILL.md` — dispatch adversarial review lanes (ZFC, ZFC-leveling, root-cause-first). Ponytail is the *do* discipline; code-standards is the *check* discipline.

--- a/.claude/skills/runtime-activation-claim/SKILL.md
+++ b/.claude/skills/runtime-activation-claim/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: runtime-activation-claim
+description: Use when making any "X is enabled" / "feature X works" / "cache works" claim in a running session — requires runtime probe output from the standard harness startup path, NOT a launchd/cron test that explicitly sets the activation env var.
+---
+
+# Runtime Activation Claim
+
+## The rule
+
+Before any claim of "feature X is working" / "cache enabled" / "warmup completed" / "feature flag is on":
+
+1. **Read the activation function source** — find `enabled()`, `is_ready()`, `is_active()`, or equivalent property on the relevant class.
+2. **Identify every gate** the function checks (env vars, sys.modules probes, config flags, runtime state).
+3. **For each gate, state what it requires** — name the env var, expected value, runtime precondition.
+4. **Run a probe in a CLEAN subprocess** with NO env override:
+   ```bash
+   python3 -c "from <module> import <Class>; print(<Class>().enabled)"
+   ```
+5. **The probe output MUST be `True`** before claiming the feature works.
+6. **Quote the probe output verbatim** in the claim.
+
+## Banned patterns
+
+- "Cache works" based on launchd/cron test logs where the launchd env set the activation var.
+- "Feature X works" based on a CI run where the env was set via `with mock.patch.dict(...)`.
+- "Warmup completed" based on `_init_event.wait()` returning (it is set at init, not at warmup completion).
+- "enabled=True" based on reading the source code without running it.
+
+## Common multi-gate features in this repo
+
+| Feature | Activation function | Standard harness probe |
+|---------|---------------------|------------------------|
+| `WORLDAI_TEST_CACHE` (ServerCacheManager) | `ServerCacheManager().enabled` | `python3 -c "from testing_mcp.lib.llm_response_cache.server_cache import ServerCacheManager; print(ServerCacheManager().enabled)"` |
+| FastEmbed classifier warmup | (instance attribute) | check `instance.ready` after init |
+| Embed LRU warmup | `embed_cache_warmup.warm_in_background()` | probe with retry until `len(embed_cache) > 0` |
+| BQ cache probes | BigQuery query result | `bq query` against live table |
+
+## Worked example — cache activation
+
+**Claim:** "The local cache is working."
+
+**Wrong evidence:** "I ran the launchd test which sets `WORLDAI_TEST_CACHE=read_write` and it passed."
+
+**Correct evidence:**
+```
+$ python3 -c "from testing_mcp.lib.llm_response_cache.server_cache import ServerCacheManager; print(ServerCacheManager().enabled)"
+True
+```
+
+In the standard harness startup path (NOT launchd env, NOT pytest). Quote the output.
+
+## Counter-example — false claim
+
+**Claim:** "Cache works."
+
+**Wrong test:** `test_cache_cross_run_savings.py` run with `WORLDAI_TEST_CACHE=read_write` explicitly set in the test harness env. Test PASSED → "cache works."
+
+**Why it's wrong:** The test harness sets the activation var, so `enabled()` returns `True` only inside that test run. In the standard `testing_mcp/` startup path (no env override), `enabled()` returns `False` because `start_local_mcp_server()` never ran (or the env wasn't propagated). The launchd test passes but the standard path is broken — exactly the PR #7810 / #7901 root cause.
+
+**How to fix the wrong test:** Remove the explicit env override from the test. Run with the standard harness env. If the test then FAILS, the cache is NOT working in the standard path.
+
+## Failure class
+
+This skill addresses the **"mislabeled artifact" + "repeated manual fix"** failure class. Same pattern has recurred across:
+- PR #7810 (cache-integrity launchd → assumed testing_mcp/ also works)
+- PR #7892 (mock Gemini response shape → claimed stripping verified)
+- PR #7901 (one-line fix → agent claimed "all good")
+- FastEmbed warmup (init_event set at init, /health 200 doesn't expose classifier state)
+
+## Connection to other skills
+
+- `evidence-standards` — for PR-level evidence requirements
+- `bypass-claims` — for circular provenance detection
+- `verification-before-completion` — for broader verification patterns
+
+## How to apply
+
+If you're about to type "X is working" or "cache enabled" or "warmup completed":
+1. Stop. Run the probe.
+2. Paste the probe output.
+3. Only then write the claim.

--- a/.claude/skills/self-hosted-runner-preflight/SKILL.md
+++ b/.claude/skills/self-hosted-runner-preflight/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: self-hosted-runner-preflight
+description: Pre-flight checklist for self-hosted runner failures. Use when investigating low disk, missing runner, or stuck Green Gate on the jleechanorg/worldarchitect.ai fleet. Always verifies host-level container state, not just GitHub API.
+---
+
+# Self-Hosted Runner Pre-Flight
+
+## When to use this skill
+- User says "runner is offline", "runner missing", "CI failed low_disk_space", "Green Gate stuck"
+- `gh api orgs/jleechanorg/actions/runners` shows fewer than 22 runners
+- A workflow run has been "in_progress" on Green Gate >30 minutes
+
+## The 5-questions pre-flight (MANDATORY before any fix)
+
+For each failure class, answer BEFORE proposing a fix:
+
+1. **What does GitHub say?**
+   `gh api orgs/jleechanorg/actions/runners?per_page=100 --jq '.runners[] | {name,status,busy}'`
+2. **What does the host actually have?**
+   - mac: `docker ps --format "{{.Names}}\t{{.Status}}" | grep org-runner-mac-`
+   - jeff-ubuntu: `ssh jeff-ubuntu "DOCKER_HOST=unix:///home/jleechan/.lima/colima/sock/docker.sock docker ps --format '{{.Names}}\t{{.Status}}' | grep org-runner-"`
+3. **What does the disk look like inside the container?**
+   `docker exec <name> df -Pk /` — needs >=1GB free for preflight to pass.
+4. **Is the runner in restart loop?**
+   - `docker ps -a --format "{{.Names}}\t{{.Status}}" | grep Restarting`
+   - If yes, check logs: `docker logs --tail 30 <name>` for 403/registration errors.
+5. **Is Green Gate stuck?**
+   Check the run step "Check smoke gate (gate 8)" — if IN_PROGRESS >30min with no smoke runs on the branch, see Class C re-dispatch.
+
+## Failure-class fixes
+
+### Class A: low_disk_space (>=1 runner has <1GB free inside container)
+- ROOT FIX: edit `self-hosted-oss/pre-job-hook.sh` to add disk cleanup (fires on EVERY job, not periodic).
+- Pattern:
+  ```bash
+  AVAIL_KB="$(df -Pk "${RUNNER_WORKDIR}" 2>/dev/null | awk 'NR==2 {print $4}')"
+  if [[ "$AVAIL_KB" -lt "$DISK_MIN_KB" ]]; then
+    rm -rf /root/.cache/pip
+    rm -rf "${RUNNER_WORKDIR}/<repo>"
+  fi
+  ```
+- Set `DISK_MIN_KB=5242880` (5GB, 5x the preflight threshold).
+- Belt-and-suspenders: add a periodic launchd script (`mac-runner-disk-cleanup.sh` style).
+- Deploy: `bash self-hosted-oss/install.sh` syncs to `~/.local/share/worldarchitect-runners/pre-job-hook.sh` (bind-mounted live — no restart needed).
+- VERIFY: `docker exec <runner> bash -c 'pgrep Runner.Worker'` returns empty (idle), then `df -Pk /` shows >=5GB.
+
+### Class B: missing runner (compose defines N but only N-1 containers exist)
+- mac (ARM64): `RUNNER_COUNT=<N> bash ~/.local/share/worldarchitect-runners/start-runner.sh start`
+- jeff-ubuntu (X64):
+  `ssh jeff-ubuntu "cd ~/projects/worktree_runner/self-hosted-colima && DOCKER_HOST=unix:///home/jleechan/.lima/colima/sock/docker.sock docker compose up -d runner-<N>"`
+- Then verify: `docker ps | grep runner-<N>` and `gh api orgs/jleechanorg/actions/runners --jq '.runners[].name' | grep runner-<N>`
+
+### Class C: Green Gate stuck on gate 8 (smoke)
+- Compare `SKEPTIC_GATE_TRIGGER` SHA pinned in PR comments to `gh pr view <N> --json headRefOid`.
+- If mismatched, re-dispatch in order:
+  ```bash
+  gh workflow run "MCP Smoke Tests" --ref <branch> -f pr_number=<N>
+  gh workflow run "Skeptic Self-Verify" --ref <branch> -f pr_number=<N>
+  gh workflow run green-gate.yml --ref <branch> -f pr_number=<N> -f head_sha=<sha>
+  ```
+- All 3 require `pr_number`; green-gate.yml ALSO requires `head_sha`.
+
+### Class D: token returns 403 from inside container
+- Confirm token length: `docker exec <name> bash -c 'echo ${#ACCESS_TOKEN}'` (should be ~40).
+- Test directly:
+  `docker exec <name> curl -X POST -H "Authorization: token $ACCESS_TOKEN" -H "Accept: application/vnd.github+json" https://api.github.com/orgs/jleechanorg/actions/runners/registration-token`
+- 201 → token fine, timing issue (config.sh ran before API ready), re-run start-runner.
+- 401/403 → token bad/expired, rotate `gh auth token` and re-deploy.
+
+## Anti-patterns
+- Trusting GitHub UI as ground truth for runner health.
+- Proposing "schedule a cron to clean up" as the primary fix (use per-job hook).
+- Re-dispatching Green Gate without first dispatching smoke (gate 8 polls forever).
+- Restarting the container while a job is running (always check `pgrep Runner.Worker` first).
+- Editing the runtime mirror directly (`~/.local/share/worldarchitect-runners/`) — edit `self-hosted-oss/`, then `bash install.sh` to sync.

--- a/.claude/skills/test-tui-claude-feature-via-cmux/SKILL.md
+++ b/.claude/skills/test-tui-claude-feature-via-cmux/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: test-tui-claude-feature-via-cmux
+description: When asked to verify whether a Claude Code feature works (especially slash commands, dialogs, pickers, status indicators), spawn a real interactive TUI session in cmux — never use `claude --print "/feature"` as a test, because --print is non-interactive and will always return "isn't available in this environment" regardless of whether the feature actually works.
+when_to_use: "Use when the user asks 'does Claude Code feature X work', 'verify /feature works', 'test the slash command', or any verification question about a Claude Code TUI-only feature. Also use proactively when about to write `claude --print \"/<feature>\"` to test anything — that's the wrong test. Trigger phrases: 'verify /', 'test /', 'check that /', 'is /feature available', 'does the advisor work', 'does the model picker work', 'is the slash command working'."
+allowed-tools: [Bash, Read]
+context: inline
+---
+
+# Test TUI-only Claude Code features via cmux, not `--print`
+
+## When to use this skill
+
+Use this skill any time a verification question is about a Claude Code feature
+that is implemented in the TUI (slash commands, dialogs, pickers, status bar
+indicators, settings menus). The most common failure mode is treating
+`claude --print "/feature"` as a test — it isn't, and the resulting
+"isn't available in this environment" error leads to wasted time reading
+minified binary strings chasing phantom gates.
+
+**Trigger phrases** (load this skill when you see any of these):
+
+- "Does /advisor work?"
+- "Does the /config menu show X?"
+- "Is the /model picker working?"
+- "Verify the slash command"
+- "Test the Claude Code TUI feature"
+- Any verification question where the answer is a slash command, dialog,
+  picker, or status indicator
+
+**Do NOT use this skill** for:
+
+- Plain completion questions (`--print "what model are you?"` works)
+- Tool use / file reading / API contract tests (`--print` is fine)
+- Anything that doesn't involve a TUI slash command, dialog, or picker
+
+## The core rule
+
+`claude --print` is **non-interactive mode**. Slash commands render inside the
+Ink TUI as menus, dialogs, or pickers — they have no `--print` representation.
+The binary's response to any TUI slash command in `--print` mode is always:
+
+> `/<feature> isn't available in this environment.`
+
+That error specifically means "I cannot show you this in non-interactive
+mode," **not** "this feature is broken." Treating it as a feature-gate
+failure is the mistake this skill exists to prevent.
+
+## The correct test path
+
+```bash
+# 1. Spawn a fresh Claude Code workspace in cmux
+export CMUX_SOCKET_PATH=/private/tmp/cmux-debug-may-18.sock
+WS_OUT=$(cmux new-workspace --cwd "$PWD" --command "claude")
+WS=$(echo "$WS_OUT" | grep -oE 'workspace:[0-9]+' | head -1)
+
+# 2. Find the auto-created surface
+sleep 2
+SURF=$(cmux list-pane-surfaces --workspace "$WS" 2>/dev/null \
+       | grep -oE 'surface:[0-9]+' | head -1)
+
+# 3. Wait for Claude to be ready (look for the `❯` prompt in screen text)
+cmux read-screen --workspace "$WS" --surface "$SURF" --scrollback --lines 30
+
+# 4. Send the slash command + press Enter
+cmux send --workspace "$WS" --surface "$SURF" "/advisor"
+cmux send-key --workspace "$WS" --surface "$SURF" enter
+
+# 5. Read the result (dialog, picker, error message, etc.)
+sleep 2
+cmux read-screen --workspace "$WS" --surface "$SURF" --scrollback --lines 50
+
+# 6. Clean up — Esc out + close workspace
+cmux send-key --workspace "$WS" --surface "$SURF" escape
+cmux close-workspace --workspace "$WS"
+```
+
+For multi-step TUI flows (multi-screen dialogs, follow-up pickers), repeat
+steps 4-5 with appropriate `send-key` calls between (arrow keys, enter,
+etc.). See the cmux skill (`~/.hermes_prod/skills/cmux/SKILL.md`) for the
+full key set.
+
+## Bundled helper: `scripts/test-tui-feature.sh`
+
+A wrapper script that takes the slash command as an argument and runs the
+full spawn-send-read-cleanup cycle:
+
+```bash
+~/.claude/skills/test-tui-claude-feature-via-cmux/scripts/test-tui-feature.sh /advisor
+~/.claude/skills/test-tui-claude-feature-via-cmux/scripts/test-tui-feature.sh /config
+~/.claude/skills/test-tui-claude-feature-via-cmux/scripts/test-tui-feature.sh /model
+```
+
+The script:
+1. Spawns a cmux workspace running `claude`
+2. Waits for the `❯` prompt (polls read-screen with a 30s timeout)
+3. Sends the slash command + Enter
+4. Reads the resulting screen text
+5. Cleans up the workspace
+6. Exits 0 on success, 1 on timeout/error
+
+## What this skill prevents
+
+- 30+ minute rabbit holes reading minified JS bundles (`isFirstPartyApiBackend`,
+  `xr()`, `VW()`, `oct()`, `isFirstPartyAnthropicBaseUrl`)
+- Phantom-gate theorizing: "maybe the proxy is making it not first-party?"
+- Adding redundant env vars to `settings.json` (e.g. `_CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL=1`)
+  that don't change behavior
+- Burning context on debug output that doesn't apply to the actual test environment
+- Forgetting that the user is observing the test (cmux makes it shareable)
+
+## When --print IS valid evidence
+
+`--print` is fine for:
+
+- Simple completion tasks: `claude --print "what model are you?"`
+- API contract tests: tool use, file reading, error handling, schema validation
+- Streaming behavior, response time, error recovery
+- Anything that doesn't require a TUI slash command, dialog, picker, or status bar
+
+**Rule of thumb**: if the question is "does this feature work in the
+TUI" or "does this slash command do X" → use cmux. If the question is
+"can the model do X" or "does the API return Y" → `--print` is fine.
+
+## Common false alarms
+
+| Symptom | Likely real cause | Test that proves it |
+|---|---|---|
+| `--print "/advisor"` returns "isn't available" | Normal non-interactive behavior | Open in cmux, see picker |
+| `--print "/advisor"` returns 401 / auth error | OAuth or keychain issue | `claude --print "what model are you?"` — if that works, auth is fine |
+| `claude` in TUI never reaches `❯` prompt | Workspace trust, settings issue | `cmux read-screen` shows what's actually on screen |
+| Slash command opens but shows wrong content | Real bug — model/state issue | Reproduce in cmux, check the actual dialog |
+
+## Verified example (2026-06-23)
+
+**Test target**: `advisorModel: "claude-opus-4-8"` in `~/.claude/settings.json`
+— was the advisor actually using Opus 4.8?
+
+- `claude --print "/advisor"` (with and without various `ANTHROPIC_BASE_URL`
+  settings) → always returned "isn't available in this environment"
+- `cmux send "/advisor" + enter` in `workspace:30 surface:65` → opened the
+  picker dialog showing `1. Fable 5 / ❯ 2. Opus 4.8 ✔ / 3. Sonnet 4.6 / 4. No advisor`
+- The `✔` on Opus 4.8 = current selection = the `advisorModel` setting was
+  being read correctly. Feature was working the whole time.
+
+The user had to push back twice ("are you opening claude code itself and
+typing `/advisor`?", "use cmux stop being lazy") before the correct test
+was performed.
+
+## References
+
+- cmux skill: `~/.hermes_prod/skills/cmux/SKILL.md`
+- Source memory file: `~/.claude/projects/-Users-jleechan--hermes-prod/memory/bestpractice_2026-06-23_test-tui-features-via-cmux.md`
+- Wiki source page: `~/llm_wiki/wiki/sources/bestpractice-2026-06-23-test-tui-features-via-cmux.md`
+- Wiki concept: `~/llm_wiki/wiki/concepts/TUISlashCommandTesting.md`
+- Bead: `jleechan-37uv` (closed)
+- Roadmap: `~/roadmap/learnings-2026-06.md` entry dated 2026-06-23
+- Claude Code binary version: 2.1.185 (verified)

--- a/.claude/skills/test-tui-claude-feature-via-cmux/scripts/test-tui-feature.sh
+++ b/.claude/skills/test-tui-claude-feature-via-cmux/scripts/test-tui-feature.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# test-tui-feature.sh — Spawn a Claude Code TUI session in cmux, send a slash
+# command, read the result, and clean up. Use for testing TUI-only features
+# (slash commands, dialogs, pickers, status indicators) that --print cannot
+# exercise.
+#
+# Usage: test-tui-feature.sh <slash-command> [wait_seconds]
+#   <slash-command>  e.g. "/advisor", "/config", "/model"
+#   [wait_seconds]   optional, default 2 (how long to wait after sending the
+#                    slash command before reading the screen)
+#
+# Exit codes:
+#   0 — slash command sent, screen read returned non-empty
+#   1 — cmux command failed or workspace not found
+#   2 — slash command did not produce visible output within wait_seconds
+#   3 — claude never reached the `❯` prompt within 30s
+#
+# Environment:
+#   CMUX_SOCKET_PATH  — default /private/tmp/cmux-debug-may-18.sock
+#   CLAUDE_CWD        — default $PWD (the directory claude should run in)
+
+set -u
+
+SLASH_CMD="${1:-}"
+WAIT_SECONDS="${2:-2}"
+
+if [ -z "$SLASH_CMD" ]; then
+  echo "Usage: $0 <slash-command> [wait_seconds]" >&2
+  echo "  e.g. $0 /advisor" >&2
+  exit 1
+fi
+
+SOCKET="${CMUX_SOCKET_PATH:-/private/tmp/cmux-debug-may-18.sock}"
+CWD="${CLAUDE_CWD:-$PWD}"
+
+# Verify cmux is reachable
+if [ ! -S "$SOCKET" ]; then
+  echo "cmux socket not found at $SOCKET" >&2
+  echo "  override with: CMUX_SOCKET_PATH=/path/to/cmux.sock" >&2
+  exit 1
+fi
+
+# Verify cmux CLI is on PATH
+if ! command -v cmux >/dev/null 2>&1; then
+  echo "cmux CLI not found in PATH" >&2
+  exit 1
+fi
+
+cleanup() {
+  if [ -n "${WS:-}" ]; then
+    cmux send-key --workspace "$WS" --surface "${SURF:-}" escape >/dev/null 2>&1 || true
+    cmux close-workspace --workspace "$WS" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+echo ">>> Spawning claude in cmux workspace..."
+WS_OUT=$(cmux new-workspace --cwd "$CWD" --command "claude" 2>&1)
+WS=$(echo "$WS_OUT" | grep -oE 'workspace:[0-9]+' | head -1)
+if [ -z "$WS" ]; then
+  echo "Failed to create workspace: $WS_OUT" >&2
+  exit 1
+fi
+echo "    workspace: $WS"
+
+# Wait for the surface to appear
+sleep 2
+SURF=$(cmux list-pane-surfaces --workspace "$WS" 2>/dev/null | grep -oE 'surface:[0-9]+' | head -1)
+if [ -z "$SURF" ]; then
+  echo "No surface found in $WS" >&2
+  exit 1
+fi
+echo "    surface: $SURF"
+
+# Wait for claude to be ready (look for `❯` prompt)
+echo ">>> Waiting for claude to be ready..."
+READY=0
+for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+  SCREEN=$(cmux read-screen --workspace "$WS" --surface "$SURF" --scrollback --lines 50 2>/dev/null)
+  if echo "$SCREEN" | grep -q "❯"; then
+    READY=1
+    break
+  fi
+  sleep 2
+done
+if [ "$READY" -ne 1 ]; then
+  echo "claude did not reach `❯` prompt within 30s" >&2
+  echo "  last screen:" >&2
+  echo "$SCREEN" | tail -20 >&2
+  exit 3
+fi
+echo "    ready (prompt visible)"
+
+# Send the slash command + Enter
+echo ">>> Sending: $SLASH_CMD"
+cmux send --workspace "$WS" --surface "$SURF" "$SLASH_CMD" >/dev/null 2>&1
+cmux send-key --workspace "$WS" --surface "$SURF" enter >/dev/null 2>&1
+
+# Wait for the result to render
+sleep "$WAIT_SECONDS"
+
+# Read the screen
+echo ">>> Screen after $SLASH_CMD:"
+echo "---"
+RESULT=$(cmux read-screen --workspace "$WS" --surface "$SURF" --scrollback --lines 50 2>/dev/null)
+echo "$RESULT"
+echo "---"
+
+# Validate non-empty result
+if [ -z "$RESULT" ] || [ "$(echo "$RESULT" | wc -l)" -lt 2 ]; then
+  echo "Slash command produced no visible output" >&2
+  exit 2
+fi
+
+# Check for the "isn't available in this environment" error — if we see it,
+# something is wrong because we ARE in an interactive TUI session
+if echo "$RESULT" | grep -q "isn't available in this environment"; then
+  echo "ERROR: slash command returned non-interactive error despite being in TUI" >&2
+  exit 2
+fi
+
+echo ">>> OK"
+exit 0

--- a/.claude/skills/test-tui-claude-feature-via-cmux/tests/test_test-tui-feature.sh
+++ b/.claude/skills/test-tui-claude-feature-via-cmux/tests/test_test-tui-feature.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# test_test-tui-feature.sh — Unit tests for test-tui-feature.sh
+#
+# These cover the deterministic parts of the helper:
+#   - Argument validation (missing slash command → exit 1, usage printed)
+#   - SOCKET detection (missing socket → exit 1, clear error)
+#   - Screen output validation (the "isn't available" detector works)
+#
+# The full TUI flow (spawn claude, send slash command, read screen) requires
+# cmux + a real claude binary and is verified by the integration smoke test
+# described in the SKILL.md "Verified example" section.
+
+set -u
+
+SCRIPT="$HOME/.claude/skills/test-tui-claude-feature-via-cmux/scripts/test-tui-feature.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+  echo "FAIL: $SCRIPT not executable"
+  exit 1
+fi
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+  local name="$1" haystack="$2" needle="$3"
+  if echo "$haystack" | grep -q "$needle"; then
+    echo "  PASS: $name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name"
+    echo "    expected to contain: $needle"
+    echo "    got: $haystack"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_exit() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $name (exit $actual)"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $name (expected exit $expected, got $actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Test 1: missing slash command → exit 1, usage printed
+echo "Test 1: missing slash command"
+OUTPUT=$("$SCRIPT" 2>&1)
+EXIT=$?
+assert_contains "prints usage" "$OUTPUT" "Usage:"
+assert_exit "exits 1" 1 "$EXIT"
+
+# Test 2: missing socket → exit 1, error mentions socket
+echo "Test 2: missing CMUX_SOCKET_PATH"
+OUTPUT=$(CMUX_SOCKET_PATH=/nonexistent/path/cmux.sock "$SCRIPT" /advisor 2>&1)
+EXIT=$?
+assert_contains "mentions cmux socket" "$OUTPUT" "cmux socket not found"
+assert_exit "exits 1" 1 "$EXIT"
+
+# Test 3: cmux not on PATH → exit 1
+echo "Test 3: cmux CLI not in PATH"
+OUTPUT=$(PATH="/usr/bin:/bin" "$SCRIPT" /advisor 2>&1)
+EXIT=$?
+assert_contains "mentions cmux CLI" "$OUTPUT" "cmux CLI not found"
+# Could be 1 or 0 if socket check fails first; just check that it errored
+if [ "$EXIT" -ne 0 ]; then
+  echo "  PASS: exits non-zero (exit $EXIT)"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: should exit non-zero"
+  FAIL=$((FAIL + 1))
+fi
+
+echo
+echo "=== Summary ==="
+echo "Passed: $PASS"
+echo "Failed: $FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Background
Since the previous PR ([PR #311](https://github.com/jleechanorg/claude-commands/pull/311)) was merged, we are opening this new PR to export the remaining missing active skills and commands from `~/.claude/` and to apply the `A1.1` fallback chain fix for the `/advice` skill.

## Goals
- Add missing active skills:
  - `runtime-activation-claim` (skill)
  - `ponytail` (skill)
  - `self-hosted-runner-preflight` (skill)
  - `test-tui-claude-feature-via-cmux` (skill, including helper scripts/tests)
- Add missing commands:
  - `fe.md` (command alias for `factory-evolve`)
  - `exportcommands.py` (command exporter script)
- Fix `/advice` skill fallback chain: designate `claude -p` as `A1.1` (first-class option when run outside Claude Code, fallback if A3 errors).

## Tenets
- **Resilience**: Clear fallback paths and diagnostic guidelines.
- **Accuracy**: Precise specifications of when and how features are declared active.
- **Portability**: Storing scripts and references in the repo rather than only locally in the home folder.

## High-Level Description
This PR exports several reference skills, aliases, and testing/export utilities for developer environment management. It also updates the `/advice` command workflow so that `claude -p` is properly prioritized as `A1.1` (which acts as a first-class choice when invoked outside of Claude Code, and fallback if `agy` errors inside Claude Code).

## Testing
- Manual Verification: Checked file existence and content alignment in local user config.
- Checked YAML frontmatter headers for Codex loader compatibility.

## Low-Level Details
- `.claude/skills/ponytail/`: Lazy senior dev rules.
- `.claude/skills/runtime-activation-claim/`: Probing requirements for feature checks.
- `.claude/skills/self-hosted-runner-preflight/`: Preflight checks and hooks.
- `.claude/skills/test-tui-claude-feature-via-cmux/`: CMUX-based Claude Code interactive testing files.
- `.claude/commands/fe.md`: Shortcut alias to `factory-evolve`.
- `.claude/commands/exportcommands.py`: Exporter automation script.
- `.claude/skills/advice/SKILL.md`: Fallback priority updates (A4 -> A1.1).

## User Stories
- N/A: Developer-only utility commands, not visible to end-users.

## Governing Design Doc
- N/A (Developer tooling config)

## Bead ID
- N/A (Developer tooling config)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only docs, aliases, and export automation; no production runtime or auth paths. Main risk is accidental leakage of project-specific paths via export filtering, which the script already validates.
> 
> **Overview**
> Exports additional **active** Claude Code reference material and tightens reviewer fallback behavior for `/advice`.
> 
> **New skills** document operational discipline: **runtime activation claims** (probe before “feature works”), **ponytail** (lazy senior-dev ladder before new code/deps), **self-hosted runner preflight** (host + GitHub checks for the runner fleet), and **test TUI features via cmux** (interactive slash-command verification with `test-tui-feature.sh` + unit tests).
> 
> **Commands / tooling:** adds **`/fe`** as a thin alias to **`/factory-evolve`** (same skill, operator-gated merge), and lands **`exportcommands.py`** — the full local-staging → GitHub PR publish pipeline (filtering, `.claude/` layout, workflow sanitization).
> 
> **`/advice`:** reorders the Reviewer A chain so **`claude -p` is A1.1** — first-class outside Claude Code and fallback after `agy`, replacing the old A4 slot.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1689117064756e50d740f00f277a8320445068ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->