### PR TITLE
[agento] noop smoke test (linux 2026-07-24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ execution_mode: immediate
 
 # Claude Commands
 
+<!-- AO worker smoke test 2026-07-24 linux -->
+
 A comprehensive collection of workflow automation commands for Claude Code that transform your development process through intelligent command composition and orchestration.
 
 The YAML frontmatter at the top of this template provides command metadata and should remain intact for downstream tooling.


### PR DESCRIPTION
AO worker dispatch test from jeff-ubuntu on 2026-07-24. Linux ao daemon (v0.1.3) healthy. Two agent plugin failures discovered during the test: (1) claude-code hit weekly Max limit (resets Jul 27), (2) codex CLI 0.144.1 rejects AO's --full-auto flag. Pivoted to inline fallback (per the standard AO INTERNAL_ERROR fallback pattern) to produce the noop PR via the same workflow an AO worker would have used. Single-line HTML comment added to README.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment with no runtime, security, or data impact.
> 
> **Overview**
> Adds a single HTML comment (`<!-- AO worker smoke test 2026-07-24 linux -->`) under the `# Claude Commands` heading in `README.md`. No functional, config, or workflow changes—documentation-only noop for validating AO worker dispatch on Linux.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273ce9181fa58a2bb75248e6c0d2e7ba1ae8ad9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->