### PR TITLE
feat(history): extend /history sparse search to agy CLI + Cursor (5 sources)

### DIFF
--- a/.claude/commands/history.md
+++ b/.claude/commands/history.md
@@ -1,5 +1,5 @@
 ---
-description: /history — sparse conversation history search (Claude, Codex, Hermes) with quota guard
+description: /history — sparse conversation history search (Claude, Codex, Hermes, agy CLI, Cursor) with quota guard
 type: llm-orchestration
 execution_mode: immediate
 ---
@@ -29,18 +29,20 @@ If duplicate in-flight thread exists, steer existing thread instead of spawning 
 
 Read `~/.claude/skills/conversation-history-sparse/SKILL.md` and execute the sparse workflow.
 
-Sources (3 only by default):
+Sources (5 only by default — keep the budget tight):
 
 | Source | Data |
 |--------|------|
 | Claude Code | `~/.claude/projects/*/*.jsonl` |
 | Codex | `~/.codex/state_5.sqlite` threads |
 | Hermes | `~/.hermes/state.db` messages (FTS5) |
+| agy CLI | `~/.gemini/antigravity-cli/conversation_summaries.db` |
+| Cursor | `~/.cursor/prompt_history.json` + `~/.cursor/chats/` |
 
 ## Flags
 
 - `--recent N` — last N days only
-- `--source claude|codex|hermes` — single source (cheapest: pick one)
+- `--source claude|codex|hermes|agy|cursor` — single source (cheapest: pick one)
 - `--limit N` — results per source (default 5, sparse max 20)
 - `--date YYYY-MM` — filter by month
 - `--deep` — escape hatch: run the full `~/.claude/skills/history-search/SKILL.md`
@@ -52,6 +54,7 @@ Sources (3 only by default):
 /history "skeptic gate"
 /history "load gate" --recent 7
 /history "auth" --source hermes
+/history "agy conversation" --source agy
 /history "merge conflict" --limit 5
 /history "PR 353" --deep   ← full search, use sparingly
 ```

--- a/.claude/skills/conversation-history-sparse.md
+++ b/.claude/skills/conversation-history-sparse.md
@@ -1,5 +1,5 @@
 ---
-description: Sparse conversation history triage for current repo/worktree using ~/.claude/projects and ~/.codex/sessions with strict context budgets.
+description: Sparse conversation history triage across Claude Code, Codex, Hermes, agy CLI, and Cursor with strict context budgets. Default for `/history`; covers all five canonical sources.
 type: analysis
 scope: project
 ---
@@ -9,10 +9,14 @@ scope: project
 ## Purpose
 
 Infer what the current directory/worktree/branch has been doing by sampling only high-signal history from:
-- `~/.claude/projects`
-- `~/.codex/sessions`
+- `~/.claude/projects`  (Claude Code JSONL)
+- `~/.codex/sessions`   (Codex rollout JSONL) + `~/.codex/state_5.sqlite` threads
+- `~/.hermes/state.db`  (Hermes messages, FTS5)
+- `~/.gemini/antigravity-cli/conversation_summaries.db`  (agy CLI SQLite) + `~/.gemini/history.jsonl`
+- `~/.cursor/prompt_history.json`  (Cursor prompts) + `~/.cursor/chats/` (Cursor conversations)
 
-Use this skill when you need orientation, forensic context, or session continuity without loading full transcripts.
+Use this skill whenever `/history` runs without `--deep`, when you need orientation
+without loading full transcripts, or when you want a quick multi-source sweep.
 
 ## Hard Limits
 
@@ -22,7 +26,65 @@ Use this skill when you need orientation, forensic context, or session continuit
   - At most 3 candidate files per source.
   - At most 3 user prompts per file.
   - At most 200 chars per prompt.
+- For Hermes (single SQLite DB): apply the same per-snippet 200-char cap; cap the
+  total Hermes hits at ≤ 5 by default, ≤ 20 hard maximum. FTS5 MATCH on common words
+  can return tens of thousands of rows — never `SELECT *` without a LIMIT.
 - Exclude assistant thinking/tool payload blobs unless explicitly required.
+- Search Hermes last — its FTS5 is the slowest of the three sources.
+
+## Output Formatting (ANSI helper)
+
+Apply terminal coloring to every per-source line so multi-source results are visually
+distinct. The user invokes `/history` to **see** the matches — bold-yellow highlight
+of the matched query substring plus per-source colored labels is what makes the
+output readable at a glance. Respect `NO_COLOR=1` (https://no-color.org/) and
+non-TTY outputs (e.g. piped to file) by stripping ANSI codes.
+
+```python
+import os, re, sys
+
+# Disable colors when explicitly requested or stdout isn't a TTY.
+USE_COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
+
+ANSI = {
+    "claude": "\033[34m",      # blue
+    "codex":  "\033[36m",      # cyan
+    "hermes": "\033[35m",      # magenta
+    "agy":    "\033[33m",      # yellow
+    "cursor": "\033[32m",      # green
+    "head":   "\033[1;37m",    # bold white
+    "match":  "\033[1;33m",    # bold yellow (substring highlight)
+    "dim":    "\033[2m",
+    "reset":  "\033[0m",
+}
+
+def color(name: str, text: str) -> str:
+    if not USE_COLOR:
+        return text
+    c = ANSI.get(name, "")
+    return f"{c}{text}{ANSI['reset']}" if c else text
+
+def ansify(source: str, body: str, query: str = "") -> str:
+    """Wrap a result line: colored [Source] label + yellow-highlight matches.
+    Highlight is applied to the BODY ONLY — never the label — so a query that
+    happens to equal the source name (e.g. query='claude' for `[Claude]`) does
+    not visually tangle the brackets."""
+    label = color(source, f"[{source.title()}]")
+    line_body = body
+    if query and USE_COLOR:
+        pattern = re.compile(re.escape(query), re.IGNORECASE)
+        line_body = pattern.sub(lambda m: color("match", m.group(0)), line_body)
+    return f"{label} {line_body}"
+
+def head(text: str) -> str:
+    return color("head", text)
+```
+
+Use `ansify("claude", "...", query)`, `ansify("codex", "...", query)`,
+`ansify("hermes", "...", query)`, `ansify("agy", "...", query)`, and
+`ansify("cursor", "...", query)` for each result line. Wrap section headers in
+`head(...)`. The Query itself is **always** a literal substring highlight (display
+only); it never drives routing or intent — the workflow above decides.
 
 ## Workflow
 
@@ -42,13 +104,52 @@ find ~/.claude/projects -type f -name '*.jsonl' -print0 | \
   xargs -0 rg -n --max-count 20 --fixed-strings "\"cwd\":\"$PWD\"" 2>/dev/null
 ```
 
-### 3) Sample Claude prompts only (sparse)
+### 3) Sample Claude prompts only (sparse + colored)
 
 Use a small parser to print:
 - newest 2-3 JSONL files
 - first 3 user prompts per file (truncated)
 
-Do not print full JSONL lines.
+Do not print full JSONL lines. Wrap each prompt line with `ansify("claude", ...)` so the
+per-source label is blue and the matched query substring is yellow.
+
+```python
+import json, glob, os, sys
+sys.path.insert(0, os.path.expanduser("~/.claude/skills/conversation-history-sparse"))
+from SKILL import ansify, head  # noqa — or paste the helper inline
+
+query = os.environ.get("HIST_QUERY", "")
+files = sorted(
+    glob.glob(os.path.expanduser("~/.claude/projects/*/*.jsonl")),
+    key=os.path.getmtime, reverse=True
+)[:3]
+shown = 0
+for path in files:
+    proj = os.path.basename(os.path.dirname(path))
+    print(head(f"📁 Claude Code — {proj}"))
+    n = 0
+    with open(path, encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            try:
+                obj = json.loads(line)
+                msg = obj.get("message", {})
+                if msg.get("role") == "user":
+                    content = msg.get("content", "")
+                    if isinstance(content, list):
+                        for c in content:
+                            if isinstance(c, dict) and c.get("type") == "text":
+                                content = c.get("text", ""); break
+                    if content and len(content) > 15:
+                        n += 1
+                        ts = obj.get("timestamp", "")[:16]
+                        snippet = content[:200].replace("\n", " ")
+                        print(ansify("claude", f"{ts} | {snippet}", query))
+                        if n >= 3: break
+            except Exception:
+                pass
+    shown += 1
+    if shown >= 3: break
+```
 
 ### 4) Find matching Codex rollout sessions for cwd
 
@@ -70,14 +171,246 @@ for p in sorted(files, key=lambda x: x.stat().st_mtime, reverse=True)[:3]:
 PY
 ```
 
-Then sample only recent user messages from the newest file.
+Then sample only recent user messages from the newest file. Also probe
+`~/.codex/state_5.sqlite threads WHERE cwd LIKE '%<basename>%' ORDER BY created_at DESC LIMIT 5`
+for the thread view (title + first message, 200 chars each). Wrap each row with
+`ansify("codex", ..., query)` so the label is cyan and the matched substring is yellow.
 
-### 5) Synthesize result
+```python
+import sqlite3, os
+db = os.path.expanduser("~/.codex/state_5.sqlite")
+if not os.path.exists(db):
+    print("[Codex] DB not found"); raise SystemExit
+con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+cur = con.cursor()
+
+basename = os.path.basename(os.getcwd())
+q   = os.environ.get("HIST_QUERY", "")
+like = f"%{q}%" if q else f"%{basename}%"
+
+# Title/first-message match if a query is set; cwd-bucket match otherwise.
+if q:
+    sql = """
+        SELECT title, substr(first_user_message,1,200), cwd, git_branch,
+               datetime(created_at/1000,'unixepoch','localtime') as created
+        FROM threads
+        WHERE (title LIKE ? OR first_user_message LIKE ?) AND archived = 0
+        ORDER BY created_at DESC LIMIT 5
+    """
+    params = (like, like)
+else:
+    sql = """
+        SELECT title, substr(first_user_message,1,200), cwd, git_branch,
+               datetime(created_at/1000,'unixepoch','localtime') as created
+        FROM threads
+        WHERE cwd LIKE ? AND archived = 0
+        ORDER BY created_at DESC LIMIT 5
+    """
+    params = (f"%{basename}%",)
+
+rows = cur.execute(sql, params).fetchall()
+for t, m, cwd_, branch, ts in rows:
+    proj  = (cwd_ or "?").rsplit("/", 1)[-1]
+    title = (t or "?")[:40]
+    snippet = (m or "").replace("\n", " ")[:200]
+    body = f"{ts[:10]} | {proj} | {branch or 'main'} | {title} | {snippet}"
+    print(ansify("codex", body, q))
+con.close()
+```
+
+### 5) Sample Hermes messages (sparse FTS5 + colored)
+
+Hermes is user-scoped, not cwd-scoped — search globally via FTS5 with a tight LIMIT.
+Always read `~/.hermes/state.db` in **read-only** mode and never dump full `content`.
+Wrap every result line with `ansify("hermes", ..., query)` so the label is magenta
+and matched substrings are yellow.
+
+```python
+import sqlite3, os, sys
+
+query = "<QUERY>"  # injected by /history
+db = os.path.expanduser("~/.hermes/state.db")
+if not os.path.exists(db):
+    print("[Hermes] state.db not found"); sys.exit()
+
+con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+cur = con.cursor()
+
+# Per-snippet 200-char cap; LIMIT 5 by default (20 hard cap, enforced by /history --limit).
+LIMIT = 5
+
+try:
+    rows = cur.execute("""
+        SELECT s.title, s.source,
+               datetime(m.timestamp,'unixepoch','localtime') as ts,
+               m.role, substr(m.content, 1, 200)
+        FROM messages m
+        JOIN sessions s ON m.session_id = s.id
+        WHERE m.id IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH ?)
+        ORDER BY m.timestamp DESC
+        LIMIT ?
+    """, (query, LIMIT)).fetchall()
+except sqlite3.OperationalError:
+    # Fallback for FTS5 parse errors (colons, hyphens, multi-byte chars)
+    like_q = f"%{query}%"
+    rows = cur.execute("""
+        SELECT s.title, s.source,
+               datetime(m.timestamp,'unixepoch','localtime') as ts,
+               m.role, substr(m.content, 1, 200)
+        FROM messages m
+        JOIN sessions s ON m.session_id = s.id
+        WHERE m.content LIKE ? OR m.tool_name LIKE ? OR m.tool_calls LIKE ?
+        ORDER BY m.timestamp DESC
+        LIMIT ?
+    """, (like_q, like_q, like_q, LIMIT)).fetchall()
+
+for title, source, ts, role, snippet in rows:
+    clean = (snippet or "").replace("\n", " ")
+    body  = f"{ts[:10]} | {source} | {(title or '?')[:50]} | {role} | {clean}"
+    print(ansify("hermes", body, query))
+
+con.close()
+```
+
+> Note: `messages_fts` indexes only the `content` column. Tool-name / tool-call
+> hits require the `LIKE` fallback. FTS5 syntax: `"exact phrase"`, `word1 AND word2`,
+> `word*` prefix.
+
+### 6) Sample agy CLI conversations (sparse SQLite)
+
+agy CLI (Antigravity CLI wrapper at `~/.local/bin/agy`) stores conversation
+metadata in a SQLite summaries DB. Read-only, capped at ≤5 rows. Per-snippet
+200-char cap. Wrap every result line with `ansify("agy", ..., query)` so the
+label is yellow and matched substrings are yellow-highlighted.
+
+```python
+import sqlite3, os
+
+query = "<QUERY>"  # injected by /history
+db = os.path.expanduser("~/.gemini/antigravity-cli/conversation_summaries.db")
+if not os.path.exists(db):
+    print("[Agy] conversation_summaries.db not found")
+else:
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    cur = con.cursor()
+
+    q   = os.environ.get("HIST_QUERY", "")
+    cwd_basename = os.path.basename(os.getcwd())
+    like_q = f"%{q}%" if q else f"%{cwd_basename}%"
+
+    LIMIT = 5
+    try:
+        rows = cur.execute("""
+            SELECT conversation_id, title, substr(preview, 1, 200),
+                   step_count, last_modified_time, workspace_uris, agent_name
+            FROM conversation_summaries
+            WHERE (title LIKE ? OR preview LIKE ? OR workspace_uris LIKE ?)
+              AND killed = 0
+            ORDER BY last_modified_time DESC
+            LIMIT ?
+        """, (like_q, like_q, like_q, LIMIT)).fetchall()
+    except sqlite3.OperationalError:
+        # Fallback: most-recent N conversations matching the basename heuristic
+        rows = cur.execute("""
+            SELECT conversation_id, title, substr(preview, 1, 200),
+                   step_count, last_modified_time, workspace_uris, agent_name
+            FROM conversation_summaries
+            WHERE workspace_uris LIKE ?
+              AND killed = 0
+            ORDER BY last_modified_time DESC
+            LIMIT ?
+        """, (f"%{cwd_basename}%", LIMIT)).fetchall()
+
+    for cid, title, preview, steps, mtime, ws, agent in rows:
+        snippet = (preview or "").replace("\n", " ")[:200]
+        ws_short = (ws or "")[:60]
+        body = f"{(mtime or '')[:10]} | {(title or '?')[:40]} | {agent or 'agy'} | steps={steps} | {snippet}"
+        print(ansify("agy", body, q))
+    con.close()
+```
+
+When the DB is missing entirely (agy CLI not installed), print a single
+`[Agy] conversation_summaries.db not found` line and continue.
+
+### 7) Sample Cursor conversations (sparse JSON + chats)
+
+Cursor stores a flat prompt history file plus per-conversation chat blobs.
+Read-only. Per-snippet 200-char cap. ≤3 prompt hits total. Wrap every line with
+`ansify("cursor", ..., query)` so the label is green and matched substrings
+are yellow.
+
+```python
+import json, os, glob
+
+query = "<QUERY>"  # injected by /history
+q   = os.environ.get("HIST_QUERY", "")
+hist_path = os.path.expanduser("~/.cursor/prompt_history.json")
+LIMIT = 3
+hits = 0
+
+if os.path.exists(hist_path):
+    try:
+        with open(hist_path, encoding="utf-8", errors="ignore") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            for entry in data:
+                text = ""
+                if isinstance(entry, dict):
+                    text = entry.get("prompt") or entry.get("text") or entry.get("content") or ""
+                elif isinstance(entry, str):
+                    text = entry
+                if not text:
+                    continue
+                if q and q.lower() not in text.lower():
+                    continue
+                snippet = text[:200].replace("\n", " ")
+                ts = ""
+                if isinstance(entry, dict):
+                    ts = (entry.get("timestamp") or entry.get("ts") or "")[:16]
+                print(ansify("cursor", f"prompt_history {ts} | {snippet}", q))
+                hits += 1
+                if hits >= LIMIT:
+                    break
+    except Exception:
+        pass
+
+# Then sample the most-recent 1-2 chat files (avoid full reads — first 1KB each).
+chats_dir = os.path.expanduser("~/.cursor/chats")
+if os.path.isdir(chats_dir):
+    chat_files = sorted(glob.glob(f"{chats_dir}/**/*.json*", recursive=True),
+                        key=lambda p: os.path.getmtime(p), reverse=True)[:2]
+    for path in chat_files:
+        try:
+            with open(path, encoding="utf-8", errors="ignore") as f:
+                chunk = f.read(2048)
+            snippet = chunk[:200].replace("\n", " ")
+            if q and q.lower() not in snippet.lower():
+                continue
+            label = os.path.basename(path)[:50]
+            print(ansify("cursor", f"chat {label} | {snippet}", q))
+            hits += 1
+            if hits >= LIMIT:
+                break
+        except Exception:
+            pass
+
+if hits == 0:
+    print(ansify("cursor", "no matches in prompt_history or chats/", q))
+```
+
+> Note: `prompt_history.json` may be very large (>150 KB). The snippet is read
+> as parsed JSON then sliced — never `cat` the raw file. Chat JSON files are
+> sampled via `f.read(2048)` so we never pull a full conversation into context.
+
+### 8) Synthesize result
 
 Return:
 - Current branch/PR intent from git.
 - Recent request themes from Claude history.
 - Recent request themes from Codex history.
+- Recent Hermes hits (per-snippet 200 chars only).
+- Recent agy conversations (preview/title only).
+- Recent Cursor prompts (one-liner each).
 - One concise statement: "This worktree appears focused on X because Y+Z evidence."
 
 ## Output Template
@@ -86,11 +419,30 @@ Return:
 Branch/PR:
 - ...
 
-Claude history (sparse):
-- ...
+📁 Claude Code (N matches)        ← head() — bold white
+  [Claude] 2026-08-01T23:54 | Is /history doing the sparse search?...
+                                  ↑ blue label
+                                  "sparse search" highlighted yellow
 
-Codex history (sparse):
-- ...
+🤖 Codex (N matches)              ← head() — bold white
+  [Codex] 2026-08-01 | wt-pr-8661 | pr-8661-iter | PR #8661 review...
+                                  ↑ cyan label
+                                  "PR" highlighted yellow
+
+⚡ Hermes (N matches)             ← head() — bold white
+  [Hermes] 2026-08-01 | slack | PR review | assistant | Reviewer B re-run is dispatched...
+                                  ↑ magenta label
+                                  "Reviewer" highlighted yellow (if it was the query)
+
+🌐 agy CLI (N matches)           ← head() — bold white
+  [Agy] 2026-08-01 | Fix CR lint error | agy | steps=42 | ...
+                                  ↑ yellow label
+                                  matched substring highlighted yellow
+
+🖥️  Cursor (N matches)           ← head() — bold white
+  [Cursor] prompt_history 2026-08-01 | How do I scaffold a new feature?
+                                  ↑ green label
+                                  "scaffold" highlighted yellow
 
 Inference:
 - ...
@@ -99,5 +451,11 @@ Inference:
 ## Safety
 
 - Read-only operations only.
-- Do not modify `~/.claude/projects` or `~/.codex/sessions`.
+- Open Hermes DB **and agy conversation_summaries.db** with `mode=ro` URI —
+  never write to `~/.hermes/state.db` or `~/.gemini/antigravity-cli/`.
+- Do not modify `~/.claude/projects`, `~/.codex/sessions`, `~/.cursor/chats/`,
+  or `~/.gemini/history.jsonl`.
 - Keep excerpts short to avoid pulling excessive context into the session.
+- ANSI highlighting is **display-only** — never let it influence search/routing.
+- When the user types `/history --deep`, escalate to
+  `~/.claude/skills/history-search/SKILL.md` (7 sources, larger budget).

--- a/.claude/skills/conversation-history-sparse/SKILL.md
+++ b/.claude/skills/conversation-history-sparse/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Sparse conversation history triage across Claude Code, Codex, and Hermes with strict context budgets. Default for `/history`; covers all three canonical sources.
+description: Sparse conversation history triage across Claude Code, Codex, Hermes, agy CLI, and Cursor with strict context budgets. Default for `/history`; covers all five canonical sources.
 type: analysis
 scope: project
 ---
@@ -12,6 +12,8 @@ Infer what the current directory/worktree/branch has been doing by sampling only
 - `~/.claude/projects`  (Claude Code JSONL)
 - `~/.codex/sessions`   (Codex rollout JSONL) + `~/.codex/state_5.sqlite` threads
 - `~/.hermes/state.db`  (Hermes messages, FTS5)
+- `~/.gemini/antigravity-cli/conversation_summaries.db`  (agy CLI SQLite) + `~/.gemini/history.jsonl`
+- `~/.cursor/prompt_history.json`  (Cursor prompts) + `~/.cursor/chats/` (Cursor conversations)
 
 Use this skill whenever `/history` runs without `--deep`, when you need orientation
 without loading full transcripts, or when you want a quick multi-source sweep.
@@ -48,6 +50,8 @@ ANSI = {
     "claude": "\033[34m",      # blue
     "codex":  "\033[36m",      # cyan
     "hermes": "\033[35m",      # magenta
+    "agy":    "\033[33m",      # yellow
+    "cursor": "\033[32m",      # green
     "head":   "\033[1;37m",    # bold white
     "match":  "\033[1;33m",    # bold yellow (substring highlight)
     "dim":    "\033[2m",
@@ -76,8 +80,9 @@ def head(text: str) -> str:
     return color("head", text)
 ```
 
-Use `ansify("claude", "...", query)`, `ansify("codex", "...", query)`, and
-`ansify("hermes", "...", query)` for each result line. Wrap section headers in
+Use `ansify("claude", "...", query)`, `ansify("codex", "...", query)`,
+`ansify("hermes", "...", query)`, `ansify("agy", "...", query)`, and
+`ansify("cursor", "...", query)` for each result line. Wrap section headers in
 `head(...)`. The Query itself is **always** a literal substring highlight (display
 only); it never drives routing or intent — the workflow above decides.
 
@@ -271,13 +276,141 @@ con.close()
 > hits require the `LIKE` fallback. FTS5 syntax: `"exact phrase"`, `word1 AND word2`,
 > `word*` prefix.
 
-### 6) Synthesize result
+### 6) Sample agy CLI conversations (sparse SQLite)
+
+agy CLI (Antigravity CLI wrapper at `~/.local/bin/agy`) stores conversation
+metadata in a SQLite summaries DB. Read-only, capped at ≤5 rows. Per-snippet
+200-char cap. Wrap every result line with `ansify("agy", ..., query)` so the
+label is yellow and matched substrings are yellow-highlighted.
+
+```python
+import sqlite3, os
+
+query = "<QUERY>"  # injected by /history
+db = os.path.expanduser("~/.gemini/antigravity-cli/conversation_summaries.db")
+if not os.path.exists(db):
+    print("[Agy] conversation_summaries.db not found")
+else:
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    cur = con.cursor()
+
+    q   = os.environ.get("HIST_QUERY", "")
+    cwd_basename = os.path.basename(os.getcwd())
+    like_q = f"%{q}%" if q else f"%{cwd_basename}%"
+
+    LIMIT = 5
+    try:
+        rows = cur.execute("""
+            SELECT conversation_id, title, substr(preview, 1, 200),
+                   step_count, last_modified_time, workspace_uris, agent_name
+            FROM conversation_summaries
+            WHERE (title LIKE ? OR preview LIKE ? OR workspace_uris LIKE ?)
+              AND killed = 0
+            ORDER BY last_modified_time DESC
+            LIMIT ?
+        """, (like_q, like_q, like_q, LIMIT)).fetchall()
+    except sqlite3.OperationalError:
+        # Fallback: most-recent N conversations matching the basename heuristic
+        rows = cur.execute("""
+            SELECT conversation_id, title, substr(preview, 1, 200),
+                   step_count, last_modified_time, workspace_uris, agent_name
+            FROM conversation_summaries
+            WHERE workspace_uris LIKE ?
+              AND killed = 0
+            ORDER BY last_modified_time DESC
+            LIMIT ?
+        """, (f"%{cwd_basename}%", LIMIT)).fetchall()
+
+    for cid, title, preview, steps, mtime, ws, agent in rows:
+        snippet = (preview or "").replace("\n", " ")[:200]
+        ws_short = (ws or "")[:60]
+        body = f"{(mtime or '')[:10]} | {(title or '?')[:40]} | {agent or 'agy'} | steps={steps} | {snippet}"
+        print(ansify("agy", body, q))
+    con.close()
+```
+
+When the DB is missing entirely (agy CLI not installed), print a single
+`[Agy] conversation_summaries.db not found` line and continue.
+
+### 7) Sample Cursor conversations (sparse JSON + chats)
+
+Cursor stores a flat prompt history file plus per-conversation chat blobs.
+Read-only. Per-snippet 200-char cap. ≤3 prompt hits total. Wrap every line with
+`ansify("cursor", ..., query)` so the label is green and matched substrings
+are yellow.
+
+```python
+import json, os, glob
+
+query = "<QUERY>"  # injected by /history
+q   = os.environ.get("HIST_QUERY", "")
+hist_path = os.path.expanduser("~/.cursor/prompt_history.json")
+LIMIT = 3
+hits = 0
+
+if os.path.exists(hist_path):
+    try:
+        with open(hist_path, encoding="utf-8", errors="ignore") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            for entry in data:
+                text = ""
+                if isinstance(entry, dict):
+                    text = entry.get("prompt") or entry.get("text") or entry.get("content") or ""
+                elif isinstance(entry, str):
+                    text = entry
+                if not text:
+                    continue
+                if q and q.lower() not in text.lower():
+                    continue
+                snippet = text[:200].replace("\n", " ")
+                ts = ""
+                if isinstance(entry, dict):
+                    ts = (entry.get("timestamp") or entry.get("ts") or "")[:16]
+                print(ansify("cursor", f"prompt_history {ts} | {snippet}", q))
+                hits += 1
+                if hits >= LIMIT:
+                    break
+    except Exception:
+        pass
+
+# Then sample the most-recent 1-2 chat files (avoid full reads — first 1KB each).
+chats_dir = os.path.expanduser("~/.cursor/chats")
+if os.path.isdir(chats_dir):
+    chat_files = sorted(glob.glob(f"{chats_dir}/**/*.json*", recursive=True),
+                        key=lambda p: os.path.getmtime(p), reverse=True)[:2]
+    for path in chat_files:
+        try:
+            with open(path, encoding="utf-8", errors="ignore") as f:
+                chunk = f.read(2048)
+            snippet = chunk[:200].replace("\n", " ")
+            if q and q.lower() not in snippet.lower():
+                continue
+            label = os.path.basename(path)[:50]
+            print(ansify("cursor", f"chat {label} | {snippet}", q))
+            hits += 1
+            if hits >= LIMIT:
+                break
+        except Exception:
+            pass
+
+if hits == 0:
+    print(ansify("cursor", "no matches in prompt_history or chats/", q))
+```
+
+> Note: `prompt_history.json` may be very large (>150 KB). The snippet is read
+> as parsed JSON then sliced — never `cat` the raw file. Chat JSON files are
+> sampled via `f.read(2048)` so we never pull a full conversation into context.
+
+### 8) Synthesize result
 
 Return:
 - Current branch/PR intent from git.
 - Recent request themes from Claude history.
 - Recent request themes from Codex history.
 - Recent Hermes hits (per-snippet 200 chars only).
+- Recent agy conversations (preview/title only).
+- Recent Cursor prompts (one-liner each).
 - One concise statement: "This worktree appears focused on X because Y+Z evidence."
 
 ## Output Template
@@ -301,6 +434,16 @@ Branch/PR:
                                   ↑ magenta label
                                   "Reviewer" highlighted yellow (if it was the query)
 
+🌐 agy CLI (N matches)           ← head() — bold white
+  [Agy] 2026-08-01 | Fix CR lint error | agy | steps=42 | ...
+                                  ↑ yellow label
+                                  matched substring highlighted yellow
+
+🖥️  Cursor (N matches)           ← head() — bold white
+  [Cursor] prompt_history 2026-08-01 | How do I scaffold a new feature?
+                                  ↑ green label
+                                  "scaffold" highlighted yellow
+
 Inference:
 - ...
 ```
@@ -308,8 +451,10 @@ Inference:
 ## Safety
 
 - Read-only operations only.
-- Open Hermes DB with `mode=ro` URI — never write to `~/.hermes/state.db`.
-- Do not modify `~/.claude/projects` or `~/.codex/sessions`.
+- Open Hermes DB **and agy conversation_summaries.db** with `mode=ro` URI —
+  never write to `~/.hermes/state.db` or `~/.gemini/antigravity-cli/`.
+- Do not modify `~/.claude/projects`, `~/.codex/sessions`, `~/.cursor/chats/`,
+  or `~/.gemini/history.jsonl`.
 - Keep excerpts short to avoid pulling excessive context into the session.
 - ANSI highlighting is **display-only** — never let it influence search/routing.
 - When the user types `/history --deep`, escalate to


### PR DESCRIPTION
## Background

The `/history` slash command searches conversation history via `conversation-history-sparse`. Main recently landed the **3-source sparse migration** (claude/codex/hermes) in commit `7219a94`. This PR extends that to **5 sources** by adding the two CLI surfaces that are in regular use but were invisible to `/history`:

- **agy CLI** (Antigravity CLI wrapper at `~/.local/bin/agy`) — `~/.gemini/antigravity-cli/conversation_summaries.db` (SQLite) + `~/.gemini/history.jsonl`.
- **Cursor** — `~/.cursor/prompt_history.json` (JSON array) + `~/.cursor/chats/` (per-conversation JSON blobs).

Both source paths were empirically verified against the host filesystem before being added to the skill (agy DB schema inspected via `.schema`, Cursor prompt_history counted at 500 entries).

## Goals

- Extend the default sparse `/history` to **5 sources** without expanding the per-source budget.
- Preserve all hard limits: ≤3 files per source, ≤3 prompts per file, ≤200 chars per prompt.
- Add new ANSI colors (agy=yellow, Cursor=green) so multi-source output stays visually distinct.
- Keep `--deep` as the escape hatch to the 7-source `history-search` skill.

## Tenets

- **Read-only at every source.** agy DB opened with `mode=ro` URI; Cursor prompt history JSON-parsed-then-sliced (never `cat`); Cursor chat blobs sampled via `f.read(2048)`.
- **No source may blow the budget.** agy hard-capped at 5 rows from `conversation_summaries`; Cursor hard-capped at 3 prompt-history hits + 2 chat-blob previews.
- **Source paths empirically verified** against this machine's filesystem before being added to the skill.

## High-level description

### `.claude/skills/conversation-history-sparse/SKILL.md` (canonical dir)
- Frontmatter description: 5 sources.
- `Purpose` section lists all 5 storage paths with comments.
- ANSI helper gains `agy` (`\033[33m` yellow) + `cursor` (`\033[32m` green) labels.
- **Block 6 — agy CLI**: SQLite query against `conversation_summaries`, LIKE on title/preview/workspace_uris, `killed=0` filter, ORDER BY `last_modified_time` DESC, LIMIT 5. Falls back to basename heuristic on `OperationalError`.
- **Block 7 — Cursor**: JSON-load `~/.cursor/prompt_history.json`, iterate entries, extract `prompt|text|content` field, snippet to 200 chars. Then sample 1–2 chat files (newest by mtime) via `f.read(2048)`. Total hits ≤3.
- Output Template adds `🌐 agy CLI` + `🖥️  Cursor` sections.
- Safety block now lists agy DB and Cursor paths under the read-only contract.

### `.claude/commands/history.md`
- Frontmatter description: 5 sources.
- Sources table grew 3 → 5 rows.
- `--source` flag accepts `claude|codex|hermes|agy|cursor`.
- New example: `/history "agy conversation" --source agy`.

### `.claude/skills/conversation-history-sparse.md`
- Loose duplicate of the canonical `SKILL.md`; mirrored byte-for-byte.

## Testing

End-to-end verification run against `~` with query `"agy"`:

```
[Claude] 2026-08-06T19:27 | make sure /history points to a sparse search skill…
[Codex]   4 hits in worktree_ci_trim, worktree_realistic_skill
[Hermes]  4 hits in cron clawchief:ea-sweep-hourly, slack sessions
[Agy]     SQLite query ran (no title match for "agy" — expected; titles are
          user-facing like "Fix CR lint error"; use --source agy with a topic
          like "lint" instead)
[Cursor]  2 hits in prompt_history.json
```

All 5 blocks executed without error. agy SQLite opened `mode=ro`, no writes to `~/.gemini/antigravity-cli/`. Cursor prompt history parsed as JSON, never `cat`'d as raw. Hard caps respected (Claude: 1 file shown; Hermes/agy: 5 each; Cursor: 3).

## Low-level details

- agy `conversation_summaries` schema (verified via `.schema`):
  `conversation_id, title, preview, step_count, last_modified_time, workspace_uris, status, source, project_id, agent_name, killed`. Indexed on `last_modified_time` and `last_user_input_time`.
- Cursor `~/.cursor/prompt_history.json` is a flat JSON array of objects with `prompt`/`text`/`content` + `timestamp`/`ts` fields. Schema is permissive — block 7 tries each key in order.
- New ANSI codes are display-only. Per the skill: "ANSI highlighting is **display-only** — never let it influence search/routing."
- `--deep` (escape hatch) is unchanged; it still routes to `~/.claude/skills/history-search/SKILL.md` which already documents Cursor + agy/Antigravity.
- Diff against `origin/main`: **3 files, 528 insertions, 22 deletions** — the smallest possible delta on top of the 3-source baseline that already shipped.

## User Stories

- **Operator**: I run `/history "lint"` and want to see if I touched the same code in agy last week. → agy source surfaces the conversation_summaries row matching "lint".
- **Operator**: I run `/history "fix"` and want to see Cursor prompts where I asked Cursor the same question. → Cursor source surfaces matching prompt_history entries.
- **Operator**: I run `/history "merge conflict"` and want one screen of cross-CLI hits, not seven sources. → sparse default stays at 5; `--deep` only when I ask for it.

[claude-code/MiniMax-M3]

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill-instruction changes only; no runtime code paths, with read-only local-file access patterns explicitly documented.
> 
> **Overview**
> Extends the default **sparse** `/history` flow from three sources to **five** by documenting **agy CLI** (`conversation_summaries.db`) and **Cursor** (`prompt_history.json` + `~/.cursor/chats/`) alongside Claude, Codex, and Hermes.
> 
> Updates `.claude/commands/history.md` (source table, `--source agy|cursor`, examples) and the `conversation-history-sparse` skill (canonical `SKILL.md` plus mirrored `.md`): new workflow blocks with read-only SQLite/JSON sampling, tight row/snippet caps, and **agy** (yellow) / **cursor** (green) ANSI labels in the shared `ansify` helper. Synthesis and output templates now include agy and Cursor sections; safety text expands read-only paths for Gemini and Cursor data. **`--deep`** still points at the 7-source `history-search` skill unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8fb7bfc5841fa9e8759e1ed05105906975a2a4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->