### PR TITLE
fix(backup): strip Agnt-F/jleechan-af content from git snapshot

### DIFF
--- a/scripts/backup-home.sh
+++ b/scripts/backup-home.sh
@@ -895,10 +895,18 @@ BACKUP_ITEMS=(
   # launchd plists (tracked in the canonical hermes repo), and *.bak pre-edit copies.
   # Added 2026-07-14: the SOUL.md Subagent-model-routing /up rule landed in the live file
   # but was never snapshotted because BACKUP_ITEMS only covered hermes/sessions/.
-  "copy|$HOME/.hermes/CLAUDE.md|hermes/CLAUDE.md|hermes_conversations/CLAUDE.md||sync"
+  # ~/.hermes/CLAUDE.md, ~/.hermes/agent-orchestrator.yaml, and
+  # ~/.hermes/workspace/SOUL.md contain Agnt-F / jleechan-af identity
+  # references (slack-channel-agentf-maps-to-local-agentf COMMIT, AO
+  # workers, etc.). Mirrors the ~/.claude-agent-f/ pattern above
+  # (line 884) — dropbox-only with empty git_rel so the
+  # block-agentf-push-to-jleechanorg pre-push hook doesn't refire
+  # every cycle. config.yaml + the other workspace/*.md files don't
+  # reference Agnt-F and stay dual-target.
+  "copy|$HOME/.hermes/CLAUDE.md||hermes_conversations/CLAUDE.md||sync"
   "copy|$HOME/.hermes/config.yaml|hermes/config.yaml|hermes_conversations/config.yaml|,*.bak|sync"
-  "copy|$HOME/.hermes/agent-orchestrator.yaml|hermes/agent-orchestrator.yaml|hermes_conversations/agent-orchestrator.yaml|,*.bak|sync"
-  "copy|$HOME/.hermes/workspace/SOUL.md|hermes/workspace/SOUL.md|hermes_conversations/workspace/SOUL.md||sync"
+  "copy|$HOME/.hermes/agent-orchestrator.yaml||hermes_conversations/agent-orchestrator.yaml|,*.bak|sync"
+  "copy|$HOME/.hermes/workspace/SOUL.md||hermes_conversations/workspace/SOUL.md||sync"
   "copy|$HOME/.hermes/workspace/HEARTBEAT.md|hermes/workspace/HEARTBEAT.md|hermes_conversations/workspace/HEARTBEAT.md||sync"
   "copy|$HOME/.hermes/workspace/AGENTS.md|hermes/workspace/AGENTS.md|hermes_conversations/workspace/AGENTS.md||sync"
   "copy|$HOME/.hermes/workspace/IDENTITY.md|hermes/workspace/IDENTITY.md|hermes_conversations/workspace/IDENTITY.md||sync"


### PR DESCRIPTION
## Background

PR #335 (reverse 2026-07-12 leak-purge) enabled dual-target backup by removing `backup/` from `.gitignore` and expanding the sparse-checkout cone. The first live cycle produced a `backup: automated home config snapshot 2026-07-15T01:59:04Z` commit, but `git push` was blocked by `~/.claude/hooks/block-agentf-push-to-jleechanorg.sh` (a PreToolUse(Bash) guard).

The hook scanned the 13K+ files staged in `backup/jeffreys-macbook-pro/...` and found Agnt-F / `jleechan-af` mentions in:

- `~/.hermes/CLAUDE.md` (1 hit)
- `~/.hermes/agent-orchestrator.yaml` (2 hits)
- `~/.hermes/workspace/SOUL.md` (5 hits — `## COMMIT: slack-channel-agentf-maps-to-local-agentf`, `## COMMIT: ao-only-no-mctrl` mentioning Agnt-F, etc.)

User directive 2026-07-15: **"A) do this"** (strip Agnt-F from snapshot for git).

## Goals

- Auto-snapshot commit can push to `origin/main` without refiring the Agnt-F pre-push hook.
- Three risky hermes files (CLAUDE.md, agent-orchestrator.yaml, SOUL.md) go to **Dropbox only** (mirroring the existing `~/.claude-agent-f/` pattern at line 884 — empty `git_rel`).
- Eight clean hermes files (config.yaml, workspace/HEARTBEAT.md, AGENTS.md, IDENTITY.md, MEMORY.md, USER.md, TOOLS.md, BOOTSTRAP.md) keep **dual-target** (git + dropbox).
- All other BACKUP_ITEMS rows untouched.

## Tenets

- **Mirror the proven pattern.** `~/.claude-agent-f/` (line 884) already uses dropbox-only with empty `git_rel` for the same reason — there's no new security boundary to design.
- **Minimum scope.** Single-file diff, 11 net lines. No script logic change, no env-var change, no `.gitignore` change.
- **Defense-in-depth preserved.** The Agnt-F pre-push hook still fires; it just doesn't have to abort the push every cycle because the Agnt-F content never gets staged.

## High-level description

3 of 11 hermes BACKUP_ITEMS rows switch from dual-target to dropbox-only:

```diff
-  "copy|$HOME/.hermes/CLAUDE.md|hermes/CLAUDE.md|hermes_conversations/CLAUDE.md||sync"
+  "copy|$HOME/.hermes/CLAUDE.md||hermes_conversations/CLAUDE.md||sync"

-  "copy|$HOME/.hermes/agent-orchestrator.yaml|hermes/agent-orchestrator.yaml|hermes_conversations/agent-orchestrator.yaml|,*.bak|sync"
+  "copy|$HOME/.hermes/agent-orchestrator.yaml||hermes_conversations/agent-orchestrator.yaml|,*.bak|sync"

-  "copy|$HOME/.hermes/workspace/SOUL.md|hermes/workspace/SOUL.md|hermes_conversations/workspace/SOUL.md||sync"
+  "copy|$HOME/.hermes/workspace/SOUL.md||hermes_conversations/workspace/SOUL.md||sync"
```

8 of 11 hermes rows are unchanged (config.yaml + 7 workspace/*.md files that don't reference Agnt-F).

## Testing

`grep -c 'Agnt-F|jleechan-af|agent-f|agentf'`:

| File | Hits | Target |
|---|---|---|
| `~/.hermes/CLAUDE.md` | 1 | **dropbox-only** |
| `~/.hermes/agent-orchestrator.yaml` | 2 | **dropbox-only** |
| `~/.hermes/workspace/SOUL.md` | 5 | **dropbox-only** |
| `~/.hermes/config.yaml` | 0 | dual-target |
| `~/.hermes/workspace/HEARTBEAT.md` | 0 | dual-target |
| `~/.hermes/workspace/AGENTS.md` | 0 | dual-target |
| `~/.hermes/workspace/IDENTITY.md` | 0 | dual-target |
| `~/.hermes/workspace/MEMORY.md` | 0 | dual-target |
| `~/.hermes/workspace/USER.md` | 0 | dual-target |
| `~/.hermes/workspace/TOOLS.md` | 0 | dual-target |
| `~/.hermes/workspace/BOOTSTRAP.md` | — | dual-target (file absent) |

Live backup verification (out-of-band in the same session):
- Both targets SUCCESS
- gitleaks pre-commit auto-scrubs any leaked secrets (caught 21 in the prior run)
- Auto-snapshot commit produces `backup: automated home config snapshot 2026-07-15T...`
- Pre-push hook does NOT block (no Agnt-F content in the staged subset)
- Push to `origin/main` succeeds

## Low-level details

- `mode|src|git_rel|dropbox_rel|exclude_csv|sync_mode` row format preserved.
- Empty `git_rel` (between the second and third `|`) means rsync skips the git target. The dropbox target still receives the file because `dropbox_rel` is set.
- No script logic change; just the BACKUP_ITEMS table.
- Out-of-band (not in this repo): the live `~/Library/LaunchAgents/org.jleechan.user-scope-backup.plist` plist already has `REQUIRE_DROPBOX_ONLY=0, ALLOW_GIT_BACKUP_SYNC=1, ALLOW_GIT_BACKUP_PUSH=1, TOKEN_HEALTH_PRECHECK=0` from PR #334. Next 2h cycle will exercise the new split.

## Bead

`jleechan-58n`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Table-only backup routing change using an existing dropbox-only pattern; no auth or backup-script behavior changes beyond what gets staged for git push.
> 
> **Overview**
> Automated git home snapshots were blocked every cycle because three Hermes files (`CLAUDE.md`, `agent-orchestrator.yaml`, `workspace/SOUL.md`) contained Agnt-F / `jleechan-af` strings and got staged under `backup/`.
> 
> Those three `BACKUP_ITEMS` rows now use an **empty `git_rel`**, so they still rsync to Dropbox but are **skipped on the git target**—same pattern as `~/.claude-agent-f/`. Eight other Hermes rows (`config.yaml` and the remaining workspace `*.md` files without Agnt-F mentions) stay **dual-target** (git + Dropbox).
> 
> No changes to `backup-home.sh` logic; only the `BACKUP_ITEMS` table and inline comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6227d027429cea2bef2104b6812c677f03af809. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated backup handling for Hermes workspace and identity files.
  * Prevented backup snapshots of temporary `.bak` configuration files.
  * Continued backing up supported files to the Dropbox destination while limiting Git snapshots to the intended configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->