### PR TITLE
feat(nextsteps): make --full opt-in; default does only beads + ~/roadmap

### DIFF
--- a/.claude/commands/nextsteps.md
+++ b/.claude/commands/nextsteps.md
@@ -1,5 +1,44 @@
+---
+description: Situational assessment and roadmap sync after a work block. Default mode reads only beads (`br`) and `~/roadmap`; `--full` preserves the legacy all-source behavior (Claude auto-memory + mem0 + GitHub Issues).
+type: orchestration
+execution_mode: immediate
+---
+
 # /nextsteps
 
 Situational assessment and roadmap sync after a work block.
 
 **Skill:** `~/.claude/skills/nextsteps/SKILL.md`
+
+## Usage
+
+- `/nextsteps` — **default (lean)**: read beads + `~/roadmap`, write the independent nextsteps `.md` doc, update `br` + `roadmap/README.md` + `~/roadmap/learnings-YYYY-MM.md`. Skip Claude auto-memory, mem0, and GitHub Issue creation.
+- `/nextsteps [brief]` — default mode, with an optional user-provided brief.
+- `/nextsteps --full` — **legacy all-source**: everything in default **plus** Claude auto-memory writes + `MEMORY.md` pointers + mem0 sync + GitHub Issue creation per new bead.
+- `/nextsteps --full [brief]` — `--full` mode with an optional brief.
+
+The `--full` flag is the only recognized modifier. Any other token (`--help`,
+`-h`, etc.) is treated as part of the brief.
+
+## What changes vs. the legacy behavior
+
+Before this change, `/nextsteps` always ran **all** phases including writing
+Claude auto-memory, calling mem0, and creating GitHub Issues for every new
+bead. The user explicitly asked to make `/nextsteps` lean by default and gate
+the side-effecting phases behind `--full`. This command file + skill enforce
+that split:
+
+| Phase | Default | `--full` |
+|-------|---------|----------|
+| 1a/1b — gather context (git, beads, roadmap) | ✅ | ✅ |
+| 2 — assess + update `roadmap/README.md` rolling activity | ✅ | ✅ |
+| 2b — write/append the Nextsteps `.md` doc | ✅ | ✅ |
+| 3 — execute parallel work | ✅ | ✅ |
+| 4 — Claude auto-memory writes + `MEMORY.md` | ❌ | ✅ |
+| 5 — mem0 sync | ❌ | ✅ |
+| 6 — `~/roadmap/learnings-YYYY-MM.md` | ✅ | ✅ |
+| 7 — bead create/update | ✅ | ✅ |
+| 7b — GitHub Issue creation per new bead | ❌ | ✅ |
+| 8 — report (mode-prefixed) | ✅ | ✅ |
+
+See `~/.claude/skills/nextsteps/SKILL.md` for the full protocol.

--- a/.claude/skills/nextsteps.md
+++ b/.claude/skills/nextsteps.md
@@ -1,17 +1,41 @@
 ---
 name: nextsteps
-description: Situational assessment, beads + roadmap sync after a work block; optional brief from user.
+description: Situational assessment, beads + ~/roadmap sync after a work block; optional brief from user. Default mode reads only beads + ~/roadmap (lean). `--full` preserves the legacy all-source behavior (Claude auto-memory, mem0, GH Issues).
 ---
 
 # /nextsteps — Situational Assessment & Roadmap Update
 
-## When invoked
+## Modes
+
+`/nextsteps` has **two modes**:
+
+| Mode | Invocation | Sources read | Side effects written |
+|------|------------|--------------|----------------------|
+| **default** (lean) | `/nextsteps` or `/nextsteps [brief]` | beads (`br list`/`br show`) + `~/roadmap/` + `roadmap/README.md` | nextsteps `.md` doc + `br` updates + `roadmap/README.md` rolling activity + `~/roadmap/learnings-YYYY-MM.md` |
+| **`--full`** | `/nextsteps --full` or `/nextsteps --full [brief]` | everything in default + Claude auto-memory + mem0 | everything in default + Claude auto-memory writes + `MEMORY.md` pointers + `mem0_shared_client.py add` + GitHub Issue creation |
+
+**Default mode skips these phases on purpose** (they are owned by `--full`):
+
+- Phase 4 — Write to Claude auto-memory
+- Phase 5 — Save to mem0
+- Phase 7b — Create or update GitHub Issues
+
+If the user wants the side-effecting phases, they must invoke
+`/nextsteps --full`.
+
+This file is the **shorter, user-scope protocol**; keep it in user scope so
+`/nextsteps` is reproducible across repos. The full canonical version with the
+fail-closed rule, doc discovery, phase detail, and `--full` mode parsing
+lives at `~/.claude/skills/nextsteps/SKILL.md`.
+
+## When invoked (default mode — lean)
 
 1. **Gather context in parallel**
    - `git log --oneline -10`
    - `br list --status open` (or `bd` if project uses bd)
    - `ls roadmap/` (or list `roadmap/README.md` recent section)
    - Use any user-provided line after `/nextsteps` as extra context.
+   - `ls ~/roadmap/` (home docs)
 
 2. **Assess**
    - Match recent commits to open beads; close or update status.
@@ -20,11 +44,25 @@ description: Situational assessment, beads + roadmap sync after a work block; op
 
 3. **Execute**
    - Prefer parallel tasks (subagents) for: beads updates, new issues, roadmap edits.
+   - **Do NOT** write Claude auto-memory files (Phase 4 — `--full` only).
+   - **Do NOT** call `mem0_shared_client.py` (Phase 5 — `--full` only).
+   - **Do NOT** run `gh issue create` for new beads (Phase 7b — `--full` only).
 
 4. **Report**
-   - IDs, paths changed, recommended next actions.
+   - First line: `Mode: default (beads + ~/roadmap)` (or `--full` variant if applicable).
+   - Then: IDs, paths changed, recommended next actions.
 
-## If `~/.claude/skills/nextsteps.md` is missing
+## When invoked (`--full` mode — legacy all-source)
+
+Run **everything in the default mode above**, plus:
+
+- **Phase 4 — Write to Claude auto-memory** for each learning/finding (`~/.claude/projects/<key>/memory/*.md` + `MEMORY.md` pointers).
+- **Phase 5 — Save to mem0** via `python3 ~/.hermes/scripts/mem0_shared_client.py add ...`.
+- **Phase 7b — Create or update GitHub Issues** for each new bead via `gh issue create`.
+
+First line of the report: `Mode: --full (beads + ~/roadmap + Claude memory + mem0 + GH Issues)`.
+
+## If `~/.claude/skills/nextsteps/SKILL.md` is missing
 
 This file is the protocol; keep it in user scope so `/nextsteps` is reproducible across repos.
 reate (parallel subagents)

--- a/.claude/skills/nextsteps/SKILL.md
+++ b/.claude/skills/nextsteps/SKILL.md
@@ -1,23 +1,77 @@
 ---
 name: nextsteps
-description: Situational assessment, beads + roadmap sync after a work block; writes a self-contained nextsteps markdown doc (TOC, executive summary, full detail, bead links), updates learnings + README, Claude auto-memory, mem0, and beads. Prefers editing existing roadmap docs over creating new files.
+description: Situational assessment and roadmap sync after a work block. Default mode reads ONLY beads (`br`) and `~/roadmap` (lean: independent nextsteps markdown doc + beads update + roadmap README + ~/roadmap learnings log). `--full` preserves the legacy all-source behavior (adds Claude auto-memory writes, mem0 sync, and GitHub Issue creation). Prefers editing existing roadmap docs over creating new files.
 ---
 
 # /nextsteps — Situational Assessment & Roadmap Update
 
 Situational assessment and roadmap sync after a work block.
 
+## Modes (read first — determines which phases run)
+
+`/nextsteps` has **two mutually exclusive modes**. Pick one based on the
+invocation; do not silently blend them.
+
+| Mode | Invocation | Sources read | Side effects written |
+|------|------------|--------------|----------------------|
+| **default** (lean) | `/nextsteps` or `/nextsteps [brief]` | beads (`br list`/`br show`) + `~/roadmap/` + `roadmap/README.md` | nextsteps `.md` doc + `br` updates + `roadmap/README.md` rolling activity + `~/roadmap/learnings-YYYY-MM.md` |
+| **`--full`** (legacy all-source) | `/nextsteps --full` or `/nextsteps --full [brief]` | everything in default + Claude auto-memory (`~/.claude/projects/<key>/memory/`) + mem0 | everything in default + Claude auto-memory writes + `MEMORY.md` pointers + `mem0_shared_client.py add` + GitHub Issue creation |
+
+**Default mode skips these phases on purpose** (they are owned by `--full`):
+
+- **Phase 4 — Write to Claude auto-memory** (writes `~/.claude/projects/.../memory/*.md` and `MEMORY.md` pointers).
+- **Phase 5 — Save to mem0** (calls `~/.hermes/scripts/mem0_shared_client.py`).
+- **Phase 7b — Create or update GitHub Issues** (calls `gh issue create` for each new bead).
+
+<!-- USER REQUEST (verbatim, preserved per task brief): "Make /nextsteps only do beads and ~/roadmap and /nextsteps --full does everything" -->
+
+If a user wants the side-effecting phases in the default run, they must invoke
+`/nextsteps --full`. Rationale: the lean default keeps `/nextsteps` focused on
+bead + roadmap state, which is what the user is asking for; the memory/issue
+mirroring is opt-in and lives behind `--full`.
+
+### How to parse the flag
+
+1. Look at the literal text right after `/nextsteps`.
+2. If the first non-whitespace token is exactly `--full`, run in `--full` mode and strip it from the brief.
+3. Otherwise (no `--full` anywhere on the line), run in default mode and treat the rest as the user-provided brief.
+4. `--full` is the only recognized flag. Any other token (`--help`, `-h`, etc.) is treated as part of the brief.
+
+Report the chosen mode on the **first line of the Phase 8 report**, e.g.:
+
+```
+Mode: default (beads + ~/roadmap)
+```
+
+or
+
+```
+Mode: --full (beads + ~/roadmap + Claude memory + mem0 + GH Issues)
+```
+
 ## Fail-closed rule
 
-A `/nextsteps` run is **incomplete** unless it leaves **all** of these artifacts:
+A `/nextsteps` run is **incomplete** unless it leaves **all** of these artifacts
+**for its chosen mode**:
 
-1. **Independent summary markdown doc** (see [Nextsteps document](#nextsteps-document-mandatory)) — TOC, executive summary, then full self-contained detail; bead links throughout  
-2. Beads updated/created via `br`  
-3. Claude memory files written with `MEMORY.md` pointers  
-4. `~/roadmap/learnings-YYYY-MM.md` appended  
-5. **`roadmap/README.md` “Recent activity (rolling)”** updated (repo git root — create section if absent)
+### Default mode (lean) — required artifacts
 
-If the session has no repo checkout, skip item 5 only and note that in the Phase 8 report.
+1. **Independent summary markdown doc** (see [Nextsteps document](#nextsteps-document-mandatory)) — TOC, executive summary, then full self-contained detail; bead links throughout
+2. Beads updated/created via `br`
+3. `~/roadmap/learnings-YYYY-MM.md` appended
+4. **`roadmap/README.md` “Recent activity (rolling)”** updated (repo git root — create section if absent)
+
+If the session has no repo checkout, skip item 4 only and note that in the Phase 8 report.
+
+### `--full` mode — required artifacts
+
+In addition to all default-mode artifacts above, a `--full` run must also
+leave:
+
+5. Claude memory files written with `MEMORY.md` pointers
+6. mem0 entry saved (or `⚠️ mem0 unavailable (skipped)` recorded)
+
+If the session has no repo checkout, skip item 4 only and note that in the Phase 8 report.
 
 ## Doc discovery — prefer update over create
 
@@ -150,7 +204,9 @@ The independent `.md` file is the **handoff artifact**: a reader must be able to
 
 For each finding, run Phases 4–7 below.
 
-### Phase 4 — Write to Claude auto-memory
+### Phase 4 — Write to Claude auto-memory  (`--full` only)
+
+**Skipped by default mode.** Run only when the invocation includes `--full`.
 
 For each learning/finding:
 
@@ -180,7 +236,9 @@ For each learning/finding:
 5. Append pointer to `MEMORY.md` (create file if missing): `- [Title](filename) — one-liner`
 6. Report: `✅ Claude auto-memory: {filename}`
 
-### Phase 5 — Save to mem0
+### Phase 5 — Save to mem0  (`--full` only)
+
+**Skipped by default mode.** Run only when the invocation includes `--full`.
 
 1. Check: skip if `~/.hermes/scripts/mem0_shared_client.py` is absent
 2. Build text: `"{title}: {one_liner}. {body_1_sentence}"`
@@ -224,7 +282,9 @@ For each gap/finding that warrants tracking:
    ```
 3. Report: `✅ bead <bd-id> created/referenced`
 
-### Phase 7b — Create or update GitHub Issues (parallel with Phase 7)
+### Phase 7b — Create or update GitHub Issues (parallel with Phase 7)  (`--full` only)
+
+**Skipped by default mode.** Run only when the invocation includes `--full`. The lean default leaves beads as the sole tracker; mirroring to GitHub Issues is opt-in via `--full`.
 
 For each bead created in Phase 7, attempt to create a linked GitHub Issue. Run all issue creates in parallel.
 
@@ -254,14 +314,28 @@ Report: `✅ GH Issue #N created` or `⚠️ GH Issues disabled — bead bd-xxx 
 
 ### Phase 8 — Report
 
-List all: **path to Nextsteps summary doc**, beads updated/created, `roadmap/README.md` touched, memory files written, mem0 status, recommended next actions.
+**First line:** the chosen mode (see [Modes](#modes-read-first--determines-which-phases-run)).
 
-Include an explicit artifact checklist:
+Then list all: **path to Nextsteps summary doc**, beads updated/created, `roadmap/README.md` touched, memory files written, mem0 status, recommended next actions.
+
+Include an explicit artifact checklist **for the chosen mode**:
+
+**Default mode checklist:**
+
+- `[x]` **Nextsteps independent `.md`** (TOC + executive summary + full detail; bead index + linked beads in queue)
+- `[x]` Beads (`br`) written
+- `[x]` `~/roadmap/learnings-YYYY-MM.md` updated (includes nextsteps doc path)
+- `[x]` `roadmap/README.md` rolling activity updated
+- `[ ]` (intentionally blank — Claude memory + mem0 + GH Issues are owned by `--full`)
+
+**`--full` mode checklist:**
 
 - `[x]` **Nextsteps independent `.md`** (TOC + executive summary + full detail; bead index + linked beads in queue)
 - `[x]` Beads (`br`) written
 - `[x]` Claude memory + `MEMORY.md` pointers written
 - `[x]` `~/roadmap/learnings-YYYY-MM.md` updated (includes nextsteps doc path)
 - `[x]` `roadmap/README.md` rolling activity updated
+- `[x]` mem0 entry saved (or `⚠️ mem0 unavailable (skipped)`)
+- `[x]` GH Issues created (or `⚠️ GH Issues disabled — bead only`)
 
 **Merge-order sanity:** If any recommended action was “merge **A** before **B**” (or “land A then rebase B”), re-assert **A** using the Phase 1 `gh pr view` results from **this** run. If **A** is **MERGED**, do **not** tell the reader to land A; say instead to **rebase B on `main`** (or the appropriate default branch). If **A** is still **OPEN**, keep the ordering advice. If **A** is **CLOSED** without merge, drop merge-order advice and flag that the stack needs re-triage.

--- a/tests/test_nextsteps_modes_contract.py
+++ b/tests/test_nextsteps_modes_contract.py
@@ -1,0 +1,397 @@
+"""Contract test: /nextsteps routing — default vs --full.
+
+User requirement (verbatim, preserved in the test fixture below):
+
+    "Make /nextsteps only do beads and ~/roadmap and
+     /nextsteps --full does everything"
+
+This test enforces the contract by reading the three files that govern the
+`/nextsteps` command and asserting that:
+
+1. **Command file** (`.claude/commands/nextsteps.md`) declares both modes and
+   has the YAML header that `commands/CLAUDE.md` requires for executable
+   commands.
+2. **Skill file** (`.claude/skills/nextsteps/SKILL.md`) — the canonical
+   protocol — has a "Modes" section that names both `default` and `--full`,
+   tags the side-effecting phases (Claude auto-memory, mem0, GH Issues) as
+   `--full`-only, and gives a Phase 8 checklist for each mode.
+3. **Loose skill** (`.claude/skills/nextsteps.md`) — the user-scope fallback —
+   also names both modes and tells the executor to skip the side-effecting
+   phases in default mode.
+
+A run that defaults to any of Phase 4 / Phase 5 / Phase 7b without an
+explicit `--full` marker on the invocation is a regression and fails this
+test.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NEXTSTEPS_CMD = REPO_ROOT / ".claude" / "commands" / "nextsteps.md"
+NEXTSTEPS_SKILL = REPO_ROOT / ".claude" / "skills" / "nextsteps" / "SKILL.md"
+NEXTSTEPS_LOOSE = REPO_ROOT / ".claude" / "skills" / "nextsteps.md"
+
+# Verbatim user request, preserved per the task brief.
+USER_REQUEST = (
+    "Make /nextsteps only do beads and ~/roadmap and "
+    "/nextsteps --full does everything"
+)
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_checklist_body(text: str, header_regex: str):
+    """Find a `**...:**` checklist header and return the body of `- [x] ...`
+    bullets that follow it, up to the next bold-header or `---` separator.
+    Returns (body, end_index) or (None, -1) if the header is missing.
+
+    The skill formats checklists as:
+
+        **Default mode checklist:**
+
+        - `[x]` item one
+        - `[x]` item two
+
+        **`--full` mode checklist:**
+
+        - `[x]` item one
+
+    so we need to skip the blank line(s) between header and bullets, then
+    slurp until the next `**...:**` block.
+    """
+    m = re.search(header_regex, text)
+    if not m:
+        return None, -1
+    start = m.end()
+    # Skip whitespace + newlines until first bullet.
+    rest = text[start:]
+    # Now collect lines that look like `- [x] ...` or `- [ ] ...`.
+    body_lines = []
+    pos = 0
+    seen_bullet = False
+    for line in rest.split("\n"):
+        # Match `- [x] ...`, ``- `[x]` ...``, etc. The skill uses backtick-
+        # wrapped checkbox markers (e.g. `- `[x]``); accept both.
+        if re.match(r"^-\s+`?\[[ xX]\]`?\s+", line):
+            body_lines.append(line)
+            seen_bullet = True
+            pos += len(line) + 1
+        elif seen_bullet and line.strip().startswith("**"):
+            # Next checklist block — stop.
+            break
+        elif seen_bullet and line.strip().startswith("---"):
+            break
+        elif line.strip() == "":
+            # Blank line — keep going whether before or after bullets.
+            pos += len(line) + 1
+            continue
+        else:
+            # Non-bullet non-empty line. If we've already started a checklist,
+            # the next section has begun; stop.
+            if seen_bullet:
+                break
+            # Otherwise skip leading prose between header and bullets.
+            pos += len(line) + 1
+    return "\n".join(body_lines), start + pos
+
+
+class NextstepsCommandContractTest(unittest.TestCase):
+    """Contract for .claude/commands/nextsteps.md — the entry point Claude reads
+    when the user types `/nextsteps`.
+    """
+
+    def setUp(self):
+        self.assertTrue(
+            NEXTSTEPS_CMD.is_file(),
+            f"nextsteps command file missing at {NEXTSTEPS_CMD}",
+        )
+        self.text = read(NEXTSTEPS_CMD)
+
+    def test_has_yaml_frontmatter(self):
+        """commands/CLAUDE.md mandates YAML frontmatter for executable commands."""
+        self.assertTrue(
+            self.text.startswith("---\n"),
+            "nextsteps command file must start with YAML frontmatter "
+            "(see commands/CLAUDE.md); the old file had none.",
+        )
+        # Must close the frontmatter before the body.
+        end = self.text.find("\n---\n", 4)
+        self.assertGreater(
+            end,
+            4,
+            "nextsteps command YAML frontmatter must close with a second `---` line.",
+        )
+
+    def test_declares_default_and_full_modes(self):
+        """Both modes must be named in the command file so a reader knows
+        which one is in effect before the skill loads.
+        """
+        # Case-insensitive lookup so we catch e.g. "Default" too.
+        text_lower = self.text.lower()
+        self.assertIn(
+            "default",
+            text_lower,
+            "command file must document the default (lean) mode",
+        )
+        self.assertIn(
+            "--full",
+            text_lower,
+            "command file must document the --full flag",
+        )
+
+    def test_preserves_user_request_verbatim(self):
+        """The user's exact phrasing should appear somewhere on the command or
+        skill files so a future maintainer can find the requirement.
+        """
+        # We accept the same content distributed across command + skill files.
+        combined = (
+            read(NEXTSTEPS_CMD) + "\n" + read(NEXTSTEPS_SKILL) + "\n" + read(NEXTSTEPS_LOOSE)
+        )
+        # Match on the unique "Make /nextsteps only do beads" prefix so we
+        # don't false-positive on partial phrases elsewhere.
+        self.assertIn(
+            "Make /nextsteps only do beads and ~/roadmap",
+            combined,
+            "user's verbatim request must be preserved (verbatim string) "
+            f"across the nextsteps command/skill files. Request: {USER_REQUEST!r}",
+        )
+
+
+class NextstepsSkillContractTest(unittest.TestCase):
+    """Contract for .claude/skills/nextsteps/SKILL.md — the canonical protocol
+    Claude reads when the command is invoked.
+    """
+
+    def setUp(self):
+        self.assertTrue(
+            NEXTSTEPS_SKILL.is_file(),
+            f"nextsteps skill missing at {NEXTSTEPS_SKILL}",
+        )
+        self.text = read(NEXTSTEPS_SKILL)
+
+    def test_modes_section_exists(self):
+        """The skill must have an explicit Modes section naming both modes."""
+        # Accept either `## Modes` or `## Modes (...)` — the canonical skill
+        # uses the parenthetical form to put the routing hint front-and-center.
+        self.assertRegex(
+            self.text,
+            r"##\s+[Mm]odes(\b|\s|\()",
+            "skill must have a `## Modes` section (with optional parenthetical) "
+            "that names both default and --full before any phase detail",
+        )
+
+    def test_default_mode_only_uses_beads_and_roadmap(self):
+        """Default mode must be defined as reading only beads + ~/roadmap.
+
+        We accept either a sentence ("reads only beads" / "only does beads
+        and ~/roadmap") or a table row.
+        """
+        # Sentence form
+        sentence_patterns = [
+            r"default.*only.*beads.*~/roadmap",
+            r"only does? beads.*~/roadmap",
+        ]
+        # Table form (the Modes table has a row labeled `default`)
+        table_pattern = (
+            r"\|.*\*\*default\*\*.*\|.*\bbr\b.*~/roadmap"
+        )
+        combined = self.text
+        ok = (
+            any(re.search(p, combined, re.IGNORECASE | re.DOTALL) for p in sentence_patterns)
+            or re.search(table_pattern, combined, re.IGNORECASE | re.DOTALL)
+        )
+        self.assertTrue(
+            ok,
+            "default mode must be explicitly scoped to beads + ~/roadmap "
+            "(sentence or table row); found neither in the skill.",
+        )
+
+    def test_full_mode_does_everything(self):
+        """`--full` mode must explicitly preserve the legacy all-source
+        behavior — i.e. it must add Claude auto-memory + mem0 + GH Issues
+        on top of the default mode.
+        """
+        sentence_patterns = [
+            r"--full.*does everything",
+            r"--full.*legacy all-source",
+            r"--full.*preserves.*legacy",
+        ]
+        # Table form: the Modes table has a `--full` row listing Claude memory
+        # + mem0 + GH Issues as side effects.
+        table_pattern = (
+            r"\|.*--full.*\|.*Claude.*memory.*mem0.*GH\s*Issues"
+        )
+        combined = self.text
+        ok = (
+            any(re.search(p, combined, re.IGNORECASE | re.DOTALL) for p in sentence_patterns)
+            or re.search(table_pattern, combined, re.IGNORECASE | re.DOTALL)
+        )
+        self.assertTrue(
+            ok,
+            "--full mode must explicitly preserve the legacy all-source "
+            "behavior (Claude memory + mem0 + GH Issues); found neither "
+            "in the skill.",
+        )
+
+    def test_side_effecting_phases_marked_full_only(self):
+        """Phase 4 (Claude memory), Phase 5 (mem0), and Phase 7b (GH Issues)
+        must each be tagged as `--full` only — otherwise the default mode
+        regresses back to writing those side effects.
+        """
+        # Each phase heading must contain `(--full only)` or equivalent.
+        for phase_num, phase_name in (
+            ("Phase 4", "Claude auto-memory"),
+            ("Phase 5", "mem0"),
+            ("Phase 7b", "GitHub Issue"),
+        ):
+            # Look for a heading line that mentions the phase number/name and
+            # includes the `--full only` marker.
+            pattern = (
+                rf"###\s+{re.escape(phase_num)}[^#\n]*{phase_name}[^#\n]*`--full`\s*only"
+            )
+            self.assertRegex(
+                self.text,
+                pattern,
+                f"{phase_num} ({phase_name}) must be tagged as `--full` only "
+                f"in the skill heading. Searched regex: {pattern}",
+            )
+
+    def test_default_mode_checklist_present(self):
+        """Phase 8 must include a default-mode checklist that omits memory +
+        mem0 + GH Issues items.
+
+        We check the `[x]` (claimed-done) bullets specifically — the `[ ]`
+        bullet that calls out "intentionally blank — Claude memory + mem0 +
+        GH Issues are owned by `--full`" is a *meta-comment* explaining the
+        omission, not a claim of work, so it's allowed to mention those
+        tokens.
+        """
+        # The default-mode checklist should mention beads + roadmap/README +
+        # learnings, but NOT mention Claude memory, mem0, or GH Issues.
+        # We locate the `Default mode checklist:` block and search within it
+        # up to the next blank-line-separated `**...**` header or `---`.
+        body, end_idx = _extract_checklist_body(
+            self.text, r"\*\*Default mode checklist:\*\*"
+        )
+        self.assertIsNotNone(
+            body,
+            "skill must include a `Default mode checklist:` block under "
+            "Phase 8 — the fail-closed rule depends on it.",
+        )
+        # Only the [x] (done) bullets count as claimed work; the [ ] bullet
+        # is an explicit non-claim.
+        done_bullets = "\n".join(
+            line for line in body.split("\n") if re.search(r"\[x\]", line)
+        )
+        self.assertIn("Beads", done_bullets)
+        self.assertIn("learnings-YYYY-MM.md", done_bullets)
+        self.assertIn("roadmap/README.md", done_bullets)
+        # And it must NOT claim to have written the --full-only side effects.
+        for forbidden in ("Claude memory", "mem0", "GH Issue"):
+            self.assertNotIn(
+                forbidden,
+                done_bullets,
+                f"default-mode checklist must not claim to write `{forbidden}` "
+                f"— that is owned by --full only.",
+            )
+
+    def test_full_mode_checklist_present(self):
+        """Phase 8 must include a `--full`-mode checklist that DOES mention
+        Claude memory + mem0 + GH Issues.
+        """
+        body, end_idx = _extract_checklist_body(
+            self.text, r"\*\*`--full` mode checklist:\*\*"
+        )
+        self.assertIsNotNone(
+            body,
+            "skill must include a `--full` mode checklist: block under "
+            "Phase 8 — the legacy all-source behavior depends on it.",
+        )
+        for required in ("Beads", "Claude memory", "MEMORY.md", "mem0", "GH Issue"):
+            self.assertIn(
+                required,
+                body,
+                f"--full checklist must include `{required}` — it is part of "
+                f"the legacy all-source behavior that --full preserves.",
+            )
+
+
+class NextstepsLooseSkillContractTest(unittest.TestCase):
+    """Contract for .claude/skills/nextsteps.md — the user-scope fallback.
+    Mirrors the canonical skill so /nextsteps works even if the user has not
+    pulled the latest canonical version.
+    """
+
+    def setUp(self):
+        # The loose file may legitimately be absent in some forks; only run
+        # this test class if it exists.
+        if not NEXTSTEPS_LOOSE.is_file():
+            self.skipTest(f"loose skill not present at {NEXTSTEPS_LOOSE}")
+
+        self.text = read(NEXTSTEPS_LOOSE)
+
+    def test_loose_skill_names_both_modes(self):
+        text_lower = self.text.lower()
+        self.assertIn("default", text_lower)
+        self.assertIn("--full", text_lower)
+
+    def test_loose_skill_marks_side_effecting_phases_default_skip(self):
+        """The loose file must say the default mode SKIPS Claude memory,
+        mem0, and GH Issue creation — that's the user's whole request.
+        """
+        text_lower = self.text.lower()
+        # Look for the explicit "skip" language tied to the side-effecting
+        # phases in the default-mode section.
+        # The loose file uses "Do NOT" + the phase tag.
+        self.assertIn(
+            "do not",
+            text_lower,
+            "loose skill must contain a `Do NOT` instruction tied to the "
+            "side-effecting phases so the default mode skips them",
+        )
+        # And it must mention all three skip targets.
+        for needle in ("claude auto-memory", "mem0", "gh issue"):
+            self.assertIn(
+                needle,
+                text_lower,
+                f"loose skill default-mode section must call out `{needle}` "
+                f"as a phase to skip",
+            )
+
+
+class NextstepsModeParsingTest(unittest.TestCase):
+    """Lightweight parser check: confirm the skill's documented flag-parsing
+    rules actually distinguish default vs --full on a few representative
+    invocations. This is not a full implementation — we just sanity-check
+    that the rules as written are coherent.
+    """
+
+    def test_skill_documents_flag_parsing_rules(self):
+        text = read(NEXTSTEPS_SKILL)
+        # Must include explicit parsing rules: "first non-whitespace token",
+        # "exactly --full", and "strip it from the brief".
+        for needle in (
+            "first non-whitespace token",
+            "exactly `--full`",
+            "strip it from the brief",
+        ):
+            self.assertIn(
+                needle,
+                text,
+                f"skill must document the flag-parsing rule: `{needle}`",
+            )
+
+    def test_mode_report_examples_present(self):
+        text = read(NEXTSTEPS_SKILL)
+        # The Phase 8 report must start with a `Mode:` line that names the
+        # chosen mode. Both default and --full examples must be present.
+        self.assertIn("Mode: default", text)
+        self.assertIn("Mode: --full", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_nextsteps_modes_contract.py
+++ b/tests/test_nextsteps_modes_contract.py
@@ -35,8 +35,7 @@ NEXTSTEPS_LOOSE = REPO_ROOT / ".claude" / "skills" / "nextsteps.md"
 
 # Verbatim user request, preserved per the task brief.
 USER_REQUEST = (
-    "Make /nextsteps only do beads and ~/roadmap and "
-    "/nextsteps --full does everything"
+    "Make /nextsteps only do beads and ~/roadmap and /nextsteps --full does everything"
 )
 
 
@@ -149,7 +148,11 @@ class NextstepsCommandContractTest(unittest.TestCase):
         """
         # We accept the same content distributed across command + skill files.
         combined = (
-            read(NEXTSTEPS_CMD) + "\n" + read(NEXTSTEPS_SKILL) + "\n" + read(NEXTSTEPS_LOOSE)
+            read(NEXTSTEPS_CMD)
+            + "\n"
+            + read(NEXTSTEPS_SKILL)
+            + "\n"
+            + read(NEXTSTEPS_LOOSE)
         )
         # Match on the unique "Make /nextsteps only do beads" prefix so we
         # don't false-positive on partial phrases elsewhere.
@@ -196,14 +199,11 @@ class NextstepsSkillContractTest(unittest.TestCase):
             r"only does? beads.*~/roadmap",
         ]
         # Table form (the Modes table has a row labeled `default`)
-        table_pattern = (
-            r"\|.*\*\*default\*\*.*\|.*\bbr\b.*~/roadmap"
-        )
+        table_pattern = r"\|.*\*\*default\*\*.*\|.*\bbr\b.*~/roadmap"
         combined = self.text
-        ok = (
-            any(re.search(p, combined, re.IGNORECASE | re.DOTALL) for p in sentence_patterns)
-            or re.search(table_pattern, combined, re.IGNORECASE | re.DOTALL)
-        )
+        ok = any(
+            re.search(p, combined, re.IGNORECASE | re.DOTALL) for p in sentence_patterns
+        ) or re.search(table_pattern, combined, re.IGNORECASE | re.DOTALL)
         self.assertTrue(
             ok,
             "default mode must be explicitly scoped to beads + ~/roadmap "
@@ -222,14 +222,11 @@ class NextstepsSkillContractTest(unittest.TestCase):
         ]
         # Table form: the Modes table has a `--full` row listing Claude memory
         # + mem0 + GH Issues as side effects.
-        table_pattern = (
-            r"\|.*--full.*\|.*Claude.*memory.*mem0.*GH\s*Issues"
-        )
+        table_pattern = r"\|.*--full.*\|.*Claude.*memory.*mem0.*GH\s*Issues"
         combined = self.text
-        ok = (
-            any(re.search(p, combined, re.IGNORECASE | re.DOTALL) for p in sentence_patterns)
-            or re.search(table_pattern, combined, re.IGNORECASE | re.DOTALL)
-        )
+        ok = any(
+            re.search(p, combined, re.IGNORECASE | re.DOTALL) for p in sentence_patterns
+        ) or re.search(table_pattern, combined, re.IGNORECASE | re.DOTALL)
         self.assertTrue(
             ok,
             "--full mode must explicitly preserve the legacy all-source "
@@ -250,9 +247,7 @@ class NextstepsSkillContractTest(unittest.TestCase):
         ):
             # Look for a heading line that mentions the phase number/name and
             # includes the `--full only` marker.
-            pattern = (
-                rf"###\s+{re.escape(phase_num)}[^#\n]*{phase_name}[^#\n]*`--full`\s*only"
-            )
+            pattern = rf"###\s+{re.escape(phase_num)}[^#\n]*{phase_name}[^#\n]*`--full`\s*only"
             self.assertRegex(
                 self.text,
                 pattern,


### PR DESCRIPTION
## Summary

Make `/nextsteps` lean by default — it now reads **only beads (`br`) and `~/roadmap`**, writing the nextsteps `.md` doc, updating beads, rolling `roadmap/README.md`, and appending `~/roadmap/learnings-YYYY-MM.md`. The legacy all-source behavior (Claude auto-memory writes, mem0 sync, GitHub Issue creation per new bead) is preserved behind a new `--full` flag.

User request (verbatim): *"Make /nextsteps only do beads and ~/roadmap and /nextsteps --full does everything"*.

## Modes

| Mode | Invocation | Sources | Side effects |
|------|------------|---------|--------------|
| **default** (lean) | `/nextsteps` or `/nextsteps [brief]` | beads + `~/roadmap/` + `roadmap/README.md` | nextsteps `.md` + `br` updates + `roadmap/README.md` rolling activity + `~/roadmap/learnings-YYYY-MM.md` |
| **`--full`** (legacy all-source) | `/nextsteps --full` or `/nextsteps --full [brief]` | everything in default + Claude auto-memory + mem0 | everything in default + Claude auto-memory writes + `MEMORY.md` pointers + `mem0_shared_client.py add` + GitHub Issue creation |

Default mode explicitly skips Phase 4 (Claude auto-memory), Phase 5 (mem0), and Phase 7b (GH Issues). Each of those phase headings is now tagged `(\`--full\` only)`. The Phase 8 report starts with a `Mode:` line and includes a per-mode artifact checklist so the fail-closed rule is enforced.

## Files

- `.claude/commands/nextsteps.md` — YAML frontmatter added (was missing per `commands/CLAUDE.md`); documents `--full`; includes the phase table.
- `.claude/skills/nextsteps/SKILL.md` — new `## Modes` section, default-mode and `--full`-mode checklists, `(``--full`` only)` tags on Phase 4/5/7b, flag-parsing rules, and verbatim user request preserved as an HTML comment.
- `.claude/skills/nextsteps.md` — user-scope loose file updated to mirror the lean/`--full` split.
- `tests/test_nextsteps_modes_contract.py` — **13 new contract tests** asserting:
  - YAML frontmatter on the command file.
  - Both modes named in command + skill + loose files.
  - Default mode explicitly scoped to beads + `~/roadmap`.
  - `--full` preserves the legacy all-source behavior.
  - Side-effecting phases (4, 5, 7b) tagged `--full` only.
  - Default-mode `[x]` bullets do not claim to write Claude memory / mem0 / GH Issues.
  - `--full`-mode checklist includes Claude memory, `MEMORY.md`, mem0, GH Issue.
  - Flag-parsing rules + `Mode:` report examples are present.
  - The user's verbatim request string is preserved verbatim across the three files.

## Test results

```
$ python3 -m unittest discover tests -v
...
Ran 25 tests in 0.006s
OK
```

All 25 tests pass — the 13 new contract tests + the 4 pre-existing `test_swarm_references` tests + the 4 pre-existing `test_checkpoint_cadence_contract` tests (and the 4 tests in the other modules). No regressions.

## How to verify locally

```bash
cd /Users/jleechan/claude-commands   # or any worktree of jleechanorg/claude-commands
git fetch origin feature/nextsteps-beads-roadmap-default
git checkout feature/nextsteps-beads-roadmap-default
python3 -m unittest tests.test_nextsteps_modes_contract -v
```

The contract test will fail (not silently pass) if a future maintainer reverts the default mode to running the side-effecting phases, removes the YAML header on `nextsteps.md`, drops the per-mode checklists, or loses the verbatim user request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only contract changes for an orchestration command; no runtime application code paths.
> 
> **Overview**
> **`/nextsteps` is lean by default** — plain invocation now limits reads and writes to beads (`br`), `~/roadmap`, and repo `roadmap/README.md` (nextsteps doc, bead updates, rolling README, learnings log). **Claude auto-memory, mem0, and per-bead GitHub Issues** move behind **`/nextsteps --full`**, which keeps the prior all-source behavior.
> 
> The command entrypoint gains **YAML frontmatter** and usage/phase tables; the canonical **`SKILL.md`** and user-scope **`nextsteps.md`** add a **Modes** section, **`--full` flag parsing**, **`--full` only** tags on Phases 4/5/7b, **mode-specific fail-closed checklists**, and a **mode-prefixed Phase 8 report**.
> 
> **`tests/test_nextsteps_modes_contract.py`** adds contract tests so default runs cannot silently re-enable the side-effecting phases or drop the documented mode split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c189c7391bf28fb116c1bfaf0d00d1cdbf9356f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->