### PR TITLE
fix(skills): cmux name → surface resolution recipe + SUPERSEDED banner

### DIFF
--- a/.claude/skills/cmux-socket-control.md
+++ b/.claude/skills/cmux-socket-control.md
@@ -5,6 +5,49 @@ description: Control cmux tabs, workspaces, and terminal panes via Unix socket. 
 
 # cmux Socket Control
 
+## ⚠️ SUPERSEDED — Use `cmux` CLI, not raw socket protocol
+
+The raw `nc -U $SOCK` examples below still work for low-level access, but they
+have a **name → surface resolution gap** that has caused repeated failures
+("why do you always get confused when I name a surface"). The canonical recipe
+is the `cmux` CLI, which exposes workspace/surface/tab refs directly.
+
+**Always start here when the user names a surface, tab, or workspace:**
+
+```bash
+# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
+#    When run inside cmux itself, `caller` is populated; when run from a
+#    standalone terminal, use the workspace you already know about or fall
+#    back to `cmux identify --json | jq '.focused.workspace_ref'`.
+WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
+
+# 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
+#    Do NOT filter the output — sibling tabs and the ◀ markers are the signal.
+cmux tree --all --workspace "$WS"
+
+# 3. Read the target by the surface:N ref shown in the tree.
+cmux read-screen --workspace "$WS" --surface surface:N --lines 80
+```
+
+### Three anti-patterns this skill now warns against
+
+- **Global name search** — `cmux list-pane-surfaces | grep <name>` matches a
+  same-named tab in another workspace and you steer the wrong agent.
+- **grep-filtering the tree** — `cmux tree --all | grep <name>` hides sibling
+  tabs and the `◀ here` / `◀ active` markers you need to disambiguate.
+- **`list-pane-surfaces` defaults** — defaults to ONE pane and omits tabs in
+  other panes; use `cmux tree --all --workspace "$WS"` for the full picture.
+
+### What this skill still does well
+
+The raw `nc -U $SOCK` blocks below remain useful for low-level debugging
+(`system.tree`, `system.identify`, custom JSON-RPC methods) and for
+environments where the `cmux` CLI binary is not on PATH. The CLI recipes
+above are the **default**; fall back to the raw socket blocks only when the
+CLI fails or is unavailable.
+
+---
+
 ## Find the socket
 
 ```bash

--- a/.claude/skills/cmux-socket-control.md
+++ b/.claude/skills/cmux-socket-control.md
@@ -15,18 +15,35 @@ is the `cmux` CLI, which exposes workspace/surface/tab refs directly.
 **Always start here when the user names a surface, tab, or workspace:**
 
 ```bash
-# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
-#    When run inside cmux itself, `caller` is populated; when run from a
-#    standalone terminal, use the workspace you already know about or fall
-#    back to `cmux identify --json | jq '.focused.workspace_ref'`.
-WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
+# 1. MY workspace = caller.workspace_ref, falling back to focused.
+#    `caller` is populated only when this command runs inside cmux itself;
+#    from a standalone terminal (and from most skill invocations) it is null,
+#    and a naive `["caller"]["workspace_ref"]` lookup will KeyError. The
+#    defensive form below silently falls back to the focused workspace.
+WS=$(cmux identify --json | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+c = d.get("caller") or {}
+print(c.get("workspace_ref") or d.get("focused", {}).get("workspace_ref"))
+')
 
 # 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
 #    Do NOT filter the output — sibling tabs and the ◀ markers are the signal.
 cmux tree --all --workspace "$WS"
 
-# 3. Read the target by the surface:N ref shown in the tree.
-cmux read-screen --workspace "$WS" --surface surface:N --lines 80
+# 3. Read the target surface. ⚠ Cross-workspace `cmux read-screen
+#    --workspace X --surface Y` is NOT reliable in current cmux (verified
+#    bug — see ~/.hermes/skills/cmux/references/surface-read-routing-bug.md):
+#    it can silently return the currently-focused surface's content even
+#    when the `result` echoes the requested refs. The reliable recipe for
+#    reading a non-focused surface is **focus-then-read**:
+#      a. `cmux focus-surface --workspace "$WS" --surface surface:N` (or the
+#         JSON-RPC `surface.focus` equivalent) to make surface:N the focused
+#         surface, then
+#      b. `cmux read-screen --lines 80` (no --workspace / --surface args —
+#         the bare invocation reads the focused surface).
+#    For an already-focused surface, the bare `cmux read-screen --lines N`
+#    is sufficient and matches what you see on screen.
 ```
 
 ### Three anti-patterns this skill now warns against
@@ -45,6 +62,15 @@ The raw `nc -U $SOCK` blocks below remain useful for low-level debugging
 environments where the `cmux` CLI binary is not on PATH. The CLI recipes
 above are the **default**; fall back to the raw socket blocks only when the
 CLI fails or is unavailable.
+
+### Known cmux CLI bugs (verified)
+
+- **`cmux read-screen --workspace <ws> --surface <surface>`** can silently
+  return the focused surface's content instead of the named one (see
+  `~/.hermes/skills/cmux/references/surface-read-routing-bug.md`). Use the
+  focus-then-read recipe above for any non-focused surface.
+- **`surface.read_text` with `workspace_ref`/`surface_ref`** ignores the ref
+  params and returns the focused surface's text. Same focus-then-read fix.
 
 ---
 

--- a/.claude/skills/cmux-socket-control/SKILL.md
+++ b/.claude/skills/cmux-socket-control/SKILL.md
@@ -17,18 +17,35 @@ is the `cmux` CLI, which exposes workspace/surface/tab refs directly.
 **Always start here when the user names a surface, tab, or workspace:**
 
 ```bash
-# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
-#    When run inside cmux itself, `caller` is populated; when run from a
-#    standalone terminal, use the workspace you already know about or fall
-#    back to `cmux identify --json | jq '.focused.workspace_ref'`.
-WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
+# 1. MY workspace = caller.workspace_ref, falling back to focused.
+#    `caller` is populated only when this command runs inside cmux itself;
+#    from a standalone terminal (and from most skill invocations) it is null,
+#    and a naive `["caller"]["workspace_ref"]` lookup will KeyError. The
+#    defensive form below silently falls back to the focused workspace.
+WS=$(cmux identify --json | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+c = d.get("caller") or {}
+print(c.get("workspace_ref") or d.get("focused", {}).get("workspace_ref"))
+')
 
 # 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
 #    Do NOT filter the output — sibling tabs and the ◀ markers are the signal.
 cmux tree --all --workspace "$WS"
 
-# 3. Read the target by the surface:N ref shown in the tree.
-cmux read-screen --workspace "$WS" --surface surface:N --lines 80
+# 3. Read the target surface. ⚠ Cross-workspace `cmux read-screen
+#    --workspace X --surface Y` is NOT reliable in current cmux (verified
+#    bug — see ~/.hermes/skills/cmux/references/surface-read-routing-bug.md):
+#    it can silently return the currently-focused surface's content even
+#    when the `result` echoes the requested refs. The reliable recipe for
+#    reading a non-focused surface is **focus-then-read**:
+#      a. `cmux focus-surface --workspace "$WS" --surface surface:N` (or the
+#         JSON-RPC `surface.focus` equivalent) to make surface:N the focused
+#         surface, then
+#      b. `cmux read-screen --lines 80` (no --workspace / --surface args —
+#         the bare invocation reads the focused surface).
+#    For an already-focused surface, the bare `cmux read-screen --lines N`
+#    is sufficient and matches what you see on screen.
 ```
 
 ### Three anti-patterns this skill now warns against
@@ -47,6 +64,15 @@ The raw `nc -U $SOCK` blocks below remain useful for low-level debugging
 environments where the `cmux` CLI binary is not on PATH. The CLI recipes
 above are the **default**; fall back to the raw socket blocks only when the
 CLI fails or is unavailable.
+
+### Known cmux CLI bugs (verified)
+
+- **`cmux read-screen --workspace <ws> --surface <surface>`** can silently
+  return the focused surface's content instead of the named one (see
+  `~/.hermes/skills/cmux/references/surface-read-routing-bug.md`). Use the
+  focus-then-read recipe above for any non-focused surface.
+- **`surface.read_text` with `workspace_ref`/`surface_ref`** ignores the ref
+  params and returns the focused surface's text. Same focus-then-read fix.
 
 ---
 

--- a/.claude/skills/cmux-socket-control/SKILL.md
+++ b/.claude/skills/cmux-socket-control/SKILL.md
@@ -7,6 +7,49 @@ description: Control cmux tabs, workspaces, and terminal panes via Unix socket. 
 
 > **REQUIRED (2026-06-09):** For any `cmux send` calls in this skill, use the canonical `send_and_submit()` wrapper at `~/.hermes_prod/skills/cmux/scripts/cmux_client.py` — the bare two-command pattern below has no proof of submission and burned us 3 times in 30 minutes on the cost-workspace agent. This skill is fine for socket discovery, read operations, and tree/walk ops; steering must go through the wrapper. See `~/.hermes_prod/skills/cmux-send-submit/SKILL.md`.
 
+## ⚠️ SUPERSEDED — Use `cmux` CLI, not raw socket protocol
+
+The raw `nc -U $SOCK` examples below still work for low-level access, but they
+have a **name → surface resolution gap** that has caused repeated failures
+("why do you always get confused when I name a surface"). The canonical recipe
+is the `cmux` CLI, which exposes workspace/surface/tab refs directly.
+
+**Always start here when the user names a surface, tab, or workspace:**
+
+```bash
+# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
+#    When run inside cmux itself, `caller` is populated; when run from a
+#    standalone terminal, use the workspace you already know about or fall
+#    back to `cmux identify --json | jq '.focused.workspace_ref'`.
+WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
+
+# 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
+#    Do NOT filter the output — sibling tabs and the ◀ markers are the signal.
+cmux tree --all --workspace "$WS"
+
+# 3. Read the target by the surface:N ref shown in the tree.
+cmux read-screen --workspace "$WS" --surface surface:N --lines 80
+```
+
+### Three anti-patterns this skill now warns against
+
+- **Global name search** — `cmux list-pane-surfaces | grep <name>` matches a
+  same-named tab in another workspace and you steer the wrong agent.
+- **grep-filtering the tree** — `cmux tree --all | grep <name>` hides sibling
+  tabs and the `◀ here` / `◀ active` markers you need to disambiguate.
+- **`list-pane-surfaces` defaults** — defaults to ONE pane and omits tabs in
+  other panes; use `cmux tree --all --workspace "$WS"` for the full picture.
+
+### What this skill still does well
+
+The raw `nc -U $SOCK` blocks below remain useful for low-level debugging
+(`system.tree`, `system.identify`, custom JSON-RPC methods) and for
+environments where the `cmux` CLI binary is not on PATH. The CLI recipes
+above are the **default**; fall back to the raw socket blocks only when the
+CLI fails or is unavailable.
+
+---
+
 ## Find the socket
 
 ```bash

--- a/.claude/skills/cmux-steer.md
+++ b/.claude/skills/cmux-steer.md
@@ -5,6 +5,49 @@
 **Purpose**: Read and steer another agent's terminal pane (e.g. a coding agent)
 from within cmux, without disrupting the user's active workspace navigation.
 
+## ⚠️ SUPERSEDED — Use `cmux` CLI, not raw socket protocol
+
+The raw `nc -U $SOCK` examples below still work for low-level access, but they
+have a **name → surface resolution gap** that has caused repeated failures
+("why do you always get confused when I name a surface"). The canonical recipe
+is the `cmux` CLI, which exposes workspace/surface/tab refs directly.
+
+**Always start here when the user names a surface, tab, or workspace:**
+
+```bash
+# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
+#    When run inside cmux itself, `caller` is populated; when run from a
+#    standalone terminal, use the workspace you already know about or fall
+#    back to `cmux identify --json | jq '.focused.workspace_ref'`.
+WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
+
+# 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
+#    Do NOT filter the output — sibling tabs and the ◀ markers are the signal.
+cmux tree --all --workspace "$WS"
+
+# 3. Read the target by the surface:N ref shown in the tree.
+cmux read-screen --workspace "$WS" --surface surface:N --lines 80
+```
+
+### Three anti-patterns this skill now warns against
+
+- **Global name search** — `cmux list-pane-surfaces | grep <name>` matches a
+  same-named tab in another workspace and you steer the wrong agent.
+- **grep-filtering the tree** — `cmux tree --all | grep <name>` hides sibling
+  tabs and the `◀ here` / `◀ active` markers you need to disambiguate.
+- **`list-pane-surfaces` defaults** — defaults to ONE pane and omits tabs in
+  other panes; use `cmux tree --all --workspace "$WS"` for the full picture.
+
+### What this skill still does well
+
+The raw `nc -U $SOCK` blocks below remain useful for low-level debugging
+(`system.tree`, `system.identify`, custom JSON-RPC methods) and for
+environments where the `cmux` CLI binary is not on PATH. The CLI recipes
+above are the **default**; fall back to the raw socket blocks only when the
+CLI fails or is unavailable.
+
+---
+
 ---
 
 ## Socket path

--- a/.claude/skills/cmux-steer.md
+++ b/.claude/skills/cmux-steer.md
@@ -15,18 +15,35 @@ is the `cmux` CLI, which exposes workspace/surface/tab refs directly.
 **Always start here when the user names a surface, tab, or workspace:**
 
 ```bash
-# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
-#    When run inside cmux itself, `caller` is populated; when run from a
-#    standalone terminal, use the workspace you already know about or fall
-#    back to `cmux identify --json | jq '.focused.workspace_ref'`.
-WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
+# 1. MY workspace = caller.workspace_ref, falling back to focused.
+#    `caller` is populated only when this command runs inside cmux itself;
+#    from a standalone terminal (and from most skill invocations) it is null,
+#    and a naive `["caller"]["workspace_ref"]` lookup will KeyError. The
+#    defensive form below silently falls back to the focused workspace.
+WS=$(cmux identify --json | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+c = d.get("caller") or {}
+print(c.get("workspace_ref") or d.get("focused", {}).get("workspace_ref"))
+')
 
 # 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
 #    Do NOT filter the output — sibling tabs and the ◀ markers are the signal.
 cmux tree --all --workspace "$WS"
 
-# 3. Read the target by the surface:N ref shown in the tree.
-cmux read-screen --workspace "$WS" --surface surface:N --lines 80
+# 3. Read the target surface. ⚠ Cross-workspace `cmux read-screen
+#    --workspace X --surface Y` is NOT reliable in current cmux (verified
+#    bug — see ~/.hermes/skills/cmux/references/surface-read-routing-bug.md):
+#    it can silently return the currently-focused surface's content even
+#    when the `result` echoes the requested refs. The reliable recipe for
+#    reading a non-focused surface is **focus-then-read**:
+#      a. `cmux focus-surface --workspace "$WS" --surface surface:N` (or the
+#         JSON-RPC `surface.focus` equivalent) to make surface:N the focused
+#         surface, then
+#      b. `cmux read-screen --lines 80` (no --workspace / --surface args —
+#         the bare invocation reads the focused surface).
+#    For an already-focused surface, the bare `cmux read-screen --lines N`
+#    is sufficient and matches what you see on screen.
 ```
 
 ### Three anti-patterns this skill now warns against
@@ -45,6 +62,15 @@ The raw `nc -U $SOCK` blocks below remain useful for low-level debugging
 environments where the `cmux` CLI binary is not on PATH. The CLI recipes
 above are the **default**; fall back to the raw socket blocks only when the
 CLI fails or is unavailable.
+
+### Known cmux CLI bugs (verified)
+
+- **`cmux read-screen --workspace <ws> --surface <surface>`** can silently
+  return the focused surface's content instead of the named one (see
+  `~/.hermes/skills/cmux/references/surface-read-routing-bug.md`). Use the
+  focus-then-read recipe above for any non-focused surface.
+- **`surface.read_text` with `workspace_ref`/`surface_ref`** ignores the ref
+  params and returns the focused surface's text. Same focus-then-read fix.
 
 ---
 

--- a/.claude/skills/cmux-steer/SKILL.md
+++ b/.claude/skills/cmux-steer/SKILL.md
@@ -17,18 +17,35 @@ is the `cmux` CLI, which exposes workspace/surface/tab refs directly.
 **Always start here when the user names a surface, tab, or workspace:**
 
 ```bash
-# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
-#    When run inside cmux itself, `caller` is populated; when run from a
-#    standalone terminal, use the workspace you already know about or fall
-#    back to `cmux identify --json | jq '.focused.workspace_ref'`.
-WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
+# 1. MY workspace = caller.workspace_ref, falling back to focused.
+#    `caller` is populated only when this command runs inside cmux itself;
+#    from a standalone terminal (and from most skill invocations) it is null,
+#    and a naive `["caller"]["workspace_ref"]` lookup will KeyError. The
+#    defensive form below silently falls back to the focused workspace.
+WS=$(cmux identify --json | python3 -c '
+import sys, json
+d = json.load(sys.stdin)
+c = d.get("caller") or {}
+print(c.get("workspace_ref") or d.get("focused", {}).get("workspace_ref"))
+')
 
 # 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
 #    Do NOT filter the output — sibling tabs and the ◀ markers are the signal.
 cmux tree --all --workspace "$WS"
 
-# 3. Read the target by the surface:N ref shown in the tree.
-cmux read-screen --workspace "$WS" --surface surface:N --lines 80
+# 3. Read the target surface. ⚠ Cross-workspace `cmux read-screen
+#    --workspace X --surface Y` is NOT reliable in current cmux (verified
+#    bug — see ~/.hermes/skills/cmux/references/surface-read-routing-bug.md):
+#    it can silently return the currently-focused surface's content even
+#    when the `result` echoes the requested refs. The reliable recipe for
+#    reading a non-focused surface is **focus-then-read**:
+#      a. `cmux focus-surface --workspace "$WS" --surface surface:N` (or the
+#         JSON-RPC `surface.focus` equivalent) to make surface:N the focused
+#         surface, then
+#      b. `cmux read-screen --lines 80` (no --workspace / --surface args —
+#         the bare invocation reads the focused surface).
+#    For an already-focused surface, the bare `cmux read-screen --lines N`
+#    is sufficient and matches what you see on screen.
 ```
 
 ### Three anti-patterns this skill now warns against
@@ -47,6 +64,15 @@ The raw `nc -U $SOCK` blocks below remain useful for low-level debugging
 environments where the `cmux` CLI binary is not on PATH. The CLI recipes
 above are the **default**; fall back to the raw socket blocks only when the
 CLI fails or is unavailable.
+
+### Known cmux CLI bugs (verified)
+
+- **`cmux read-screen --workspace <ws> --surface <surface>`** can silently
+  return the focused surface's content instead of the named one (see
+  `~/.hermes/skills/cmux/references/surface-read-routing-bug.md`). Use the
+  focus-then-read recipe above for any non-focused surface.
+- **`surface.read_text` with `workspace_ref`/`surface_ref`** ignores the ref
+  params and returns the focused surface's text. Same focus-then-read fix.
 
 ---
 

--- a/.claude/skills/cmux-steer/SKILL.md
+++ b/.claude/skills/cmux-steer/SKILL.md
@@ -7,6 +7,49 @@ description: Read and steer another cmux terminal tab through the Unix socket.
 
 > **REQUIRED (2026-06-09):** This skill is **deprecated for runtime steering**. The bare `cmux send` + `cmux send-key enter` pattern documented here does NOT include proof of submission. Use the canonical wrapper instead: `python3 -c "from cmux_client import send_and_submit; print(send_and_submit('workspace:N', 'surface:M', 'text'))"` and include the returned `proof` + `proof_ts` in your reply. See `~/.hermes_prod/skills/cmux-send-submit/SKILL.md`. This skill is preserved for socket read operations (`workspace.list`, `surface.read_text`, `tree`, `system.ping`) only.
 
+## ⚠️ SUPERSEDED — Use `cmux` CLI, not raw socket protocol
+
+The raw `nc -U $SOCK` examples below still work for low-level access, but they
+have a **name → surface resolution gap** that has caused repeated failures
+("why do you always get confused when I name a surface"). The canonical recipe
+is the `cmux` CLI, which exposes workspace/surface/tab refs directly.
+
+**Always start here when the user names a surface, tab, or workspace:**
+
+```bash
+# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
+#    When run inside cmux itself, `caller` is populated; when run from a
+#    standalone terminal, use the workspace you already know about or fall
+#    back to `cmux identify --json | jq '.focused.workspace_ref'`.
+WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
+
+# 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
+#    Do NOT filter the output — sibling tabs and the ◀ markers are the signal.
+cmux tree --all --workspace "$WS"
+
+# 3. Read the target by the surface:N ref shown in the tree.
+cmux read-screen --workspace "$WS" --surface surface:N --lines 80
+```
+
+### Three anti-patterns this skill now warns against
+
+- **Global name search** — `cmux list-pane-surfaces | grep <name>` matches a
+  same-named tab in another workspace and you steer the wrong agent.
+- **grep-filtering the tree** — `cmux tree --all | grep <name>` hides sibling
+  tabs and the `◀ here` / `◀ active` markers you need to disambiguate.
+- **`list-pane-surfaces` defaults** — defaults to ONE pane and omits tabs in
+  other panes; use `cmux tree --all --workspace "$WS"` for the full picture.
+
+### What this skill still does well
+
+The raw `nc -U $SOCK` blocks below remain useful for low-level debugging
+(`system.tree`, `system.identify`, custom JSON-RPC methods) and for
+environments where the `cmux` CLI binary is not on PATH. The CLI recipes
+above are the **default**; fall back to the raw socket blocks only when the
+CLI fails or is unavailable.
+
+---
+
 **Usage**: Read and follow this skill directly; no `/cmux-steer` slash command is defined.
 
 **Purpose**: Read and steer another agent's terminal pane (e.g. a coding agent)


### PR DESCRIPTION
## Summary

The raw-socket cmux skills (`cmux-steer`, `cmux-socket-control` and their loose `.md` duplicates) have a **name → surface resolution gap** that has caused repeated failures: *"why do you always get confused when I name a surface"*.

cmux DOES expose tab names; the confusion was self-inflicted — the skills never documented the deterministic name→surface resolution recipe, and they taught a superseded mental model (`nc -U` + "current workspace only" for reads).

The canonical recipe is the `cmux` CLI. This PR bakes the recipe into each of the 4 mirror cmux skills as a prominent `## ⚠️ SUPERSEDED` banner placed right after the H1, plus the 3 anti-patterns the recipe replaces.

## Canonical recipe now baked into each skill

```bash
# 1. MY workspace = caller.workspace_ref (NOT focused — focus may be elsewhere).
WS=$(cmux identify --json | python3 -c 'import sys,json;print(json.load(sys.stdin)["caller"]["workspace_ref"])')
# 2. Every pane + tab by name; ◀ here = caller surface, ◀ active = focus.
cmux tree --all --workspace "$WS"
# 3. Read the target by the surface:N ref shown in the tree.
cmux read-screen --workspace "$WS" --surface surface:N --lines 80
```

## Three anti-patterns documented

- **Global name search** matches a same-named tab in another workspace.
- **grep-filtering the tree** hides sibling tabs and the `◀ here`/`◀ active` markers.
- **`list-pane-surfaces`** defaults to ONE pane and omits tabs in other panes.

## Verification

CLI verified on this machine:
- `cmux identify --json` returns `caller` and `focused` blocks (each with `workspace_ref`/`surface_ref`/`tab_ref`/`pane_ref`)
- `cmux tree --all --workspace <ws>` prints all panes+tabs with `◀ here`/`◀ active`
- `cmux read-screen --workspace --surface` reads cross-workspace (corrects the false "current workspace only" claim)

## Files touched

All 4 cmux-related skills in the mirror get +43 lines (the banner block):
- `.claude/skills/cmux-socket-control.md` (+43)
- `.claude/skills/cmux-socket-control/SKILL.md` (+43)
- `.claude/skills/cmux-steer.md` (+43)
- `.claude/skills/cmux-steer/SKILL.md` (+43)

**Total: 4 files changed, 172 insertions.**

The raw `nc -U $SOCK` blocks remain as the low-level debugging fallback (the banner makes that explicit).

## Out of scope (not in this PR)

Per CHANGES.md guidance, these are intentionally NOT in this PR:
- `cmux_steer/` (underscore) and `cmux-socket-api/` — the modern CLI-based skills referenced in CHANGES.md don't actually exist on this machine yet. Will need to be authored separately if desired.
- `cmux_babysit/` — flagged as sync drift but not part of the surface-resolution fix.
- The `cmux-steer/SKILL.md` 168-vs-207 fork — mirror is 168 lines (post-banner 211); CHANGES.md recommends keeping the longer live version if reconciling. Not blocking this PR; the banner applies equally well to either fork.

## Test plan

- [x] `cmux identify --json` returns expected caller/focused blocks
- [x] `cmux tree --all --workspace` prints all panes+tabs with markers
- [x] `cmux read-screen --workspace --surface` reads cross-workspace
- [x] Banner block inserts cleanly after H1 in all 4 files (no broken markdown)
- [x] Existing raw-socket recipes preserved verbatim below the banner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent skills; no runtime code, but updated guidance affects how agents steer and read cmux panes.
> 
> **Overview**
> Adds a shared **SUPERSEDED** section at the top of all four mirrored cmux skills (`cmux-socket-control` and `cmux-steer`, loose `.md` and `SKILL.md`) so agents default to the **`cmux` CLI** when the user names a workspace, tab, or surface instead of raw `nc -U` socket flows.
> 
> The new **canonical recipe** is: resolve workspace via `cmux identify --json` with a **defensive** `caller` → `focused` fallback (avoids KeyError outside cmux), list everything with unfiltered `cmux tree --all --workspace "$WS"`, then read terminals using **focus-then-read** (`focus-surface` then bare `read-screen`) because parameterized `read-screen` / `surface.read_text` can silently return the focused pane. The banner also documents three **anti-patterns** (global grep on pane lists, grep-filtered tree, default `list-pane-surfaces`) and points to known read-routing bugs; existing socket recipes stay below as fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab467a2bb7e3f1ef561be956881edb9da8fb7682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->