### PR TITLE
fix(backup): back up hermes config + workspace/* to both git + dropbox

### DIFF
--- a/scripts/backup-home.sh
+++ b/scripts/backup-home.sh
@@ -890,6 +890,22 @@ BACKUP_ITEMS=(
   # Not git-tracked because sessions are large ephemeral chat history.
   "copy|$HOME/.hermes/sessions/||hermes_conversations/hermes/sessions/||sync"
   "copy|$HOME/.hermes_prod/sessions/||hermes_conversations/hermes_prod/sessions/||sync"
+  # Hermes config + workspace policy/state — small text files, mirror to BOTH git and Dropbox.
+  # Excludes secrets (auth.json, .env), SQLite (state.db* would need a sqlite backup mode row),
+  # launchd plists (tracked in the canonical hermes repo), and *.bak pre-edit copies.
+  # Added 2026-07-14: the SOUL.md Subagent-model-routing /up rule landed in the live file
+  # but was never snapshotted because BACKUP_ITEMS only covered hermes/sessions/.
+  "copy|$HOME/.hermes/CLAUDE.md|hermes/CLAUDE.md|hermes_conversations/CLAUDE.md||sync"
+  "copy|$HOME/.hermes/config.yaml|hermes/config.yaml|hermes_conversations/config.yaml|,*.bak|sync"
+  "copy|$HOME/.hermes/agent-orchestrator.yaml|hermes/agent-orchestrator.yaml|hermes_conversations/agent-orchestrator.yaml|,*.bak|sync"
+  "copy|$HOME/.hermes/workspace/SOUL.md|hermes/workspace/SOUL.md|hermes_conversations/workspace/SOUL.md||sync"
+  "copy|$HOME/.hermes/workspace/HEARTBEAT.md|hermes/workspace/HEARTBEAT.md|hermes_conversations/workspace/HEARTBEAT.md||sync"
+  "copy|$HOME/.hermes/workspace/AGENTS.md|hermes/workspace/AGENTS.md|hermes_conversations/workspace/AGENTS.md||sync"
+  "copy|$HOME/.hermes/workspace/IDENTITY.md|hermes/workspace/IDENTITY.md|hermes_conversations/workspace/IDENTITY.md||sync"
+  "copy|$HOME/.hermes/workspace/MEMORY.md|hermes/workspace/MEMORY.md|hermes_conversations/workspace/MEMORY.md||sync"
+  "copy|$HOME/.hermes/workspace/USER.md|hermes/workspace/USER.md|hermes_conversations/workspace/USER.md||sync"
+  "copy|$HOME/.hermes/workspace/TOOLS.md|hermes/workspace/TOOLS.md|hermes_conversations/workspace/TOOLS.md||sync"
+  "copy|$HOME/.hermes/workspace/BOOTSTRAP.md|hermes/workspace/BOOTSTRAP.md|hermes_conversations/workspace/BOOTSTRAP.md||sync"
   "copy|$HOME/.claude/agents/|claude/agents/|claude_conversations/agents/||sync"
   "copy|$HOME/.claude/hooks/|claude/hooks/|claude_conversations/hooks/||sync"
   "copy|$HOME/.claude/CLAUDE.md|claude/CLAUDE.md|claude_conversations/CLAUDE.md||sync"


### PR DESCRIPTION
## Background

backup-home.sh currently only covers `~/.hermes/sessions/` and `~/.hermes_prod/sessions/` (Dropbox-only, 3.8GB ephemeral chat history). Other useful hermes state — the user-scope `~/.hermes/CLAUDE.md` overlay, `config.yaml`, `agent-orchestrator.yaml`, and the `workspace/` policy files (SOUL.md, HEARTBEAT.md, AGENTS.md, IDENTITY.md, MEMORY.md, USER.md, TOOLS.md, BOOTSTRAP.md) — never made it into BACKUP_ITEMS.

Concretely: the 2026-07-14 `/up` rule for subagent model routing landed in `~/.hermes/workspace/SOUL.md` but the change was invisible to the backup target until a manual run with `TOKEN_HEALTH_PRECHECK=0` was performed during this work.

## Goals

- Extend `BACKUP_ITEMS` so the small hermes text files are mirrored to **both** git + Dropbox.
- Exclude secrets (`auth.json`, `auth.lock`, `.env*`), large SQLite (`state.db*`), launchd plists (already in canonical hermes repo), and `*.bak` pre-edit copies.
- Keep `backup/` in `.gitignore` — snapshots never reach the public repo, only Dropbox and the gitignored local working tree.

## Tenets

- **No secrets to git** — credentials stay in macOS Keychain; `auth.json` and `*.env` are explicitly not in BACKUP_ITEMS.
- **Hermes sessions stay Dropbox-only** — 3.8GB ephemeral history is not for the git working tree.
- **Bead-first** — bead `jleechan-58n` carries the contract; PR body and commit message cross-reference it.

## High-level description

Single-file change. Adds 11 new rows to `BACKUP_ITEMS` in `scripts/backup-home.sh`:

| Source | git_rel | dropbox_rel | exclude |
|---|---|---|---|
| `~/.hermes/CLAUDE.md` | `hermes/CLAUDE.md` | `hermes_conversations/CLAUDE.md` | — |
| `~/.hermes/config.yaml` | `hermes/config.yaml` | `hermes_conversations/config.yaml` | `*.bak` |
| `~/.hermes/agent-orchestrator.yaml` | `hermes/agent-orchestrator.yaml` | `hermes_conversations/agent-orchestrator.yaml` | `*.bak` |
| `~/.hermes/workspace/SOUL.md` | `hermes/workspace/SOUL.md` | `hermes_conversations/workspace/SOUL.md` | — |
| `~/.hermes/workspace/HEARTBEAT.md` | …/HEARTBEAT.md | …/HEARTBEAT.md | — |
| `~/.hermes/workspace/AGENTS.md` | …/AGENTS.md | …/AGENTS.md | — |
| `~/.hermes/workspace/IDENTITY.md` | …/IDENTITY.md | …/IDENTITY.md | — |
| `~/.hermes/workspace/MEMORY.md` | …/MEMORY.md | …/MEMORY.md | — |
| `~/.hermes/workspace/USER.md` | …/USER.md | …/USER.md | — |
| `~/.hermes/workspace/TOOLS.md` | …/TOOLS.md | …/TOOLS.md | — |
| `~/.hermes/workspace/BOOTSTRAP.md` | …/BOOTSTRAP.md | …/BOOTSTRAP.md | — (skipped if absent) |

## Testing

- `bash scripts/backup-home.sh --dry-run` — verified both `[git]` and `[dropbox]` targets plan to copy each new file. `BOOTSTRAP.md` reports `SKIP missing` (file doesn't exist on this machine — harmless, future installs auto-pick up).
- `TOKEN_HEALTH_PRECHECK=0 bash scripts/backup-home.sh` — live run. `Home backup results: git=SUCCESS dropbox=SUCCESS`. Verified:
  - `backup/jeffreys-macbook-pro/hermes/workspace/SOUL.md` contains `## Subagent model routing (mandatory, 2026-07-14)`
  - `~/Library/CloudStorage/Dropbox/conversation-backups/hermes_conversations/workspace/SOUL.md` contains the same heading
- No git push happened — `backup/` is gitignored, so even with `ALLOW_GIT_BACKUP_PUSH=1` set in env, no leakage reached `origin/main`.

## Low-level details

- 16-line change, 0 deletions.
- No script defaults flipped (REQUIRE_DROPBOX_ONLY=1, ALLOW_GIT_BACKUP_PUSH=0, ALLOW_GIT_BACKUP_SYNC=0 unchanged). The plist template is untouched (still matches `origin/main`).
- The unrelated launchd-plist drift + script-defaults flip that was sitting unstaged in this clone was **not** included — that is a separate policy decision and belongs in its own PR.

## User Stories

- Operator adds a `/up` rule to `~/.hermes/workspace/SOUL.md` → next backup cycle picks it up and the rule is in `Dropbox/conversation-backups/hermes_conversations/workspace/SOUL.md` for restore.
- Operator edits `~/.hermes/agent-orchestrator.yaml` to route a new worker → backup captures the change with `*.bak` files excluded so the diff stays reviewable.

## Governing design doc

None — this is a one-line behavioral extension to an existing BACKUP_ITEMS list, not a new policy. Bead `jleechan-58n` is the contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope-limited backup list change for small text files with documented secret exclusions; does not alter auth, push guards, or default Dropbox-only mode.
> 
> **Overview**
> Extends `BACKUP_ITEMS` in `scripts/backup-home.sh` so small Hermes state under `~/.hermes/` is snapshotted to **both** the git backup tree and Dropbox, not just session history.
> 
> Adds eleven `copy|…|sync` rows for `CLAUDE.md`, `config.yaml`, `agent-orchestrator.yaml`, and workspace policy files (`SOUL.md`, `HEARTBEAT.md`, `AGENTS.md`, `IDENTITY.md`, `MEMORY.md`, `USER.md`, `TOOLS.md`, `BOOTSTRAP.md`). YAML rows exclude `*.bak`; comments document that secrets, SQLite, and launchd plists are intentionally omitted. Existing Hermes session dirs remain **Dropbox-only**; no backup script defaults or plist behavior change in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed78db55025b40d28ffb31011c8832dd2d36a5d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->