### PR TITLE
feat(commands): add /swarm and /sidekick from user-scope

### DIFF
--- a/.claude/commands/sidekick.md
+++ b/.claude/commands/sidekick.md
@@ -1,0 +1,15 @@
+# /sidekick — spawn or respawn the persistent orchestrator teammate
+
+Load and follow the `sidekick` skill at `~/.claude/skills/sidekick/SKILL.md` (Skill tool: `sidekick`).
+
+Usage: `/sidekick [model] [mission...]`
+
+- `/sidekick` — respawn from the current branch's `/tmp/<repo>/sidekick/<branch_name>/STATE.md` (crash recovery; `/`→`-` in branch names), default model sonnet
+- `/sidekick fable` — respawn on the Fable model (token-economy block included: sub-agents cost-routed to sonnet/haiku)
+- `/sidekick fable fix CI, then drive PRs to green` — fresh mission: write initial STATE.md, create tasks, spawn
+
+Behavior contract (details in the skill):
+1. State file first — respawns never overwrite an existing STATE.md
+2. One named background teammate via Agent tool; shared TaskList lanes
+3. Commit-often discipline propagated verbatim to all sub-agents
+4. Never merge / never force-push; milestone reports relayed to the user

--- a/.claude/commands/swarm.md
+++ b/.claude/commands/swarm.md
@@ -1,0 +1,36 @@
+---
+description: /swarm — orchestrate multi-agent swarms (ultracode workflows + agent-team lanes) with adversarial verification
+type: llm-orchestration
+execution_mode: immediate
+---
+
+# /swarm <goal> [--engine workflow|team|sidekick] [--shape retro|review|solutions|innov|triage] [--sidekick [model]]
+
+Run the goal as a multi-agent swarm with adversarial verification, cost-routed subagents, and artifacts committed to a PR.
+
+Read `~/.claude/skills/swarm/SKILL.md` and execute the full playbook with the provided goal.
+
+## Defaults
+
+- Engine: Workflow tool (ultracode). Agent teams only for interactive lanes needing mid-flight steering.
+- Durability: ALL swarm work runs INSIDE a sidekick by default (`--sidekick [fable|sonnet]` only overrides the model; see `~/.claude/skills/sidekick/SKILL.md`): state at `/tmp/<repo>/sidekick/<branch>/STATE.md`, commit-often propagated to all sub-agents, restart via `/sidekick` in any session. The main loop supervises and relays only — exception: a single quick fan-out (<15 min, user watching) may run inline.
+- Verification: 3-lens refute-by-default, ≥2/3 to survive; audit dead-verifier false kills.
+- Models: haiku (mechanical), sonnet (miners/verifiers/docs); never let fan-outs inherit the session model.
+- Output: disjoint OUTDIR per lane under repo `docs/` (or `~/roadmap/`), commit+push per completed package.
+- Close-out: /advice pass → PR comment with runId/agent/token provenance → /learn.
+
+## Examples
+
+```text
+# Monthly design retrospective swarm (Collect→Verify→Synthesize→Plan)
+/swarm design retrospective for last month --shape retro
+
+# Adversarial code-quality sweep of your_app (Review→Verify→Innovate→Docs)
+/swarm code quality audit of your_app --shape review
+
+# Innovation pass over existing design docs (Innovate→Challenge)
+/swarm one smartest addition per design doc in docs/plans/<dir> --shape innov
+
+# Crash-recoverable overnight fleet drive owned by a fable sidekick
+/swarm fix CI health then drive all open PRs to green --sidekick fable
+```


### PR DESCRIPTION
Surgical export of ~/.claude/commands/swarm.md and sidekick.md to jleechanorg/claude-commands.

Source files:
- ~/.claude/commands/swarm.md (2022 B → 36 lines after filters)
- ~/.claude/commands/sidekick.md (897 B → 15 lines after filters)

Content filters applied (8 perl substitutions per ~/.claude/commands/exportcommands.sh):
- jleechanorg/worldarchitect.ai → $GITHUB_REPOSITORY
- worldarchitect.ai → your-project.com
- \bjleechan\b → $USER
- jleechan2015@gmail.com → your-email@example.com
- jleechan@users.noreply.github.com → your-email@example.com
- WorldArchitect.AI → YourProject
- TESTING=true vpython → TESTING=true python
- mvp_site/ → your_app/

Verified clean: zero /Users/jleechan, jleechan2015, or org-safety pattern matches in staged diff.

Complements PR #315 which ships the .claude/skills/swarm/ and .claude/skills/sidekick/ SKILL.md files those commands load at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions to slash-command markdown with no runtime code, auth, or data-path changes.
> 
> **Overview**
> Adds two new Claude Code slash commands under `.claude/commands/`, extending the plugin’s command surface beyond existing entries like `/cerebras`.
> 
> **`/sidekick`** documents how to spawn or crash-recover a persistent background orchestrator: load the `sidekick` skill, optional model/mission args, branch-scoped `STATE.md` under `/tmp`, shared TaskList lanes, commit-often rules, and no merge/force-push.
> 
> **`/swarm`** is an `llm-orchestration` command with frontmatter for immediate execution. It defines multi-agent swarm goals (engines, shapes, sidekick durability), default verification and model routing, artifact output paths, and example invocations (retro, review, innov, overnight CI/PR drives).
> 
> Content is a sanitized export from user-scope commands (org/user placeholders such as `your_app/` and `$GITHUB_REPOSITORY`), meant to pair with the swarm/sidekick **skills** shipped separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea54479d17fcf63a9c9e64a379e5d7bcfa547e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->