### PR TITLE
fix(code-standards): make user-scope command project-agnostic + add bidirectional pointer contract + add worldai-only banners to repo-specific commands

### DIFF
--- a/.claude/commands/benchg-ts.md
+++ b/.claude/commands/benchg-ts.md
@@ -1,8 +1,17 @@
 ---
-description: "/benchg-ts - TypeScript Migration Benchmark: Genesis vs Ralph"
+description: "/benchg-ts - TypeScript Migration Benchmark: Genesis vs Ralph (worldarchitect.ai only — hardcoded to worldai_genesis2 / worldai_ralph2 target paths under worktree_ralph/)"
 type: orchestration
 execution_mode: immediate
 ---
+> **Worldai-only command.** This is a TypeScript migration benchmark
+> comparing the Genesis and Ralph orchestration systems. It hardcodes
+> worldarchitect.ai paths (`/Users/$USER/projects/worktree_ralph/`,
+> `worldai_genesis2`, `worldai_ralph2`) and worldai-specific LLM cost
+> weights. The repo-local counterpart lives at
+> `jleechanorg/worldarchitect.ai/.claude/commands/benchg-ts.md` and is
+> preferred when working in that repo. When invoked outside the worldai
+> repo, the hardcoded paths will not resolve.
+
 # /benchg-ts - TypeScript Migration Benchmark: Genesis vs Ralph
 
 **Command Summary**: Execute comprehensive TypeScript migration benchmark comparing Genesis and Ralph orchestration systems with automated monitoring, validation, and reporting

--- a/.claude/commands/code-standards.md
+++ b/.claude/commands/code-standards.md
@@ -1,16 +1,25 @@
 ---
-description: "User-scope /code-standards — review code, diffs, PRs, or proposed implementations against the user-wide standards: ZFC, ZFC leveling, root-cause-first, and the ponytail (lazy senior dev) ladder. Same skill family lives at `~/.claude/skills/code-standards/SKILL.md`."
+description: "Project-agnostic /code-standards — review code, diffs, PRs, or proposed implementations against the user-wide standards (ZFC, ZFC leveling, root-cause-first, ponytail). The repo-local command at .claude/commands/code-standards.md (when present in the working repo) ADDS repo-specific behavior and MUST be loaded alongside this one."
 type: quality
 execution_mode: immediate
 ---
 
 # /code-standards [scope]
 
-> This is the **user-scope** `/code-standards` command, at
+> This is the **project-agnostic** `/code-standards` command, at
 > `~/.claude/commands/code-standards.md`, so every repo — including ones
 > without a repo-local `.claude/commands/code-standards.md` — can invoke the
-> same review lanes against the same source skills. **If a repo-local
-> `.claude/commands/code-standards.md` exists, prefer it.**
+> same review lanes against the same source skills.
+>
+> **Bidirectional pointer contract:**
+> 1. If the working repo has its own `.claude/commands/code-standards.md`,
+>    load **BOTH** this file AND the repo-local one. The repo-local file is
+>    allowed to add repo-specific lanes (e.g. `/thermo`, repo-specific smoke
+>    markers, repo-specific example scopes) but MUST NOT redefine the four
+>    user-scope lanes — those live here.
+> 2. The repo-local file MUST contain a reciprocal pointer back to this file
+>    so the two stay synchronized.
+> 3. If a repo-local file is absent, this file is the complete implementation.
 
 Read `~/.claude/skills/code-standards/SKILL.md` and execute the full
 four-lane workflow (ponytail, ZFC, ZFC leveling, root-cause-first) against
@@ -25,15 +34,32 @@ four-lane workflow (ponytail, ZFC, ZFC leveling, root-cause-first) against
 | ZFC leveling | `~/.claude/skills/zfc-leveling-roadmap/SKILL.md` |
 | Root-cause-first | `~/.claude/skills/root-cause-first/SKILL.md` |
 
+If a repo-local command adds extra lanes (e.g. `/thermo`), they layer on top
+of the four above — they do not replace them.
+
 ## Flags
 
 - `smoke-test` — load-only check; reports command/skill paths and revision
-  marker without dispatching review lanes or editing files.
+  marker without dispatching review lanes or editing files. The repo-local
+  command may define its own marker, but `smoke-test` mode semantics are
+  shared.
 
 ## Examples
 
 ```
 /code-standards
-/code-standards $PROJECT_ROOT/rewards_engine.py
+/code-standards <relative/path/to/file>
+/code-standards <branch-or-pr>
 /code-standards smoke-test
 ```
+
+Always pair this command with the repo-local `.claude/commands/code-standards.md`
+when one exists in the working repo. The two are intentionally designed to
+co-exist; do not delete either one.
+
+## For Codex callers
+
+`~/.codex/commands/code-standards.md` is the Codex-side dispatcher. If a
+repo-local `.codex/commands/code-standards.md` exists, prefer it; otherwise
+load `~/.codex/commands/code-standards.md` and follow the same bidirectional
+contract above.

--- a/.claude/commands/end2end-testing.md
+++ b/.claude/commands/end2end-testing.md
@@ -1,8 +1,17 @@
 ---
-description: /end2end-testing - Show end-to-end testing principles and patterns
+description: /end2end-testing - Show end-to-end testing principles and patterns (worldarchitect.ai only — primary E2E directory is $PROJECT_ROOT/tests/test_end2end/)
 type: documentation
 execution_mode: immediate
 ---
+> **Worldai-only command.** This command's content is specific to
+> `jleechanorg/worldarchitect.ai` (Fake Firestore, Fake LLM, the
+> `$PROJECT_ROOT/tests/test_end2end/` directory, and `End2EndBaseTestCase`).
+> The repo-local counterpart lives at
+> `jleechanorg/worldarchitect.ai/.claude/commands/end2end-testing.md` and
+> is preferred when working in that repo. When invoked outside the worldai
+> repo, this file is the fallback but the E2E directory paths will not
+> exist.
+
 ## ⚡ EXECUTION INSTRUCTIONS FOR CLAUDE
 **When this command is invoked, YOU (Claude) must execute these steps immediately:**
 

--- a/.claude/commands/feature-dev.md
+++ b/.claude/commands/feature-dev.md
@@ -1,9 +1,16 @@
 ---
-description: Guided feature development with systematic codebase understanding and architecture focus
+description: Guided feature development with systematic codebase understanding and architecture focus (worldarchitect.ai only — defaults to $PROJECT_ROOT/ layouts and Flask/Firebase/Gemini patterns)
 type: llm-orchestration
 execution_mode: immediate
 argument-hint: Optional feature description
 ---
+
+> **Worldai-only command.** Hardcoded to the WorldArchitect.AI narrative
+> (Python / Flask / Firebase / Gemini) and the `$PROJECT_ROOT/` package
+> layout. The repo-local counterpart lives at
+> `jleechanorg/worldarchitect.ai/.claude/commands/feature-dev.md` and is
+> preferred when working in that repo. When invoked outside the worldai
+> repo, the layout and stack assumptions will not apply.
 
 ## ⚡ EXECUTION INSTRUCTIONS FOR CLAUDE
 **When this command is invoked, YOU (Claude) must execute these steps immediately.**

--- a/.claude/commands/gene.md
+++ b/.claude/commands/gene.md
@@ -1,8 +1,14 @@
 ---
-description: /gene - Genesis Execution (Auto-Execute)
+description: /gene - Genesis Execution (Auto-Execute) (worldarchitect.ai only — the Genesis orchestration system is part of WorldArchitect.AI)
 type: llm-orchestration
 execution_mode: immediate
 ---
+> **Worldai-only command.** Genesis is the WorldArchitect.AI orchestration
+> system. The repo-local counterpart lives at
+> `jleechanorg/worldarchitect.ai/.claude/commands/gene.md` and is preferred
+> when working in that repo. When invoked outside the worldai repo, the
+> Genesis-specific routing/state assumptions will not apply.
+
 ## ⚡ EXECUTION INSTRUCTIONS FOR CLAUDE
 **When this command is invoked, YOU (Claude) must execute these steps immediately:**
 **This is NOT documentation - these are COMMANDS to execute right now.**

--- a/.claude/commands/investigatedice.md
+++ b/.claude/commands/investigatedice.md
@@ -1,8 +1,16 @@
 ---
-description: Investigate dice integrity warnings for a campaign. Queries GCP logs, Firestore story entries, and game_state to diagnose dice fabrication issues.
+description: Investigate dice integrity warnings for a campaign. Queries GCP logs, Firestore story entries, and game_state to diagnose dice fabrication issues. (worldarchitect.ai only — queries GCP project worldarchitecture-ai and the dice service.)
 type: llm-orchestration
 execution_mode: immediate
 ---
+> **Worldai-only command.** Hardcoded to the worldarchitect.ai GCP project
+> (`worldarchitecture-ai`), the worldai dice service, and the
+> `mvp_site/world_logic.py` injection path. The repo-local counterpart
+> lives at
+> `jleechanorg/worldarchitect.ai/.claude/commands/investigatedice.md`
+> (currently a thin pointer to this file). When invoked outside the
+> worldai repo, the GCP queries will fail.
+
 ## EXECUTION INSTRUCTIONS FOR CLAUDE
 **When this command is invoked, execute these steps immediately.**
 **This is NOT documentation - these are COMMANDS to execute right now.**

--- a/.claude/commands/worldai-usage-email.md
+++ b/.claude/commands/worldai-usage-email.md
@@ -1,8 +1,15 @@
 ---
-description: Send daily/weekly Your Project usage report email to $USER@gmail.com
+description: Send daily/weekly Your Project usage report email to $USER@gmail.com (worldarchitect.ai only — requires worldarchitect.ai worktree + scripts/daily_campaign_report.py)
 type: git
 execution_mode: manual
 ---
+> **Worldai-only command.** Sends the WorldArchitect.AI daily + weekly
+> usage report. Requires a `worldarchitect.ai` worktree on disk and the
+> `scripts/daily_campaign_report.py` script. The repo-local counterpart
+> lives at
+> `jleechanorg/worldarchitect.ai/.claude/commands/worldai-usage-email.md`
+> (currently a thin pointer to this file).
+
 # WorldAI Usage Email - Send Daily/Weekly Report
 
 Sends the Your Project daily + weekly usage report email to $USER@gmail.com.


### PR DESCRIPTION
## Summary

Two related cleanups in the user-scope `~/.claude/commands/` reference library:

1. **/code-standards bidirectional pointer contract** — the user-scope `/code-standards` command and skill were previously worldarchitect.ai-flavored (they referenced `jleechanorg/worldarchitect.ai/.claude/commands/code-standards.md` as the source of truth). This makes them project-agnostic with an explicit bidirectional contract: when a working repo has its own `.claude/commands/code-standards.md`, both files load and the repo-local file is allowed to add repo-specific lanes (`/thermo`, `/es` evidence rule) without forking the four user-scope lanes (ponytail, ZFC, ZFC leveling, root-cause-first).

2. **Worldai-only banners on repo-specific commands** — six commands in `~/.claude/commands/` contain worldarchitect.ai-specific content (GCP project names, mvp_site paths, hardcoded worldai email, flask/firebase/gemini stack, etc.). Each now has a > Worldai-only command banner + reciprocal pointer to the repo-local copy:
   - end2end-testing.md (Fake Firestore, mvp_site/tests/test_end2end/)
   - investigatedice.md (GCP worldarchitecture-ai, worldai dice service)
   - worldai-usage-email.md (worldarchitect.ai worktree + daily_campaign_report.py)
   - feature-dev.md (Flask/Firebase/Gemini, mvp_site/ layouts)
   - gene.md (Genesis = WorldArchitect.AI orchestration)
   - benchg-ts.md (hardcoded worktree_ralph/worldai_genesis2/worldai_ralph2)

## Paired PR

This is paired with a PR on `jleechanorg/worldarchitect.ai` that:
- Updates `.claude/commands/code-standards.md` to add the reciprocal "always look for the user-scope counterpart" rule
- Adds 7 thin repo-local pointer files (`af.md`, `auto-factory.md`, `benchg-ts.md`, `feature-dev.md`, `gene.md`, `investigatedice.md`, `worldai-usage-email.md`) so the worldai command surface is self-contained

## Files changed (8)

```
.claude/commands/benchg-ts.md           | 11 +++++-
.claude/commands/code-standards.md      | 70 +++++++++++++++++++++++++--------
.claude/commands/end2end-testing.md     | 11 +++++-
.claude/commands/feature-dev.md         |  9 ++++-
.claude/commands/gene.md                |  8 +++-
.claude/commands/investigatedice.md     | 10 ++++-
.claude/commands/worldai-usage-email.md |  9 ++++-
.claude/skills/code-standards/SKILL.md  | 31 +++++++++++++++
8 files changed, 136 insertions(+), 23 deletions(-)
```

## What I did NOT change

- **exportcommands.md**: the tracked copy is already project-agnostic (no YAML frontmatter, references `~/.claude/` + `~/.hermes/` as superset sources). No banner needed.
- **auto-factory.md and af.md**: live as symlinks in `~/.claude/` pointing to `~/projects/dark-factory/.claude/commands/`. The dark-factory repo has its own worktree on `fix-af-multirepo-dispatch` (WIP checkpoint); banner additions there are parked for follow-up.
- **Conditional references** in evidence stacks (e.g. `/skeptic verdict (worldarchitect.ai PRs)` in `/a`/`/fullrun`, `mvp_site/**` examples in `/green`/`/er`/`/evidence_review`): these are conditional mentions, not repo-specific logic. Left as-is.

## Testing

- `git diff --check` clean
- All changes are documentation-only; no executable code paths in this repo change
- Bidirectional pointer contract verified by hand-tracing: repo-local `.claude/commands/code-standards.md` will reference `~/.claude/commands/code-standards.md` (this file), and the SKILL.md bidirectional contract section explicitly requires the reciprocal pointer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only command/skill documentation; no runtime or application code paths change.
> 
> **Overview**
> Documentation-only updates to the user-scope `~/.claude/commands/` library so multi-repo callers know what to load and when paths are WorldArchitect-specific.
> 
> **`/code-standards`** is reframed as **project-agnostic** (no longer “prefer repo-local as sole source of truth”). It adds an explicit **bidirectional pointer contract**: if the working repo has `.claude/commands/code-standards.md`, load **both** files; repo-local may add lanes (e.g. `/thermo`) but must not redefine the four user-scope lanes. Examples are generalized, and **Codex** dispatchers are told to follow the same contract.
> 
> **Six WorldArchitect-specific commands** (`benchg-ts`, `end2end-testing`, `feature-dev`, `gene`, `investigatedice`, `worldai-usage-email`) get **“Worldai-only command”** callouts, richer YAML `description` text (GCP paths, stacks, hardcoded worktrees), and pointers to the preferred repo-local copies under `jleechanorg/worldarchitect.ai`.
> 
> Paired with a separate worldai repo PR for reciprocal `code-standards` pointers and thin repo-local command stubs; executable behavior in this repo is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a93b65cee9a18ff18772f2f5bb133bca1c199cba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->