### PR TITLE
[antig] Add YAML frontmatter validation check to test_installation.sh

### DIFF
--- a/test_installation.sh
+++ b/test_installation.sh
@@ -233,6 +233,52 @@ if [ "$ROOT_CHECK_FAILED" -eq 0 ]; then
         echo "  ❌ Found $UNREADABLE unreadable files"
         TEST_FAILURES=$((TEST_FAILURES + 1))
     fi
+
+    # Test 11: Validate YAML frontmatter in all SKILL.md files
+    echo ""
+    echo "✓ Test 11: Validating YAML frontmatter in SKILL.md files..."
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    INVALID_FRONTMATTER=0
+
+    if command -v python3 >/dev/null 2>&1; then
+        while IFS= read -r skill_file; do
+            if ! python3 -c "
+import sys, yaml
+try:
+    content = open('$skill_file').read()
+    parts = content.split('---')
+    if len(parts) < 3:
+        print('  ❌ $skill_file: Missing YAML frontmatter delimiters (---)')
+        sys.exit(1)
+    fm = yaml.safe_load(parts[1])
+    if not isinstance(fm, dict):
+        print('  ❌ $skill_file: Frontmatter is not a key-value mapping')
+        sys.exit(1)
+    if 'name' not in fm:
+        print('  ❌ $skill_file: Missing required field \"name\"')
+        sys.exit(1)
+    if 'description' not in fm:
+        print('  ❌ $skill_file: Missing required field \"description\"')
+        sys.exit(1)
+except Exception as e:
+    print(f'  ❌ $skill_file: Invalid YAML frontmatter: {e}')
+    sys.exit(1)
+" 2>/dev/null; then
+                INVALID_FRONTMATTER=$((INVALID_FRONTMATTER + 1))
+            else
+                echo "  ✅ $skill_file frontmatter is valid"
+            fi
+        done < <(find .claude/skills -name "SKILL.md" -type f)
+
+        if [ $INVALID_FRONTMATTER -eq 0 ]; then
+            echo "  ✅ All SKILL.md frontmatter files are valid"
+        else
+            echo "  ❌ Found $INVALID_FRONTMATTER invalid SKILL.md files"
+            TEST_FAILURES=$((TEST_FAILURES + 1))
+        fi
+    else
+        echo "  ⚠️  Skipping SKILL.md frontmatter validation (python3 not available)"
+    fi
 fi
 
 # Summary


### PR DESCRIPTION
## Background
To prevent YAML frontmatter formatting syntax errors in `SKILL.md` files (such as unquoted colons, missing names, or incorrect mappings) from being merged in the future, we are introducing automated YAML frontmatter validation.

## Goals
- Add Test 11 to `test_installation.sh` to recursively check and validate all `SKILL.md` frontmatter in the repository using Python's `yaml` parser.

## Tenets
- **Automation**: Block invalid metadata formats programmatically before commits/merges.
- **Durability**: Drill down to the root cause of YAML syntax errors by adding automated verification checks.

## High-Level Description
Integrates a new test step (`Test 11`) to `test_installation.sh` that programmatically loads and parses YAML frontmatter in all skills, checking for valid syntax and required `name` and `description` fields.

## Testing
- Verified locally by running `bash test_installation.sh`, which successfully scans all repository skills and detects formatting errors.

## Low-Level Details
- `test_installation.sh`: Implements Test 11 YAML parser validation loop.

## User Stories
- N/A: Tooling check only.

## Governing Design Doc
- N/A

## Bead ID
- N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/install tooling only; no runtime product or auth/data paths change.
> 
> **Overview**
> Adds **Test 11** to `test_installation.sh` so the install script recursively finds every `SKILL.md` under `.claude/skills` and validates its YAML frontmatter before merges.
> 
> When `python3` is available, each file is checked for `---` delimiters, parseable YAML via `yaml.safe_load`, a mapping-shaped frontmatter block, and required **`name`** and **`description`** fields; failures increment `TEST_FAILURES` and print per-file errors. If `python3` is missing, the test is skipped with a warning, matching other optional checks in the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9698e926a61f16a7a63d25743e1009989433f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->