### PR TITLE
[antig] Fix YAML frontmatter syntax in advice skill description

### DIFF
--- a/.claude/skills/advice/SKILL.md
+++ b/.claude/skills/advice/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advice
-description: Token-efficient second opinion slash command /advice. Extracts decision point + artifact (≤150 lines), then fans out in parallel: (1) Opus subagent reviewer with fallback chain codex→agy→cursor, (2) /research on the decision topic, (3) /secondo multi-model opinion. Use instead of advisor() which ships the full conversation uncached.
+description: "Token-efficient second opinion slash command /advice. Extracts decision point + artifact (≤150 lines), then fans out in parallel: (1) Opus subagent reviewer with fallback chain codex→agy→cursor, (2) /research on the decision topic, (3) /secondo multi-model opinion. Use instead of advisor() which ships the full conversation uncached."
 ---
 
 # /advice — Token-Efficient Second Opinion


### PR DESCRIPTION
## Summary

Fixes the YAML frontmatter error visible in the GitHub file preview at
<https://github.com/jleechanorg/claude-commands/blob/main/.claude/skills/advice/SKILL.md>:

> Error in user YAML: (<unknown>): mapping values are not allowed in this
> context at line 2 column 142

The `description` field contains the substring `parallel: (1)` which GitHub's
stricter YAML renderer (js-yaml) treats as a nested mapping because the value
is unquoted. Wrapping the description in double quotes resolves the parse error
without changing the displayed text.

## Context

- PR #312 was merged to `main` as `9c7c177`, but the description was unquoted in
  the merged tree.
- A previous fix (commit `0f094770` on `export-missing-skills-and-fixes`) added
  the quotes but was committed 4 minutes after the PR #312 merge happened, so
  it never reached `main`.
- `~/.claude/skills/advice/SKILL.md` (user-scope mirror) already has the
  correct, quoted version — only the repo copy needs this fix.

## Change

```diff
-description: Token-efficient second opinion slash command /advice. ...
+description: "Token-efficient second opinion slash command /advice. ..."
```

## User Stories

- As a developer browsing the repo on GitHub, I want the SKILL.md preview to
  render correctly (no red YAML error banner) so I can read the description.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.claude/skills/advice/SKILL.md').read().split('---',2)[1])"`
  → parses without error, returns `{name: 'advice', description: '...'}`.
- Visual diff: one line, no content change to the rendered markdown body.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line documentation/frontmatter fix with no runtime or security impact.
> 
> **Overview**
> Fixes GitHub’s YAML frontmatter parse error on `.claude/skills/advice/SKILL.md` by wrapping the `description` value in **double quotes**.
> 
> The unquoted text included `parallel: (1)`, which **js-yaml** treated as a nested mapping instead of plain prose. **Quoted description** restores a valid preview banner and leaves the markdown body unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83864ebd19a155784a332bffb886ac545daf1a05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->