### PR TITLE
browser: add /browser command + browser-control skill with fail-closed contract

### DIFF
--- a/.claude/commands/browser.md
+++ b/.claude/commands/browser.md
@@ -1,54 +1,159 @@
 ---
-description: Control live browser sessions, websites, settings, OAuth, and Slack app configuration through the current browser policy. For auth-gated share links (Gemini / ChatGPT / Google Docs / Notion), use `browserclaw cookies decrypt + inject` — verified recipe at ~/.hermes/skills/browserclaw/references/gemini-share-link-as-user.md.
+description: Control live browser sessions, websites, settings, OAuth, and Slack app configuration through the current browser policy. Primary Aside (MCP then CLI), then browserclaw cookies decrypt + inject for headless auth, then Playwright headless. Auth-gated share links reuse the installed browserclaw skill's verified cookie-injection references after both Aside paths are exhausted.
 type: skill
 execution_mode: immediate
 ---
 
 # /browser [task]
 
-Read `~/.claude/skills/browser-control/SKILL.md` and execute the workflow for `$ARGUMENTS`.
+Route the task in this priority order. Advance only when the current route cannot complete the authenticated task; a single transport/tab error is not enough. Even if the browser-control skill is unavailable, missing, or fails to load, this command MUST still resolve to the right tool.
 
-Use `~/.claude/skills/playwright-ui-testing/SKILL.md` only when the task is deterministic UI testing, CI, isolated profiles, traces, video, or multi-browser coverage.
+1. **Aside-MCP** if the active runtime exposes the Aside MCP tools. Use them. The user's existing signed-in tabs and session persist across calls.
+2. **Aside CLI** (`aside repl` / `aside "<prompt>"` / `aside account list`) — drives the already-running `Aside.app` profile and reuses its signed-in session. It is a real browser session, not the headless fallback. Sandbox note: `aside` Bash calls require `dangerouslyDisableSandbox: true` (Aside CLI fails closed, not soft, when the Bash sandbox blocks its local IPC).
+3. **`browserclaw cookies decrypt + inject`** for sites where the user is already authenticated but Aside is not signed-in, unavailable, or on a headless host. Decrypt the user's existing cookies from the local Chromium profile (Aside → Chrome Default → Profile 1 → Profile 2 → Brave → Edge), inject into Playwright Chromium headless (`--browser-channel chromium --headless`), navigate. ALWAYS use `--summary` when only a domain check is needed, write only to a private `/tmp` file, never log values, never commit cookie JSON, delete the file immediately after use. **Never** route credential-bearing flows through `browserclaw capture` / `learn` / `reverse` — those persist full HTTP traffic to a HAR file that can contain the new secret in plaintext.
+4. **Playwright headless (no auth)** for unauthenticated/deterministic flows, scripted sweeps, or CI-style checks.
+5. **Visible/headed browser** — only when the user explicitly opted in for it in the current thread.
+
+**Fingerprint-sensitive sites (Aside-only exception):** LinkedIn, banks/brokerages (Chase, Fidelity, Vanguard, Schwab), and sites with active Cloudflare/Akamai bot-mitigation that flag the Chromium-for-Testing headless fingerprint. For these, drop the cookie-copy route and use the existing signed-in Aside profile directly. If the host is headless, post a ONE-LINE BLOCKER naming the missing display rather than retrying headless.
+
+Then load the installed `browser-control` skill with normal skill discovery and execute the workflow for `$ARGUMENTS`. Use the installed `playwright-ui-testing` skill only when the task is deterministic UI testing, CI, isolated profiles, traces, video, or multi-browser coverage. The full contract for these routing rules lives in `browser-control/SKILL.md` and is enforced by the contract test `tests/test_browser_command_contract.py` in this repo, which fails if the routing order or the auth-gate recipe pointer ever changes.
 
 ## Auth-gated share links (Gemini / ChatGPT / Google Docs / Notion)
 
-**If the task is "read / save / summarize / extract / ingest" the content of an auth-gated share URL** (`share.gemini.google/...`, `chatgpt.com/share/...`, `docs.google.com/document/d/.../edit` with restricted access, `notion.so/...` shared pages, vendor AI share dialogs) and an anonymous fetch returns the vendor's sign-in shell — **do NOT post an "unblock options" menu and do NOT ask the user to paste the content.** On the first refusal, pivot to **`browserclaw` headless** and read the page AS the user.
+**If the task is "read / save / summarize / extract / ingest" the content of an auth-gated share URL** (`share.gemini.google/...`, `chatgpt.com/share/...`, `docs.google.com/document/d/.../edit` with restricted access, `notion.so/...` shared pages, vendor AI share dialogs) and an anonymous fetch returns the vendor's sign-in shell — **do NOT post an "unblock options" menu and do NOT ask the user to paste the content.** Continue the same global routing order: try the existing signed-in Aside session through MCP, then Aside CLI; only if neither can access the content, pivot to **`browserclaw` headless** and read the page as the user. The fingerprint-sensitive Aside-only exception still overrides this fallback.
 
-Verified 5-step recipe (2026-07-20 on Gemini share `Td7fA4pzuvMs`, 79 Google cookies decrypted, full 169KB page text extracted, campaign module saved via PR $GITHUB_REPOSITORY#8483):
+Verified 5-step recipe (2026-07-20 on Gemini share `Td7fA4pzuvMs`, 79 Google cookies decrypted, full 169KB page text extracted). The safe recipe below is canonical; the multi-profile sweep is embedded inline so the canonical lifecycle does not depend on operator-executed fixed-path sweep snippets. The optional browserclaw reference files are background only and must not override this guarded lifecycle.
 
 ```bash
-# 1. Decrypt Chrome Default cookies for the vendor auth domain
-env -i HOME="$HOME" PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-  browserclaw cookies decrypt \
-    --db "$HOME/Library/Application Support/Google/Chrome/Default/Cookies" \
-    --output /tmp/<vendor>-cookies.json \
-    --domain-filter '%<vendor-domain>%' --summary
+# Canonical guarded lifecycle for /browser auth-gated content.
+# Fail-closed: any decrypt/inject/Playwright failure aborts before
+# persisted credential state, and INT/TERM/HUP also trigger cleanup.
+# One canonical cleanup trap removes BOTH the cookie file and the
+# page text on every success, error, and signal. The secret branch
+# runs INSIDE this trap, and the multi-profile sweep produces a
+# cookie artifact the canonical recipe consumes before cleanup.
+set -euo pipefail
+# Restrict the process umask so any mktemp / redirect that does
+# not respect an explicit chmod still ends up owner-only. The
+# canonical recipe also re-applies chmod 600 after every sweep
+# write because browserclaw's writer uses Path.write_text()
+# which honors the process umask.
+umask 077
+TMP_COOKIES="$(mktemp -t browserclaw-XXXXXX.json)"
+TMP_PAGE="$(mktemp -t browserclaw-page-XXXXXX.txt)"
+chmod 600 "$TMP_COOKIES" "$TMP_PAGE"
+# INT/TERM/HUP handlers MUST terminate nonzero after cleanup so
+# a signal during a long decrypt/inject does not let bash
+# continue past the trap and recreate credential files. We use
+# the same trap as cleanup_browser_share and force an exit
+# in the trap function itself.
+cleanup_browser_share() {
+  local rc=$?
+  rm -f "$TMP_COOKIES" "$TMP_PAGE"
+  return "$rc"
+}
+exit_on_signal() {
+  local rc=$?
+  cleanup_browser_share || true
+  # Exit immediately with 128+signal so bash does NOT continue
+  # past the trap. Re-raising via `kill -SIG $$` is unreliable
+  # because bash defers re-entry of the same signal while the
+  # handler is still running; a direct `exit` is the documented
+  # and race-free way to terminate from a signal trap.
+  if [ -n "${1:-}" ]; then
+    case "${1}" in
+      INT)  exit 130 ;;
+      TERM) exit 143 ;;
+      HUP)  exit 129 ;;
+      *)    exit "$rc" ;;
+    esac
+  fi
+  exit "$rc"
+}
+trap 'exit_on_signal TERM' TERM
+trap 'exit_on_signal HUP' HUP
+trap 'exit_on_signal INT' INT
+trap cleanup_browser_share EXIT
 
-# 2. If 0 cookies returned, sweep Profile 1 / Aside / Brave per
-#    ~/.hermes/skills/browserclaw/references/multi-profile-cookie-scan.md.
-#    If still 0, post ONE-LINE BLOCKER naming the missing-cookie domain.
+# 1. Multi-profile sweep runs FIRST, Aside first — the canonical
+#    recipe does NOT depend on Chrome Default being non-empty
+#    before falling through to other profiles. The sweep writes
+#    the first non-empty cookie JSON to $TMP_COOKIES and short-
+#    circuits. Each browserclaw write is followed by chmod 600
+#    because browserclaw's writer honors the process umask.
+#
+#    When multiple Aside accounts are signed in (`aside account
+#    list` shows more than one), prefer the one the current
+#    task asked for; if the task did not name one, run the
+#    sweep with the default profile and let the gate decide.
+#    Each browserclaw call uses `--keychain-account` to pin the
+#    keychain entry that decrypts the corresponding cookies.db.
+set +e
+for entry in \
+  "Aside:$HOME/Library/Application Support/Aside/Default/Cookies:Aside Safe Storage:Aside" \
+  "Aside-Profile1:$HOME/Library/Application Support/Aside/Profile 1/Cookies:Aside Safe Storage:Aside-Profile1" \
+  "Chrome-Default:$HOME/Library/Application Support/Google/Chrome/Default/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile1:$HOME/Library/Application Support/Google/Chrome/Profile 1/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile2:$HOME/Library/Application Support/Google/Chrome/Profile 2/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile3:$HOME/Library/Application Support/Google/Chrome/Profile 3/Cookies:Chrome Safe Storage:Chrome" \
+  "Brave:$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies:Brave Safe Storage:Brave" \
+  "Edge:$HOME/Library/Application Support/Microsoft Edge/Default/Cookies:Microsoft Edge Safe Storage:Microsoft Edge"; do
+  IFS=: read label db svc acct <<< "$entry"
+  [ -f "$db" ] || continue
+  env -i HOME="$HOME" \
+    PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    browserclaw cookies decrypt --db "$db" \
+      --output "$TMP_COOKIES" \
+      --keychain-service "$svc" --keychain-account "$acct" \
+      --domain-filter '%<vendor-domain>%' --summary >/dev/null 2>&1 || true
+  if [ -s "$TMP_COOKIES" ]; then
+    count="$(jq -r '.cookies | length' "$TMP_COOKIES" 2>/dev/null || echo 0)"
+    if [ "$count" -gt 0 ]; then
+      # browserclaw's writer uses Path.write_text() and does not
+      # enforce a restrictive mode. Re-apply 0600 so the cookie
+      # file never ends up world- or group-readable even with a
+      # permissive umask. The EXIT trap will remove the file
+      # on any subsequent failure.
+      chmod 600 "$TMP_COOKIES"
+      echo "MATCH: $label (${count} cookies) — stopping sweep" >&2
+      break
+    fi
+  fi
+  rm -f "$TMP_COOKIES"
+done
+set -e
 
-# 3. Inject + navigate headless Chromium + dump page text
+DECRYPT_COUNT="$(jq -r '.cookies | length' "$TMP_COOKIES" 2>/dev/null || echo 0)"
+if [ "$DECRYPT_COUNT" -le 0 ]; then
+  echo "BLOCKER: no <vendor-domain> cookies in any profile. Ask the user to log in once." >&2
+  exit 11
+fi
+
+# 2. We now have a valid cookie artifact. Inject.
+
+# 3. Inject + navigate headless Chromium; keep private body text temporary.
 env -i HOME="$HOME" PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
   browserclaw cookies inject \
-    --cookies /tmp/<vendor>-cookies.json \
+    --cookies "$TMP_COOKIES" \
     --goto "<full-share-url-with-skid-if-present>" \
     --browser-channel chromium \
     --headless \
     --wait-after-load 12 \
-    --screenshot /tmp/<vendor>_authed.png \
-    --print-text 100000 > /tmp/<vendor>_page.txt
+    --print-text 100000 > "$TMP_PAGE"
 
-# 4. If --print-text truncates mid-sentence (Gemini share pages lazy-load
-#    sections), re-extract with Playwright + scroll-to-bottom. See
-#    ~/.hermes/skills/browserclaw/references/gemini-share-link-as-user.md
-#    for the verified Python script.
+# 4. If --print-text truncates mid-sentence, scroll to the bottom with a bare
+#    headless Playwright script that reads `$TMP_COOKIES` and overwrites
+#    `$TMP_PAGE`; preserve the same trap and never use fixed output paths.
 
-# 5. Read the captured text end-to-end. Verify the expected first-user
-#    message appears (NOT the vendor sign-in form). Proceed with the user's
-#    actual ask against the captured content.
+# 5. Read only the captured fields needed for the task. Verify the expected
+#    first-user message appears, not the sign-in shell.
+
+# 6. Final cleanup runs the trap once on normal exit; failures abort
+#    via set -e and the EXIT trap removes both files.
+cleanup_browser_share
+trap - EXIT INT TERM HUP
 ```
 
 **Why `--browser-channel chromium` (not `chrome`):** `channel=chrome` briefly opens a visible Chrome window before transitioning to headless — verified bug 2026-07-18. The bundled Chromium-for-Testing is always headless and never pollutes the user's existing Chrome session.
 
-This pattern is enforced by SOUL.md `## COMMIT: read-auth-gated-share-links-with-browserclaw` (verified 2026-07-20). The contract test `tests/test_browser_command_mentions_browserclaw.py` in `~/jleechanclaw` fails if this file ever drops the `browserclaw` reference or the auth-gate recipe pointer.
+This pattern is enforced by the contract test `tests/test_browser_command_contract.py` in this repo, which fails if the routing order or the auth-gate recipe pointer ever changes.

--- a/.claude/commands/browser.md
+++ b/.claude/commands/browser.md
@@ -148,10 +148,12 @@ env -i HOME="$HOME" PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/loca
 # 5. Read only the captured fields needed for the task. Verify the expected
 #    first-user message appears, not the sign-in shell.
 
-# 6. Final cleanup runs the trap once on normal exit; failures abort
-#    via set -e and the EXIT trap removes both files.
-cleanup_browser_share
-trap - EXIT INT TERM HUP
+# 6. Cleanup is owned by the EXIT/INT/TERM/HUP trap (cleanup_browser_share),
+#    which is armed throughout the recipe. There is no disarm line —
+#    keeping the trap armed is the fail-closed contract: any signal
+#    arriving after step 5 still removes both files. The trap's
+#    `rm -f` is idempotent, so a normal exit that fires the EXIT
+#    trap is the same as an explicit cleanup call.
 ```
 
 **Why `--browser-channel chromium` (not `chrome`):** `channel=chrome` briefly opens a visible Chrome window before transitioning to headless — verified bug 2026-07-18. The bundled Chromium-for-Testing is always headless and never pollutes the user's existing Chrome session.

--- a/.claude/skills/browser-control/SKILL.md
+++ b/.claude/skills/browser-control/SKILL.md
@@ -12,7 +12,7 @@ The numbered **Routing order** below is the only authoritative sequence; these b
 - **Live websites, authenticated sessions, account settings, OAuth, existing tabs:** start at Aside MCP, then Aside CLI (the only signed-in path that does not copy session material).
 - **Authenticated fallback on fingerprint-TOLERANT sites:** use the guarded browserclaw decrypt → headless inject lifecycle only after both Aside paths fail to complete the authenticated task. **Fingerprint-sensitive sites (LinkedIn, banks/brokerages, Cloudflare/Akamai-protected, user-declared no-headless) NEVER advance past Aside.** When Aside is unavailable on a fingerprint-sensitive target, post a ONE-LINE display/input blocker; do not fall through to cookie injection, capture, learn, reverse, or Playwright.
 - **Deterministic local-app testing, CI, isolated profiles, traces, video, multi-browser:** use Playwright headless / `playwright-ui-testing` after the authenticated routes are inapplicable.
-- **Authorized API discovery (no credentials):** `browserclaw capture` is allowed only when no credentials, cookies, authorization headers, tokens, or secret pages can enter the capture. This is a separate, narrow escape hatch — it is NOT the headless-host fallback for the numbered routes above.
+- **Visible/headed browser:** only when the user explicitly asked for it in the current thread. Headed Chromium is the user's existing Chrome session; do not use it from a sandboxed Bash call unless the user opts in.
 
 ## Routing order (operational, in priority order)
 
@@ -23,6 +23,8 @@ Apply these in order; proceed only after the current route fails to complete the
 3. **browserclaw cookies decrypt → inject** — for fingerprint-tolerant sites where Aside is unavailable, not signed-in, or on a headless host. The fingerprint-sensitive Aside-only exception below overrides this fallback. Decrypt the user's existing cookies from the local Chromium profile, inject into Playwright Chromium headless, navigate. Profile sweep order: **Aside → Chrome Default → Chrome Profile 1 → Chrome Profile 2 → Brave → Microsoft Edge**. Chrome path: `~/Library/Application Support/Google/Chrome/<Profile>/Cookies`. Aside/Edge/Brave use the same shape with a different `--keychain-service`/`--keychain-account`. Discover profile locations from the installed browserclaw skill, but apply only the guarded lifecycle below; do not execute older fixed-path output snippets.
 4. **Playwright headless (no auth)** — for unauthenticated/deterministic flows, scraping public pages, scripted sweeps, or CI-style checks. Use `playwright-ui-testing` if the task is a real test (isolated profiles, traces, video).
 5. **Visible/headed browser** — only when the user explicitly asked for it in the current thread. Headed Chromium is the user's existing Chrome session; do not use it from a sandboxed Bash call unless the user opts in.
+
+> **Footnote — `browserclaw capture` / `learn` / `reverse` (NOT a route).** These subcommands persist full HTTP request/response traffic to a `capture.har` file on disk, which can contain the new secret in plaintext. They are allowed ONLY for tasks where no credentials, cookies, authorization headers, tokens, or secret pages can enter the capture — e.g. API documentation discovery against a public docs site. They are NOT the headless fallback for any of the numbered routes above; if you need an authenticated page, use route 3 (browserclaw `cookies decrypt` + `cookies inject`) instead.
 
 ## Live-browser workflow
 
@@ -141,12 +143,14 @@ env -i HOME="$HOME" PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/loca
     --wait-after-load 12 \
     --print-text 100000 > "$TMP_PAGE"
 
-# 4. Read only the fields needed for the task, then remove both the
-#    cookie file and the captured private text on both success and
-#    failure. The trap is the cleanup; this final call disarms it
-#    so a normal exit does not double-fire.
-cleanup_browser_creds
-trap - EXIT INT TERM HUP
+# 4. Read only the fields needed for the task, then trust the EXIT
+#    trap to remove both the cookie file and the captured private
+#    text on both success and failure. The trap is the cleanup;
+#    there is no disarm line and no explicit cleanup call here —
+#    keeping the trap armed is the fail-closed contract: any signal
+#    arriving after step 3 still removes both files. The trap's
+#    `rm -f` is idempotent, so a normal exit that fires the EXIT
+#    trap is the same as an explicit cleanup call.
 ```
 
 **Secret-bearing page branch:** API-key, token, password, recovery-code, banking, and similar pages MUST NOT execute the generic `--print-text` recipe above, MUST NOT capture screenshots, MUST NOT write a HAR, and MUST NOT persist DOM text. The branch must persist neither DOM text nor images. After injecting the guarded cookies, use a bare headless Playwright script that inspects only the minimum safe non-secret DOM state in memory, emits the boolean/status result to **stdout** (not a file), and persists nothing on disk. The lifecycle MUST be fail-closed: it owns combined cleanup of the cookie file and any per-branch scratch file, and INT/TERM/HUP also trigger cleanup:

--- a/.claude/skills/browser-control/SKILL.md
+++ b/.claude/skills/browser-control/SKILL.md
@@ -7,17 +7,278 @@ description: Control real websites and authenticated browser sessions, inspect p
 
 ## Route the task
 
-1. **Live websites, authenticated sessions, account settings, OAuth, or existing tabs**: use `aside-browser-default` first. Inspect the active runtime's available browser tools before hard-coding a tool name.
-2. **Deterministic local-app testing, CI, isolated profiles, traces, video, or multi-browser coverage**: load `playwright-ui-testing`.
-3. **Authorized API discovery only**: use `browserclaw`. Do not use it for Slack app settings, OAuth flows, or any capture likely to retain credentials, cookies, authorization headers, or tokens.
+The numbered **Routing order** below is the only authoritative sequence; these bullet categories are a non-binding restatement. A route is considered to have **succeeded** only when it completes the authenticated task the user asked for — a single transport error, a missing-tab condition, or one failed CLI call is not enough to advance. When a route fails to complete the authenticated task, fall back to the next numbered route.
+
+- **Live websites, authenticated sessions, account settings, OAuth, existing tabs:** start at Aside MCP, then Aside CLI (the only signed-in path that does not copy session material).
+- **Authenticated fallback on fingerprint-TOLERANT sites:** use the guarded browserclaw decrypt → headless inject lifecycle only after both Aside paths fail to complete the authenticated task. **Fingerprint-sensitive sites (LinkedIn, banks/brokerages, Cloudflare/Akamai-protected, user-declared no-headless) NEVER advance past Aside.** When Aside is unavailable on a fingerprint-sensitive target, post a ONE-LINE display/input blocker; do not fall through to cookie injection, capture, learn, reverse, or Playwright.
+- **Deterministic local-app testing, CI, isolated profiles, traces, video, multi-browser:** use Playwright headless / `playwright-ui-testing` after the authenticated routes are inapplicable.
+- **Authorized API discovery (no credentials):** `browserclaw capture` is allowed only when no credentials, cookies, authorization headers, tokens, or secret pages can enter the capture. This is a separate, narrow escape hatch — it is NOT the headless-host fallback for the numbered routes above.
+
+## Routing order (operational, in priority order)
+
+Apply these in order; proceed only after the current route fails to complete the authenticated task (not merely after one transport or tab call errors). The order intentionally prefers tools that already have the user's session over tools that copy session material.
+
+1. **Aside-MCP if available.** Most specific, lowest friction: the user's existing signed-in tabs and session are preserved across calls. Detect by listing MCP tools in the active runtime.
+2. **Aside CLI** (`aside repl` / `aside "<prompt>"` / `aside account list`) — `repl` mode for interactive navigation, `agent`/`<prompt>` mode for an Aside-driven task. Use the already-running `Aside.app` profile. `account list` returns the active profile(s). Aside drives a real browser session; it remains the primary signed-in path, even though it is not the headless fallback.
+3. **browserclaw cookies decrypt → inject** — for fingerprint-tolerant sites where Aside is unavailable, not signed-in, or on a headless host. The fingerprint-sensitive Aside-only exception below overrides this fallback. Decrypt the user's existing cookies from the local Chromium profile, inject into Playwright Chromium headless, navigate. Profile sweep order: **Aside → Chrome Default → Chrome Profile 1 → Chrome Profile 2 → Brave → Microsoft Edge**. Chrome path: `~/Library/Application Support/Google/Chrome/<Profile>/Cookies`. Aside/Edge/Brave use the same shape with a different `--keychain-service`/`--keychain-account`. Discover profile locations from the installed browserclaw skill, but apply only the guarded lifecycle below; do not execute older fixed-path output snippets.
+4. **Playwright headless (no auth)** — for unauthenticated/deterministic flows, scraping public pages, scripted sweeps, or CI-style checks. Use `playwright-ui-testing` if the task is a real test (isolated profiles, traces, video).
+5. **Visible/headed browser** — only when the user explicitly asked for it in the current thread. Headed Chromium is the user's existing Chrome session; do not use it from a sandboxed Bash call unless the user opts in.
 
 ## Live-browser workflow
 
 1. Check for usable existing tabs before opening a new one.
 2. Read the page with an accessibility snapshot before acting. Use current refs, not guessed selectors or coordinates.
-3. Treat login, consent, chooser, and MFA screens as recoverable states. Never bypass them, extract secrets, or copy cookies between browser profiles.
+3. Treat login, consent, chooser, and MFA screens as recoverable states. Never bypass them. Treat any cookie/session material you copy as a credential.
 4. Confirm any side effect from the resulting page state. Before sending, submitting, deleting, installing, authorizing, or publishing, verify the target and requested scope.
 5. Close tabs opened solely for the task when they are no longer useful.
+
+## Authorized credential reuse (the safe cookie-copy contract)
+
+`browserclaw` documents the cookie decrypt + inject flow as the headless fallback for sites where the user is already authenticated. That is the supported, authorized path for any site where the user has an existing signed-in profile — Gemini / ChatGPT / Google Docs / Notion share links, Slack, GitHub, GCP Console, Firebase Console, etc. The actual ban is on **credential exposure**, not on the act of carrying an authenticated session from one Chromium profile to a headless session for the same user.
+
+Use this contract for any credential-bearing flow:
+
+```bash
+# One guarded lifecycle: create → decrypt → inject → delete.
+# Fail-closed: any nonzero exit (set -euo pipefail) runs cleanup before abort.
+# One canonical cleanup trap removes BOTH the cookie file and the page
+# text on every success, error, and signal. The secret branch runs
+# INSIDE this trap, and the multi-profile sweep produces a cookie
+# artifact the canonical recipe consumes before cleanup.
+set -euo pipefail
+# Restrict the process umask so any mktemp / redirect that does
+# not respect an explicit chmod still ends up owner-only. The
+# canonical recipe also re-applies chmod 600 after every sweep
+# write because browserclaw's writer uses Path.write_text()
+# which honors the process umask.
+umask 077
+TMP_COOKIES="$(mktemp -t browserclaw-XXXXXX.json)"
+TMP_PAGE="$(mktemp -t browserclaw-page-XXXXXX.txt)"
+chmod 600 "$TMP_COOKIES" "$TMP_PAGE"
+# INT/TERM/HUP handlers MUST terminate nonzero after cleanup so
+# a signal during a long decrypt/inject does not let bash
+# continue past the trap and recreate credential files.
+cleanup_browser_creds() {
+  local rc=$?
+  rm -f "$TMP_COOKIES" "$TMP_PAGE"
+  return "$rc"
+}
+exit_on_signal() {
+  local rc=$?
+  cleanup_browser_creds || true
+  # Exit immediately with 128+signal so bash does NOT continue
+  # past the trap. Re-raising via `kill -SIG $$` is unreliable
+  # because bash defers re-entry of the same signal while the
+  # handler is still running; a direct `exit` is the documented
+  # and race-free way to terminate from a signal trap.
+  if [ -n "${1:-}" ]; then
+    case "${1}" in
+      INT)  exit 130 ;;
+      TERM) exit 143 ;;
+      HUP)  exit 129 ;;
+      *)    exit "$rc" ;;
+    esac
+  fi
+  exit "$rc"
+}
+trap 'exit_on_signal TERM' TERM
+trap 'exit_on_signal HUP' HUP
+trap 'exit_on_signal INT' INT
+trap cleanup_browser_creds EXIT
+
+# 1. Multi-profile sweep runs FIRST, Aside first — the canonical
+#    recipe does NOT depend on Chrome Default being non-empty
+#    before falling through to other profiles. The sweep writes
+#    the first non-empty cookie JSON to $TMP_COOKIES and short-
+#    circuits. Each browserclaw write is followed by chmod 600
+#    because browserclaw's writer honors the process umask.
+set +e
+for entry in \
+  "Aside:$HOME/Library/Application Support/Aside/Default/Cookies:Aside Safe Storage:Aside" \
+  "Aside-Profile1:$HOME/Library/Application Support/Aside/Profile 1/Cookies:Aside Safe Storage:Aside-Profile1" \
+  "Chrome-Default:$HOME/Library/Application Support/Google/Chrome/Default/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile1:$HOME/Library/Application Support/Google/Chrome/Profile 1/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile2:$HOME/Library/Application Support/Google/Chrome/Profile 2/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile3:$HOME/Library/Application Support/Google/Chrome/Profile 3/Cookies:Chrome Safe Storage:Chrome" \
+  "Brave:$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies:Brave Safe Storage:Brave" \
+  "Edge:$HOME/Library/Application Support/Microsoft Edge/Default/Cookies:Microsoft Edge Safe Storage:Microsoft Edge"; do
+  IFS=: read label db svc acct <<< "$entry"
+  [ -f "$db" ] || continue
+  env -i HOME="$HOME" \
+    PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    browserclaw cookies decrypt --db "$db" \
+      --output "$TMP_COOKIES" \
+      --keychain-service "$svc" --keychain-account "$acct" \
+      --domain-filter '%<target-domain>%' --summary >/dev/null 2>&1 || true
+  if [ -s "$TMP_COOKIES" ]; then
+    count="$(jq -r '.cookies | length' "$TMP_COOKIES" 2>/dev/null || echo 0)"
+    if [ "$count" -gt 0 ]; then
+      chmod 600 "$TMP_COOKIES"
+      echo "MATCH: $label (${count} cookies) — stopping sweep" >&2
+      break
+    fi
+  fi
+  rm -f "$TMP_COOKIES"
+done
+set -e
+
+DECRYPT_COUNT="$(jq -r '.cookies | length' "$TMP_COOKIES" 2>/dev/null || echo 0)"
+if [ "$DECRYPT_COUNT" -le 0 ]; then
+  echo "BLOCKER: no <target-domain> cookies in any profile. Ask the user to log in once." >&2
+  exit 11
+fi
+
+# 3. Inject + navigate headless Chromium. Keep body text private and temporary.
+#    Do not write a screenshot by default; capture one only when the user
+#    explicitly requested visual evidence AND the page is known not to
+#    display secrets.
+env -i HOME="$HOME" PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+  browserclaw cookies inject \
+    --cookies "$TMP_COOKIES" \
+    --goto "<full-authenticated-url>" \
+    --browser-channel chromium \
+    --headless \
+    --wait-after-load 12 \
+    --print-text 100000 > "$TMP_PAGE"
+
+# 4. Read only the fields needed for the task, then remove both the
+#    cookie file and the captured private text on both success and
+#    failure. The trap is the cleanup; this final call disarms it
+#    so a normal exit does not double-fire.
+cleanup_browser_creds
+trap - EXIT INT TERM HUP
+```
+
+**Secret-bearing page branch:** API-key, token, password, recovery-code, banking, and similar pages MUST NOT execute the generic `--print-text` recipe above, MUST NOT capture screenshots, MUST NOT write a HAR, and MUST NOT persist DOM text. The branch must persist neither DOM text nor images. After injecting the guarded cookies, use a bare headless Playwright script that inspects only the minimum safe non-secret DOM state in memory, emits the boolean/status result to **stdout** (not a file), and persists nothing on disk. The lifecycle MUST be fail-closed: it owns combined cleanup of the cookie file and any per-branch scratch file, and INT/TERM/HUP also trigger cleanup:
+
+```bash
+# Secret-bearing page branch — fail-closed lifecycle.
+# Self-contained: it runs the canonical multi-profile sweep to
+# obtain $TMP_COOKIES, then a bare Playwright script that emits
+# the boolean to stdout only. The EXIT/INT/TERM/HUP trap removes
+# every browserclaw temp file on every signal, and the signal
+# handlers re-raise the signal so the script exits nonzero.
+set -euo pipefail
+# Restrict the process umask so any mktemp / redirect that does
+# not respect an explicit chmod still ends up owner-only. The
+# canonical recipe also re-applies chmod 600 after every sweep
+# write because browserclaw's writer uses Path.write_text()
+# which honors the process umask.
+umask 077
+TMP_COOKIES="$(mktemp -t browserclaw-XXXXXX.json)"
+TMP_PAGE="$(mktemp -t browserclaw-page-XXXXXX.txt)"
+SECRET_STDOUT_BUF="$(mktemp -t browserclaw-secret-out-XXXXXX.txt)"
+chmod 600 "$TMP_COOKIES" "$TMP_PAGE" "$SECRET_STDOUT_BUF"
+cleanup_secret_branch() {
+  local rc=$?
+  rm -f "$TMP_COOKIES" "$TMP_PAGE" "$SECRET_STDOUT_BUF"
+  return "$rc"
+}
+exit_on_signal() {
+  local rc=$?
+  cleanup_secret_branch || true
+  # Exit immediately with 128+signal so bash does NOT continue
+  # past the trap. Re-raising via `kill -SIG $$` is unreliable
+  # because bash defers re-entry of the same signal while the
+  # handler is still running; a direct `exit` is the documented
+  # and race-free way to terminate from a signal trap.
+  if [ -n "${1:-}" ]; then
+    case "${1}" in
+      INT)  exit 130 ;;
+      TERM) exit 143 ;;
+      HUP)  exit 129 ;;
+      *)    exit "$rc" ;;
+    esac
+  fi
+  exit "$rc"
+}
+trap 'exit_on_signal TERM' TERM
+trap 'exit_on_signal HUP' HUP
+trap 'exit_on_signal INT' INT
+trap cleanup_secret_branch EXIT
+
+# 1a. Multi-profile sweep — same body as the canonical recipe.
+set +e
+for entry in \
+  "Aside:$HOME/Library/Application Support/Aside/Default/Cookies:Aside Safe Storage:Aside" \
+  "Aside-Profile1:$HOME/Library/Application Support/Aside/Profile 1/Cookies:Aside Safe Storage:Aside-Profile1" \
+  "Chrome-Default:$HOME/Library/Application Support/Google/Chrome/Default/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile1:$HOME/Library/Application Support/Google/Chrome/Profile 1/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile2:$HOME/Library/Application Support/Google/Chrome/Profile 2/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile3:$HOME/Library/Application Support/Google/Chrome/Profile 3/Cookies:Chrome Safe Storage:Chrome" \
+  "Brave:$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies:Brave Safe Storage:Brave" \
+  "Edge:$HOME/Library/Application Support/Microsoft Edge/Default/Cookies:Microsoft Edge Safe Storage:Microsoft Edge"; do
+  IFS=: read label db svc acct <<< "$entry"
+  [ -f "$db" ] || continue
+  env -i HOME="$HOME" \
+    PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    browserclaw cookies decrypt --db "$db" \
+      --output "$TMP_COOKIES" \
+      --keychain-service "$svc" --keychain-account "$acct" \
+      --domain-filter '%<target-domain>%' --summary >/dev/null 2>&1 || true
+  if [ -s "$TMP_COOKIES" ]; then
+    count="$(jq -r '.cookies | length' "$TMP_COOKIES" 2>/dev/null || echo 0)"
+    if [ "$count" -gt 0 ]; then
+      chmod 600 "$TMP_COOKIES"
+      break
+    fi
+  fi
+  rm -f "$TMP_COOKIES"
+done
+set -e
+
+if [ "$(jq -r '.cookies | length' "$TMP_COOKIES" 2>/dev/null || echo 0)" -le 0 ]; then
+  echo "BLOCKER: no <target-domain> cookies in any profile. Ask the user to log in once." >&2
+  exit 11
+fi
+
+# Bare Playwright script: reads $TMP_COOKIES, inspects DOM, emits the
+# boolean to stdout only. NEVER: --print-text, capture, learn,
+# reverse, persisted DOM, screenshots. The URL is defined on its own
+# line so `set -u` does not trip when we expand it on the next.
+BROWSE_TARGET_URL="<full-secret-bearing-url>"
+"$HOME/.local/orch-venv/bin/python" - "$TMP_COOKIES" "$BROWSE_TARGET_URL" <<'PY'
+import json, sys
+from playwright.sync_api import sync_playwright
+
+cookies_path, target_url = sys.argv[1], sys.argv[2]
+cookies = json.loads(open(cookies_path).read())["cookies"]
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True, channel="chromium")
+    ctx = browser.new_context(storage_state={"cookies": cookies, "origins": []})
+    page = ctx.new_page()
+    page.goto(target_url, wait_until="domcontentloaded", timeout=30000)
+    page.wait_for_timeout(5000)
+    has_secret = page.evaluate("() => !!document.querySelector('[data-secret], .token, .api-key')")
+    browser.close()
+
+# Emit the boolean to stdout; do NOT persist the result.
+sys.stdout.write("present=" + ("true" if has_secret else "false") + "\n")
+PY
+
+# Trap removes every browserclaw temp file on normal exit. No disarm
+# line — keeping the trap armed is the fail-closed contract.
+```
+
+For ordinary private content (not secret-bearing), the generic `--print-text` recipe above is permitted but must omit `--screenshot`; only capture one when the user requested visual evidence AND the page is known not to display secrets.
+
+**Safeguards** (enforced by the contract test `tests/test_browser_command_contract.py`):
+
+- The cookies JSON and any captured private body text live only in private mode-600 temp files, are never committed or logged, and are removed by an EXIT trap on success and failure.
+- Use `--summary` when only a domain/name/length check is needed; never log raw values.
+- **Never** route credential-bearing flows through `browserclaw capture` / `learn` / `reverse` — those commands persist full HTTP request/response traffic to a `capture.har` file on disk, which CAN contain the new secret in plaintext (the exact leak class this skill's credential rule already bans). For those flows, use `cookies inject` (navigation only, no HAR) or a bare Playwright script, read the result from the DOM/page text, and do not persist the raw network traffic.
+- The `--browser-channel chromium` choice (not `chrome`) keeps the bundled Chromium-for-Testing always-headless and never touches the user's existing Chrome session.
+
+## Fingerprint-sensitive sites (Aside-only exception)
+
+Playwright cookie injection can invalidate sessions on sites that bind cookies to a device fingerprint (Cloudflare clearance, browser UUIDs, anti-bot TLS fingerprinting, etc.). For these known-bad sites, drop the cookie-copy route and use the existing signed-in Aside profile directly — even from a headless host, fail over to a host with a real attached display and use Aside instead of trying to spoof the missing fingerprint:
+
+- LinkedIn
+- Banks / brokerage sites (Chase, Fidelity, Vanguard, Schwab, etc.)
+- Sites with active Cloudflare or Akamai bot-mitigation that flag the Chromium-for-Testing headless fingerprint
+- Sites that the user has explicitly flagged as "do not attempt headless"
+
+If the host is headless and the URL is fingerprint-sensitive, post a ONE-LINE BLOCKER explaining the missing display/input rather than attempting `cookies inject` and silently failing.
 
 ## Slack app and credential work
 
@@ -32,9 +293,9 @@ Report the precise layer that failed: browser transport, current tab/profile acc
 ## Environment gotchas
 
 - **Aside CLI in a sandboxed Bash tool call fails closed, not soft.** `aside account list` / `aside repl` / `aside "<prompt>"` return `fetch failed` immediately — before the Aside daemon writes any log line — when the Bash tool's default sandbox blocks the CLI's local IPC to the already-running `Aside.app` (a real launchd-managed process; verify with `ps -p <pid>` or `launchctl list | grep -i aside`, not `ps aux | grep aside`, since sandboxed `ps aux` may not enumerate it even though the process is alive). This is NOT an Aside outage. Fix: pass `dangerouslyDisableSandbox: true` on every Bash call that invokes `aside`. Confirmed 2026-07-16: identical command failed sandboxed, succeeded immediately unsandboxed against the same running daemon.
-- **Aside additionally requires a real, rendered display — not just an unsandboxed process.** On a headless host (`ioreg -c IODisplayConnect | grep -c IODisplayConnect` returns `0`), the Aside daemon answers metadata-only calls (`account list`) fine but any call needing a browser window/tab (`openTab`, navigation, an agent `aside "<prompt>"` task) fails with `This task is not bound to a browser profile. Open it in Aside browser and try again.` — confirmed 2026-07-16 on a headless Mac runner even after disabling the sandbox and confirming the daemon PID alive. This is a hardware/session limitation, not fixable by CLI flags, retries, or `open -a Aside`. **On a headless host, do not attempt Aside for any interactive navigation — go straight to the `browserclaw` headless fallback below.** Aside remains correct on a host with a real attached display (physical or a virtual/loopback one).
+- **Aside additionally requires a real, rendered display — not just an unsandboxed process.** On a headless host (`ioreg -c IODisplayConnect | grep -c IODisplayConnect` returns `0`), the Aside daemon answers metadata-only calls (`account list`) fine but navigation fails with `This task is not bound to a browser profile. Open it in Aside browser and try again.` For ordinary **fingerprint-tolerant** sites, proceed to the guarded browserclaw `cookies decrypt` + `cookies inject` headless fallback (route 3 in the numbered order). **The fingerprint-sensitive Aside-only exception overrides this rule with NO fall-through:** for LinkedIn, banks/brokerages, Cloudflare/Akamai-protected, and user-declared no-headless sites, post the ONE-LINE display blocker and never attempt cookie injection, `browserclaw capture`, `learn`, `reverse`, or Playwright. The escape hatch (`browserclaw capture --headless --url ...` below) is a NARROW no-credentials discovery tool only and is NOT a substitute for the numbered routes.
 - **Aside has no headless mode** (`aside --help` lists no such flag) — it drives a real, visible browser via an extension bridge tied to the active macOS GUI session. It is not a background/CI-safe tool by design.
-- **`browserclaw` as a headless-chrome fallback**: `browserclaw capture --headless --url <url> [--goal "<task>" --provider <p> --model <m>]` is genuinely headless (Playwright-backed, no display or GUI session required) and works from a sandboxed Bash call without special flags — confirmed working on the same headless host where Aside failed. Use `browserclaw cookies decrypt` / `cookies inject` to carry over an authenticated session from the real Chrome/Brave/Edge profile. **Do not route credential-bearing flows (API key creation/rotation, token/secret pages) through `capture`/`learn`/`reverse`** — those commands persist full HTTP request/response traffic to a `capture.har` file on disk, which will contain the new secret in plaintext (the exact leak class this skill's credential rule already bans). For those flows, use `cookies inject` (navigation only, no HAR) or a bare Playwright script, read the result from the DOM/page text, and do not persist the page's raw network traffic.
+- **`browserclaw` as a headless-chrome fallback** (route 3 in the numbered order): use `browserclaw cookies decrypt` + `cookies inject` to carry over an authenticated session from the real Chrome/Brave/Edge/Aside profile per the "Authorized credential reuse" contract above. **`browserclaw capture --headless --url <url> [--goal "<task>" --provider <p> --model <m>]` is a separate, narrow discovery tool** (Playwright-backed, no display or GUI session required, confirmed working on the same headless host where Aside failed) — it is NOT the headless fallback for authenticated flows and is NOT permitted for credential-bearing targets. **Do not route credential-bearing flows (API key creation/rotation, token/secret pages, password/banking/recovery-code pages) through `capture`/`learn`/`reverse`** — those commands persist full HTTP request/response traffic to a `capture.har` file on disk, which will contain the new secret in plaintext (the exact leak class this skill's credential rule already bans). For those flows, use `cookies inject` (navigation only, no HAR) or a bare Playwright script that reads only minimum non-secret DOM state, emit only a boolean/status result, and persist neither DOM text nor images (see the secret-bearing page branch below).
 
 ## Completion
 

--- a/hermes/skills/aside-browser-default/SKILL.md
+++ b/hermes/skills/aside-browser-default/SKILL.md
@@ -18,7 +18,7 @@ context: hermes
 | `mcp__playwright-mcp` | Fallback | Only when Aside CLI is unavailable, or for Playwright-specific fixtures (trace viewer, `--isolated` profile mode, video recording) |
 | `mcp__plugin-superpowers-chrome__chrome_use_browser` | Fallback | Only when Chrome-specific behavior is required (e.g., you need Chrome's exact `--user-data-dir` semantics for a particular test) |
 
-**Explicit opt-in phrases only:** Jeffrey says *"show browser"*, *"headed mode"*, *"visible browser"*, or *"I want to see the window"* in the **current thread**. Aside supports both headed and headless modes; the agent picks based on the opt-in.
+**Explicit opt-in phrases only:** Jeffrey says *"show browser"*, *"headed mode"*, *"visible browser"*, or *"I want to see the window"* in the **current thread**. Aside drives a real GUI browser session and is not headless. Without opt-in, use Aside only when its existing session can be driven without surfacing a new window; otherwise use the guarded Playwright Chromium headless fallback.
 
 ## Why Aside
 
@@ -158,7 +158,7 @@ curl -fsSL https://releases.aside.com/install.sh | bash
 ## Anti-patterns (BANNED)
 
 - ❌ Calling `mcp__playwright-mcp__*` as a first resort without checking Aside first
-- ❌ Calling `show_browser` / headed mode without explicit opt-in (Aside supports both, but the headless-only default still applies)
+- ❌ Calling `show_browser` / headed mode without explicit opt-in (Aside is a real GUI browser — not headless — and the headless-only default applies only when falling back to Playwright or `browserclaw`)
 - ❌ Spawning a fresh Playwright Chromium per agent call (Aside's persistent daemon is faster + more stateful)
 - ❌ Using `mcp__claude-in-chrome__*` for any browser work (requires extension, fails headless/CI)
 - ❌ Assuming Chrome Default cookies reflect the user's actual session — **Aside and Chrome have INDEPENDENT cookie DBs** (different Safe Storage keychains, different file paths). A user logged into `app.monarch.com` via Aside may have ZERO cookies for it in Chrome's `Default/Cookies`, yet the full session lives in `~/Library/Application Support/Aside/Default/Cookies`. Before declaring "no auth," sweep `browserclaw cookies decrypt --db <aside-db> --keychain-service 'Aside Safe Storage' --keychain-account 'Aside'` (verified 2026-07-22: 10 valid `.api.monarch.com` cookies including `session_id` + `csrftoken` lived in Aside's DB; Chrome's profile had zero). See `references/aside-cookie-portability.md` for the full multi-DB sweep pattern.

--- a/hermes/skills/browserclaw/references/gemini-share-link-as-user.md
+++ b/hermes/skills/browserclaw/references/gemini-share-link-as-user.md
@@ -3,44 +3,29 @@ title: "Read a Gemini / ChatGPT / Google-Doc share link as the user"
 type: reference
 date: 2026-07-20
 verified_against: Gemini Flash share `Td7fA4pzuvMs` ("God of Murder Campaign Design")
+status: HARDENED 2026-08-09 — guarded lifecycle, no fixed /tmp paths, no screenshots, EXIT-trap cleanup. Background only; the canonical lifecycle is in `~/.claude/commands/browser.md` and `~/.claude/skills/browser-control/SKILL.md` and MUST NOT be overridden by the snippets below.
 ---
 
 # Reading auth-gated AI share links as the user
 
+> **Background reference only.** The canonical guarded lifecycle for /browser is in `~/.claude/commands/browser.md` (the **Auth-gated share links** section) and `~/.claude/skills/browser-control/SKILL.md` (**Authorized credential reuse**). The snippets below MUST NOT override that canonical lifecycle — they exist to document the verified end-to-end pattern, not to be copy-pasted as a competing instruction set.
+
 When the user gives you a `share.gemini.google/...`, `chatgpt.com/share/...`, or "anyone with the link" Google Doc URL and asks you to read the content, anonymous fetch (`curl`, `web_extract`, even headless `browser_navigate`) returns a **sign-in shell** with the conversation body loaded client-side only after Google / vendor auth.
 
-The wrong move is to declare the task blocked and ask the user to paste the content. The right move is to read the page *as the user* by decrypting their Chrome cookies and injecting them into a headless Chromium session.
+The wrong move is to declare the task blocked and ask the user to paste the content. The right move is to read the page *as the user* by decrypting their Chrome cookies and injecting them into a headless Chromium session, using the **canonical guarded lifecycle** referenced above. Key invariants the lifecycle enforces:
+
+- Cookie JSON + page text live only in **mktemp-generated private temp files** (`TMP_COOKIES`, `TMP_PAGE`), `chmod 600`, removed by EXIT trap on both success and failure. **No fixed predictable temp paths** — every credential-bearing write is a fresh `mktemp` file.
+- **No `--screenshot`** is written by default. Screenshots are only allowed when the user explicitly requested visual evidence AND the page is known not to display secrets.
+- **No HAR** is ever produced (the `browserclaw capture`/`learn`/`reverse` subcommands are banned for credential flows).
+- The decrypt, inject, and Python scripts propagate nonzero exit via `set -euo pipefail`; cleanup runs even on failure.
 
 This is what "use /browser or /browserclaw headless next time without asking" means — reach for the auth-aware recipe on the **first refusal**, not after being told.
 
-## Verified recipe (5 steps)
+## Verified recipe (background — see canonical lifecycle above)
 
-```bash
-# 1. Decrypt Chrome Default cookies for the target auth domain
-env -i HOME="$HOME" \
-  PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-  browserclaw cookies decrypt \
-    --db "$HOME/Library/Application Support/Google/Chrome/Default/Cookies" \
-    --output /tmp/google-cookies.json \
-    --domain-filter '%.google.com%' \
-    --summary
-# Expected: "Wrote 79 cookies to /tmp/google-cookies.json" (or similar)
+The canonical 5-step guarded lifecycle is in `~/.claude/commands/browser.md` § **Auth-gated share links** (the `# 1.` through `# 6.` blocks ending in `cleanup_browser_share`). It uses `$TMP_COOKIES` / `$TMP_PAGE` from `mktemp -t browserclaw-XXXXXX.json` and `mktemp -t browserclaw-page-XXXXXX.txt`, `chmod 600` them, traps `cleanup_browser_share EXIT`, and removes both on both success and failure. **Do not substitute the older fixed-path snippets that previously lived in this file.**
 
-# 2. Inject + navigate headless, dump the full page text
-env -i HOME="$HOME" \
-  PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-  browserclaw cookies inject \
-    --cookies /tmp/google-cookies.json \
-    --goto "https://gemini.google.com/share/<share-id>" \
-    --browser-channel chromium \
-    --headless \
-    --wait-after-load 12 \
-    --screenshot /tmp/share_authed.png \
-    --print-text 100000 > /tmp/share_page.txt
-# Expected: "cookies_injected: 79, page text captured"
-```
-
-The redirect (`/share/<id>` → `gemini.google.com/share/<daf9bcee379e>?skid=…`) is normal — the `skid` query parameter carries the conversation token. Pass the final redirected URL to `--goto` if you want to skip the redirect.
+The historical snippets in earlier versions of this file (using predictable cookie / page-text / screenshot paths) are RETIRED. If you see those fixed-path snippets anywhere else in the repo or in your own notes, replace them with the canonical guarded lifecycle — fixed predictable paths leak credentials across processes and survive long after the script exits.
 
 ## Why headless Chromium (not `channel=chrome`)
 
@@ -52,47 +37,25 @@ The redirect (`/share/<id>` → `gemini.google.com/share/<daf9bcee379e>?skid=…
 
 ## Truncation pitfall — scroll-to-bottom re-extraction
 
-Gemini's share UI lazy-loads conversation history as the user scrolls. `--print-text 100000` captures the visible viewport but can **truncate mid-sentence** for long conversations (verified 2026-07-20: v7 truncated at "replaced by somethi").
+Gemini's share UI lazy-loads conversation history as the user scrolls. The canonical lifecycle's `--print-text 100000` captures the visible viewport but can **truncate mid-sentence** for long conversations (verified 2026-07-20: v7 truncated at "replaced by somethi").
 
-**Fix:** re-extract with Playwright's scroll-to-bottom pattern, then grab the full `document.body.innerText`:
-
-```python
-from playwright.sync_api import sync_playwright
-import json, pathlib
-
-with open("/tmp/google-cookies.json") as f:
-    state = {"cookies": json.load(f)["cookies"], "origins": []}
-
-with sync_playwright() as p:
-    browser = p.chromium.launch(headless=True)
-    ctx = browser.new_context(storage_state=state, viewport={"width": 1280, "height": 900})
-    page = ctx.new_page()
-    page.goto("https://gemini.google.com/share/<id>", wait_until="domcontentloaded", timeout=30000)
-    page.wait_for_timeout(10000)
-    for _ in range(12):
-        page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
-        page.wait_for_timeout(1000)
-    page.evaluate("window.scrollTo(0, 0)")
-    page.wait_for_timeout(1500)
-    full_text = page.evaluate("document.body.innerText")
-    pathlib.Path("/tmp/share_full.txt").write_text(full_text, encoding="utf-8")
-    print(f"len={len(full_text)}")
-    browser.close()
-```
-
-Use the orch-venv Python (has Playwright + browsers installed): `$HOME/.local/orch-venv/bin/python`. The system `python3` does NOT have Playwright browsers cached and will fail with `Executable doesn't exist at $HOME/Library/Caches/ms-playwright/chromium_headless_shell-1208/...`.
+**Fix:** re-extract with Playwright's scroll-to-bottom pattern, but write the result to a fresh `mktemp -t browserclaw-full-XXXXXX.txt` path, `chmod 600`, and trap-cleanup on EXIT. Use the orch-venv Python (has Playwright + browsers installed): `$HOME/.local/orch-venv/bin/python`. The system `python3` does NOT have Playwright browsers cached and will fail with `Executable doesn't exist at $HOME/Library/Caches/ms-playwright/chromium_headless_shell-1208/...`.
 
 ## Multi-turn conversation recovery (THE FINAL THING)
 
 Gemini share pages render the full back-and-forth between the user and Gemini as `You said` / response pairs. When the user asks "make sure the final thing didn't miss anything I asked," the **last `You said` block** is what they want captured — not any of the intermediate drafts.
 
-Detection recipe:
+Detection recipe (write to a fresh mktemp path, not a fixed /tmp file):
 
 ```bash
-grep -nE "^You said|^REVISED|^Campaign Design|^System:" /tmp/share_full.txt
+TMP_FULL="$(mktemp -t browserclaw-full-XXXXXX.txt)"
+chmod 600 "$TMP_FULL"
+cleanup_browser_share_full() { rm -f "$TMP_FULL"; }
+trap cleanup_browser_share_full EXIT INT TERM
+grep -nE "^You said|^REVISED|^Campaign Design|^System:" "$TMP_FULL"
 ```
 
-This prints every revision boundary. The final content to save is whatever comes **after the last `You said`** block in the file. Preserve intermediate drafts at `/tmp/share_full.txt` for archival; only the final state lands in the user's artifact (wiki, world_reference, etc.).
+This prints every revision boundary. The final content to save is whatever comes **after the last `You said`** block in the file. Preserve intermediate drafts at `$TMP_FULL` for archival; only the final state lands in the user's artifact (wiki, world_reference, etc.). Cleanup runs on EXIT.
 
 ## What this works for (verified or expected to work)
 
@@ -108,8 +71,9 @@ This prints every revision boundary. The final content to save is whatever comes
 ## What this DOES NOT bypass
 
 - **2FA / WebAuthn / passkey-only accounts** — the cookies decrypt, but the session might require re-prompt after N hours idle. Fix: user must have logged in within the cookie's lifetime.
-- **Cloudflare Turnstile / DataDome / fingerprint challenges** — these check JS-side fingerprint, not cookies. Sites that reject headless Chromium's fingerprint (LinkedIn, X/Twitter, Facebook — observed 2026-07-05) will still bounce even with valid session cookies.
+- **Cloudflare Turnstile / DataDome / fingerprint challenges** — these check JS-side fingerprint, not cookies. Sites that reject headless Chromium's fingerprint (LinkedIn, X/Twitter, Facebook — observed 2026-07-05) will still bounce even with valid session cookies. **For fingerprint-sensitive targets, the browser-control skill's Aside-only exception overrides this entire recipe** — post a ONE-LINE display blocker, do not run the lifecycle at all.
 - **MFA-gated Google accounts with no Chrome session** — if the user has never logged into Google in Chrome, there are no cookies to decrypt. Fall back to `gog`/`gws` CLI auth (separate Google OAuth flow) or ask the user to log into Chrome once.
+- **Secret-bearing pages** (API-key creation/rotation, token pages, password/banking/recovery-code pages) — the canonical lifecycle's secret-bearing branch applies: NO `--print-text`, NO screenshots, NO HAR, NO persisted DOM. Use a bare Playwright script that emits only a boolean/status result and persists nothing.
 
 ## Anti-pattern: declaring blocked and asking the user to paste
 
@@ -125,5 +89,6 @@ The failure mode this recipe prevents:
 
 - Parent skill: `~/.hermes/skills/browserclaw/SKILL.md` (cookies decrypt + inject + CDP v20 bypass recipes)
 - Sibling policy: `~/.hermes/skills/browser-headless-default/SKILL.md` (headless-only mandate; this recipe is the canonical "headless + auth" answer)
+- Canonical guarded lifecycle: `~/.claude/commands/browser.md` § **Auth-gated share links** and `~/.claude/skills/browser-control/SKILL.md` § **Authorized credential reuse** — these are authoritative.
 - `~/.claude/skills/google-credentials-fallback/SKILL.md` (fallback to `gog`/`gws` for Google Docs when the user has no Chrome session)
 - SOUL.md `## COMMIT: finish-the-job` — declaring blocked without trying the auth-aware recipe is a finish-the-job violation

--- a/hermes/skills/browserclaw/references/multi-profile-cookie-scan.md
+++ b/hermes/skills/browserclaw/references/multi-profile-cookie-scan.md
@@ -1,4 +1,13 @@
+---
+title: "Multi-profile cookie scan — when the target site isn't in `Default`"
+type: reference
+date: 2026-07-14
+status: HARDENED 2026-08-09 — guarded mktemp lifecycle, no fixed /tmp paths, EXIT-trap cleanup. Background only; the canonical lifecycle is in `~/.claude/commands/browser.md` and `~/.claude/skills/browser-control/SKILL.md`.
+---
+
 # Multi-profile cookie scan — when the target site isn't in `Default`
+
+> **Background reference only.** The canonical guarded lifecycle for /browser is in `~/.claude/commands/browser.md` (the **Auth-gated share links** section) and `~/.claude/skills/browser-control/SKILL.md` (**Authorized credential reuse**). The snippets below MUST NOT override that canonical lifecycle — they document the verified multi-DB sweep pattern.
 
 When `browserclaw cookies decrypt --domain-filter '%target.com%'` returns `Wrote 0 cookies` against `~/Library/Application Support/Google/Chrome/Default/Cookies`, **do not stop**. The user may have the site logged into a different Chrome profile, a different browser (Brave, Aside), or a different default browser entirely. Always sweep all known profiles before concluding "no session exists."
 
@@ -10,7 +19,7 @@ When `browserclaw cookies decrypt --domain-filter '%target.com%'` returns `Wrote
 | Chrome Profile 1 | `~/Library/Application Support/Google/Chrome/Profile 1/Cookies` | `Chrome Safe Storage` | `Chrome` (same — Chrome uses one keychain entry per OS user) |
 | Chrome Profile N | `~/Library/Application Support/Google/Chrome/Profile N/Cookies` | `Chrome Safe Storage` | `Chrome` |
 | Brave | `~/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies` | `Brave Safe Storage` | `Brave` |
-| Edge | `~/Library/Application Support/Edge/Default/Cookies` | `Microsoft Edge Safe Storage` | `Microsoft Edge` |
+| Edge | `~/Library/Application Support/Microsoft Edge/Default/Cookies` | `Microsoft Edge Safe Storage` | `Microsoft Edge` |
 | **Aside (2026-06-27+ default)** | `~/Library/Application Support/Aside/Default/Cookies` | `Aside Safe Storage` | `Aside` |
 | Codex | `~/Library/Application Support/Codex/Default/Cookies` | `Codex Safe Storage` (or similar) | `Codex` |
 
@@ -22,42 +31,87 @@ Don't guess. Before the sweep loop, list what's actually installed:
 ls -d ~/Library/Application\ Support/Google/Chrome/Profile*/Cookies \
        ~/Library/Application\ Support/Google/Chrome/Default/Cookies \
        ~/Library/Application\ Support/BraveSoftware/Brave-Browser/Default/Cookies \
-       ~/Library/Application\ Support/Edge/Default/Cookies \
+       ~/Library/Application\ Support/Microsoft\ Edge/Default/Cookies \
        ~/Library/Application\ Support/Aside/Default/Cookies \
        ~/Library/Application\ Support/Codex/Default/Cookies 2>/dev/null
 ```
 
-## Sweep loop
+## Sweep loop (background — see canonical lifecycle above)
+
+The canonical lifecycle uses `mktemp -t browserclaw-XXXXXX.json`, `chmod 600`, and `trap ... EXIT INT TERM` cleanup. **Do not use fixed `/tmp/<name>-cookies.json` paths** — those leak credentials across processes and survive long after the script exits. The hardened sweep loop is:
 
 ```bash
 TARGET='venmo.com'   # or whatever domain you're hunting
 
-for prof in "Default" "Profile 1" "Profile 2" "Profile 3"; do
-  DB="$HOME/Library/Application Support/Google/Chrome/$prof/Cookies"
-  [ -f "$DB" ] || continue
-  echo "=== $prof ==="
-  env -i HOME="$HOME" \
-    PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
-    browserclaw cookies decrypt --db "$DB" \
-      --output "/tmp/${prof// /}-cookies.json" \
-      --domain-filter "%${TARGET}%" --summary 2>&1 | head -5
-done
+# One mktemp cookie file reused for the entire sweep; deleted before exit.
+set -euo pipefail
+umask 077
+TMP_COOKIES="$(mktemp -t browserclaw-sweep-XXXXXX.json)"
+chmod 600 "$TMP_COOKIES"
+trap 'rm -f "$TMP_COOKIES"' EXIT INT TERM HUP
 
-# Non-Chrome browsers
-for entry in \
-  "Aside:$HOME/Library/Application Support/Aside/Default/Cookies:Aside Safe Storage:Aside" \
-  "Brave:$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies:Brave Safe Storage:Brave" \
-  "Edge:$HOME/Library/Application Support/Edge/Default/Cookies:Microsoft Edge Safe Storage:Microsoft Edge"; do
-  IFS=: read name db svc acct <<< "$entry"
-  [ -f "$db" ] || continue
-  echo "=== $name ==="
+# Iterate every Chromium-style profile you might have. Aside is
+# listed first because its signed-in session is the operator's
+# most common source of cookies. Each entry expands to
+# `<label>:<db-path>:<keychain-service>:<keychain-account>`.
+# use. The matching profile is logged for traceability.
+# The helper writes a fresh mktemp summary file (never a fixed /tmp
+# path), reads a non-empty summary via `jq -e` (set -e / pipefail
+# safe), and removes the summary in the same call before returning.
+# Bash $RANDOM is the seed that makes the summary unique so a
+# concurrent sweep on the same host cannot collide.
+match_profile() {
+  local label="$1" db="$2" svc="$3" acct="$4"
+  [ -f "$db" ] || return 0
+  local summary_file
+  summary_file="$(mktemp -t browserclaw-sweep-sum-XXXXXX.txt)"
+  chmod 600 "$summary_file"
   env -i HOME="$HOME" \
     PATH="$HOME/.local/orch-venv/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
     browserclaw cookies decrypt --db "$db" \
-      --output "/tmp/${name}-cookies.json" \
-      --keychain-service "$svc" --keychain-account "$acct" \
-      --domain-filter "%${TARGET}%" --summary 2>&1 | head -5
+      --output "$TMP_COOKIES" \
+      ${svc:+--keychain-service "$svc"} ${acct:+--keychain-account "$acct"} \
+      --domain-filter "%${TARGET}%" --summary >"$summary_file" 2>&1 || true
+  local count=0
+  if [ -s "$TMP_COOKIES" ]; then
+    count="$(jq -r '.cookies | length' "$TMP_COOKIES" 2>/dev/null || echo 0)"
+  fi
+  if [ "$count" -gt 0 ]; then
+    echo "MATCH: $label (${count} cookies) — stopping sweep"
+    rm -f "$summary_file"
+    return 1
+  fi
+  echo "=== $label === Wrote 0 cookies"
+  # Explicit summary reads (not `| head -5`) — pipefail-unsafe
+  # pipelines were the round-3 finding here.
+  if [ -s "$summary_file" ]; then
+    head -n 5 "$summary_file"
+  fi
+  rm -f "$summary_file"
+  return 0
+}
+
+# Chrome profiles — sweep in the order Aside-first then Chrome
+# Default, Profile 1, Profile 2, Profile 3. Aside is a real launchd
+# daemon and is the primary signed-in browser per the browser-control
+# skill, so it goes first.
+for entry in \
+  "Aside:$HOME/Library/Application Support/Aside/Default/Cookies:Aside Safe Storage:Aside" \
+  "Chrome-Default:$HOME/Library/Application Support/Google/Chrome/Default/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile1:$HOME/Library/Application Support/Google/Chrome/Profile 1/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile2:$HOME/Library/Application Support/Google/Chrome/Profile 2/Cookies:Chrome Safe Storage:Chrome" \
+  "Chrome-Profile3:$HOME/Library/Application Support/Google/Chrome/Profile 3/Cookies:Chrome Safe Storage:Chrome" \
+  "Brave:$HOME/Library/Application Support/BraveSoftware/Brave-Browser/Default/Cookies:Brave Safe Storage:Brave" \
+  "Edge:$HOME/Library/Application Support/Microsoft Edge/Default/Cookies:Microsoft Edge Safe Storage:Microsoft Edge"; do
+  IFS=: read label db svc acct <<< "$entry"
+  if ! match_profile "$label" "$db" "$svc" "$acct"; then
+    break
+  fi
 done
+
+# Cleanup runs on both success and failure (set -euo pipefail + EXIT trap).
+cleanup_sweep
+trap - EXIT INT TERM HUP
 ```
 
 **If ALL return `Wrote 0 cookies`:**
@@ -84,8 +138,11 @@ If the search finds the data, fetch and parse:
 gog gmail search "from:venmo.com subject:transaction history" --max 10
 # Get full message body for a specific ID
 gog gmail thread <thread_id> --select body
-# Or download the attachment if it's a CSV
-gog gmail attachment <msg_id> --output /tmp/venmo.csv
+# Or download the attachment if it's a CSV (use a guarded mktemp path, not a fixed /tmp path).
+VENMO_ATTACH="$(mktemp -t venmo-attach-XXXXXX.csv)"
+chmod 600 "$VENMO_ATTACH"
+gog gmail attachment <msg_id> --output "$VENMO_ATTACH"
+trap 'rm -f "$VENMO_ATTACH"' EXIT INT TERM
 ```
 
 The right order is:
@@ -122,6 +179,7 @@ Gmail sweep:
 
 ## Cross-references
 
+- Canonical guarded lifecycle: `~/.claude/commands/browser.md` § **Auth-gated share links** and `~/.claude/skills/browser-control/SKILL.md` § **Authorized credential reuse** — these are authoritative.
 - browserclaw SKILL.md "Edge cases / failure modes" — has the single-profile case; this file extends it for multi-profile
 - browserclaw SKILL.md "Poll-until-cookies-appear pattern" — what to do AFTER finding a profile with 0 cookies: register a 5-min poll cron
 - SOUL.md `## COMMIT: bashrc-profile-xapp-drift-blocks-launchd` — env -i wrapper rationale

--- a/tests/test_browser_command_contract.py
+++ b/tests/test_browser_command_contract.py
@@ -257,6 +257,20 @@ class BrowserCommandContractTest(_BrowserFilesBase):
         assert '--screenshot' not in self.cmd_text, (
             "auth-gated private-content recipe must not persist screenshots by default"
         )
+        # Round-7 reviewer-required test: the canonical recipe in
+        # browser.md MUST NOT contain a `trap -` disarm line. The
+        # round-6 reviewer flagged that a disarm at the end of the
+        # recipe orphans the credential file if a signal arrives
+        # between the last cookie write and script exit.
+        canonical_block = self.cmd_text.split(
+            "## Auth-gated share links", 1)[1].split(
+            "## ", 1)[0]
+        assert "trap -" not in canonical_block, (
+            "browser.md canonical recipe must NOT disarm its trap; "
+            "the EXIT trap must stay armed until the script exits. "
+            "`rm -f` is idempotent so a normal exit firing the trap "
+            "is the same as an explicit cleanup call."
+        )
 
     def test_auth_gated_flow_preserves_global_routing_order(self) -> None:
         section = self.cmd_text.split("## Auth-gated share links", 1)[1]
@@ -464,8 +478,7 @@ class BrowserSkillContractTest(_BrowserFilesBase):
         cleanup + signal-handler traps, and never disarm them.
         """
         assert "set -euo pipefail" in self.skill_text, (
-            "browser-control/SKILL.md must declare `set -euo pipefail` so the "
-            "credential lifecycle fails closed on any nonzero exit"
+            "browser-control/SKILL.md must use 'set -euo pipefail'"
         )
         assert "exit_on_signal" in self.skill_text, (
             "browser-control/SKILL.md must install exit_on_signal "
@@ -482,6 +495,22 @@ class BrowserSkillContractTest(_BrowserFilesBase):
         )
         assert "trap cleanup_browser_creds EXIT" in self.skill_text, (
             "browser-control/SKILL.md must trap EXIT to cleanup_browser_creds"
+        )
+        # Round-7 reviewer-required test: the canonical recipe MUST
+        # NOT contain a `trap -` disarm line at the end. The EXIT
+        # trap is the cleanup; arming it once at the top of the
+        # recipe and never disarming it is the fail-closed contract.
+        # A `trap -` line at the end would mean a signal arriving
+        # between the last cookie write and the script exit could
+        # orphan the credential file (round-6 reviewer flag).
+        canonical_block = self.skill_text.split(
+            "## Authorized credential reuse", 1)[1].split(
+            "## Fingerprint-sensitive", 1)[0]
+        assert "trap -" not in canonical_block, (
+            "browser-control/SKILL.md canonical recipe must NOT disarm "
+            "its trap; the EXIT trap must stay armed until the script "
+            "exits. `rm -f` is idempotent so a normal exit firing the "
+            "trap is the same as an explicit cleanup call."
         )
 
     def test_no_screenshot_in_any_documented_bash_block(self) -> None:

--- a/tests/test_browser_command_contract.py
+++ b/tests/test_browser_command_contract.py
@@ -1,0 +1,1185 @@
+"""Contract tests for the /browser command and the browser-control skill.
+
+The /browser command and `.claude/skills/browser-control/SKILL.md` together
+implement the routing-order contract:
+
+1. Aside-MCP first (when the active runtime exposes it).
+2. Aside CLI (`aside repl` / `aside "<prompt>"`) — drives the already-running
+   Aside.app profile.
+3. `browserclaw cookies decrypt + inject` for headless auth on sites where
+   the user is already authenticated. Re-decrypt from the local Chromium
+   profile (Aside → Chrome Default → Profile 1 → Profile 2 → Brave → Edge).
+4. Playwright headless for unauthenticated / deterministic flows.
+5. Visible/headed browser only when the user explicitly asks for it.
+
+These tests protect against:
+
+- Regression of the old "never copy cookies between browser profiles" line
+  in the live-browser workflow that contradicted the documented
+  browserclaw cookie-inject fallback.
+- A reordering of the routing priorities (e.g. promoting Playwright above
+  Aside, or dropping the Aside-MCP preference).
+- Browserclaw HAR-based capture being reintroduced on credential flows
+  (the `capture`/`learn`/`reverse` ban).
+- Loss of the fingerprint-sensitive outlier exception (LinkedIn / banks /
+  Cloudflare-protected sites that bind cookies to the running browser).
+- Loss of the explicit credential-reuse safeguards (private /tmp only,
+  --summary, never commit, never log values).
+- Loss of the clean-the-cookie-JSON-after-use step.
+- Reintroducing fixed `/tmp/<x>.json` paths in the referenced recipes that
+  leak credentials across processes.
+- Allowing fingerprint-sensitive sites (LinkedIn, banks, Cloudflare) to
+  fall through to cookie injection on a headless host.
+- Reintroducing `--print-text`, screenshots, or HARs on secret-bearing
+  pages (API keys, tokens, banking, recovery codes).
+- Loss of the fail-closed shell lifecycle (`set -euo pipefail`, EXIT
+  trap on both success and failure, nonzero exit preserved on cleanup).
+
+The tests are file/contract-only: they do NOT run any real cookie
+decrypt/inject, do NOT touch `~/.claude`, and do NOT make network calls.
+The actual browser path is exercised by the parent Hermes session.
+
+A shell-lifecycle simulation is run as a subprocess to prove the
+cleanup-on-failure + nonzero-exit-preserved contract locally without
+touching any real cookie state.
+"""
+
+
+import os
+import re
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BROWSER_CMD = REPO_ROOT / ".claude" / "commands" / "browser.md"
+BROWSER_SKILL = REPO_ROOT / ".claude" / "skills" / "browser-control" / "SKILL.md"
+ASIDE_SKILL = REPO_ROOT / "hermes" / "skills" / "aside-browser-default" / "SKILL.md"
+GEMINI_REF = REPO_ROOT / "hermes" / "skills" / "browserclaw" / "references" / "gemini-share-link-as-user.md"
+MULTI_REF = REPO_ROOT / "hermes" / "skills" / "browserclaw" / "references" / "multi-profile-cookie-scan.md"
+
+# Ordered route priorities — the test enforces this order in the
+# numbered "Routing order" sections of both files.
+EXPECTED_ROUTE_ORDER = [
+    ("aside-mcp", "Aside-MCP must be the first routing priority"),
+    ("aside-repl", "Aside CLI must be the second routing priority"),
+    ("browserclaw", "browserclaw must be the third routing priority"),
+    ("playwright-headless", "Playwright headless must be the fourth routing priority"),
+    ("visible-headed", "visible/headed must be the last routing priority"),
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_any_match(text: str, patterns: list[tuple[str, str]]) -> list[str]:
+    """Return the list of messages for patterns that did NOT match."""
+    missing = []
+    for pattern, message in patterns:
+        if not re.search(pattern, text, re.IGNORECASE | re.DOTALL):
+            missing.append(message)
+    return missing
+
+
+def assert_none_match(text: str, patterns: list[tuple[str, str]]) -> list[str]:
+    """Return the list of messages for patterns that DID match (should be disallowed)."""
+    found = []
+    for pattern, message in patterns:
+        if re.search(pattern, text, re.IGNORECASE | re.DOTALL):
+            found.append(message)
+    return found
+
+
+def first_index(text: str, pattern: str) -> int:
+    """Return the integer index of the first match, or -1 if not found."""
+    m = re.search(pattern, text, re.IGNORECASE | re.DOTALL)
+    return m.start() if m else -1
+
+
+def parse_numbered_route_order(text: str) -> list[tuple[int, int, str]]:
+    """Parse the numbered 'Routing order' section: returns list of
+    (line_number, route_index, route_text) for every numbered route entry
+    starting with `<n>. **<RouteName>**`. The returned list is sorted by
+    line_number so the relative ordering is preserved.
+    """
+    entries = []
+    for m in re.finditer(r"^(\d+)\.\s+\*\*([^*]+)\*\*", text, re.MULTILINE):
+        entries.append((m.start(), int(m.group(1)), m.group(2).strip()))
+    return entries
+
+
+def route_label_signature(label: str) -> str:
+    """Map a numbered-route bold label into one of EXPECTED_ROUTE_ORDER's
+    signature strings. Returns the signature, or '' if no match.
+    """
+    norm = label.lower()
+    if "aside-mcp" in norm or re.search(r"\baside\s*mcp\b", norm):
+        return "aside-mcp"
+    if "aside cli" in norm or "aside repl" in norm:
+        return "aside-repl"
+    if "browserclaw" in norm:
+        return "browserclaw"
+    if "playwright" in norm and "headless" in norm:
+        return "playwright-headless"
+    if "visible" in norm or "headed" in norm:
+        return "visible-headed"
+    return ""
+
+
+# Anchored phrases that MUST appear in the command file. Running these as
+# regex via `re.search` lets the contract tolerate whitespace/line-wrap
+# tweaks without silently missing a forced structure.
+CMD_ROUTING_PATTERNS = [
+    (r"Aside-MCP|aside\s*mcp", "Aside-MCP must be first routing priority"),
+    (r"aside\s+repl|aside\s+account\s+list", "Aside CLI surface must be referenced"),
+    (r"browserclaw\s+cookies\s+decrypt", "browserclaw decrypt must be named"),
+    (r"browserclaw\s+cookies\s+inject", "browserclaw inject must be named"),
+    (r"--browser-channel\s+chromium", "chromium channel must be set (not chrome)"),
+    (r"--headless", "headless mode must be set"),
+    (r"--summary", "--summary flag must be set for non-credential cookies"),
+    (r"Playwright\s+headless", "Playwright headless fallback must be named"),
+    (r"visible|headed", "visible/headed exception must be explicit"),
+    (r"profile|Profile\s+1", "profile sweep must be named"),
+    (r"capture\s*/\s*learn\s*/\s*reverse|capture.*learn.*reverse", "HAR-based capture ban must be stated"),
+    (r"mktemp|/tmp/", "private /tmp cookie JSON must be required"),
+    (r"rm\s+-f|rm\s+TMP_COOKIES", "cookie JSON cleanup step must be present"),
+    (r"never\s+commit|no\s+commit", "commit ban must be stated"),
+    (r"never\s+log|do\s+not\s+log", "no-log-values safeguard must be stated"),
+    (r"LinkedIn", "LinkedIn fingerprint-sensitive exception must be named"),
+    (r"banks?|brokerage", "banks/brokerage outlier must be named"),
+    (r"playwright-ui-testing|Playwright(?=.*fixture|\s+UI\s+testing|deterministic)", "deterministic UI testing must route to playwright-ui-testing"),
+]
+
+SKILL_ROUTING_PATTERNS = [
+    (r"Aside-MCP|aside-mcp", "Aside-MCP must be listed as the primary tool"),
+    (r"aside\s+repl|aside\s+account\s+list", "Aside CLI must be referenced"),
+    (r"browserclaw\s+cookies\s+decrypt", "browserclaw decrypt must be named"),
+    (r"browserclaw\s+cookies\s+inject", "browserclaw inject must be named"),
+    (r"--browser-channel\s+chromium", "chromium channel must be set"),
+    (r"--headless", "headless mode must be set"),
+    (r"--summary", "--summary flag must be set"),
+    (r"Playwright\s+headless", "Playwright headless fallback must be named"),
+    (r"profile|Profile\s+1", "profile sweep must be named"),
+    (r"capture\s*/\s*learn\s*/\s*reverse|capture.*learn.*reverse", "HAR-based capture ban must be stated"),
+    (r"never\s+commit|no\s+commit", "commit ban must be stated"),
+    (r"never\s+log|do\s+not\s+log", "no-log-values safeguard must be stated"),
+    (r"LinkedIn", "LinkedIn fingerprint-sensitive exception must be named"),
+    (r"banks?|brokerage", "banks/brokerage outlier must be named"),
+    (r"Cloudflare|Akamai", "Cloudflare/Akamai bot-mitigation must be named"),
+    (r"chmod\s+600|mode\s+600|private\s+/tmp", "private /tmp cookie JSON must be required"),
+    (r"rm\s+-f", "cookie JSON cleanup step must be present"),
+    (r"playwright-ui-testing", "deterministic UI testing must route to playwright-ui-testing"),
+]
+
+# Phrases that MUST NOT appear in the live-browser workflow now that the
+# contradiction has been resolved. The contradiction was the old "never copy
+# cookies between browser profiles" line that contradicted the documented
+# browserclaw cookie-inject fallback.
+DISALLOWED_PHRASES = [
+    (r"never.*copy\s+cookies\s+between\s+profiles", "old 'never copy cookies between profiles' ban contradicts the browserclaw fallback"),
+    (r"do\s+not\s+copy\s+cookies", "old 'do not copy cookies' ban contradicts the browserclaw fallback"),
+]
+
+# Fixed /tmp path patterns that MUST NOT appear in the canonical lifecycle
+# or in the hardened references. These are the unsafe patterns from
+# round-1/round-2 review.
+UNSAFE_FIXED_TMP_PATHS = [
+    (r"/tmp/google-cookies\.json", "fixed /tmp/google-cookies.json leaks across processes"),
+    (r"/tmp/share_page\.txt", "fixed /tmp/share_page.txt leaks across processes"),
+    (r"/tmp/share_full\.txt", "fixed /tmp/share_full.txt leaks across processes"),
+    (r"/tmp/share_authed\.png", "fixed /tmp/share_authed.png leaks screenshots"),
+    (r"/tmp/\$\{prof// /}-cookies\.json", "fixed per-profile /tmp/-cookies.json leaks across processes"),
+    (r'/tmp/\${name}-cookies\.json', "fixed per-browser /tmp/-cookies.json leaks across processes"),
+    (r"/tmp/venmo\.csv", "fixed /tmp/venmo.csv leaks downloaded attachments"),
+]
+
+
+class _BrowserFilesBase(unittest.TestCase):
+    """Define `cmd_text` and `skill_text` in concrete subclasses."""
+
+    cmd_text: str = ""
+    skill_text: str = ""
+
+
+class BrowserCommandContractTest(_BrowserFilesBase):
+    """The /browser command is concise but MUST encode the routing order inline."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        assert BROWSER_CMD.is_file(), f"browser.md missing at {BROWSER_CMD}"
+        cls.cmd_text = read(BROWSER_CMD)
+
+    def test_routing_order_anchors_present(self) -> None:
+        missing = assert_any_match(self.cmd_text, CMD_ROUTING_PATTERNS)
+        assert not missing, (
+            "browser.md is missing required routing-order anchors:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    def test_routing_order_lists_aside_mcp_first(self) -> None:
+        # The Aside-MCP preference must come BEFORE the Aside CLI mention in
+        # the routing order, not after.
+        first_aside_mcp = first_index(self.cmd_text, r"aside-mcp|aside\s*mcp|Aside-MCP")
+        first_aside_cli = first_index(self.cmd_text, r"aside\s+repl|aside\s+account\s+list")
+        assert first_aside_mcp >= 0, "Aside-MCP must be referenced in the command"
+        assert first_aside_cli >= 0, "Aside CLI must be referenced in the command"
+        assert first_aside_mcp < first_aside_cli, (
+            "Aside-MCP must appear before the Aside CLI mention so the routing "
+            "order is unambiguous"
+        )
+
+    def test_routing_order_lists_browserclaw_before_playwright_fallback(self) -> None:
+        first_browserclaw = first_index(self.cmd_text, r"browserclaw")
+        first_playwright = first_index(self.cmd_text, r"Playwright\s+headless")
+        assert first_browserclaw >= 0, "browserclaw must be referenced"
+        assert first_playwright >= 0, "Playwright headless fallback must be referenced"
+        assert first_browserclaw < first_playwright, (
+            "browserclaw must be a higher-priority fallback than Playwright headless"
+        )
+
+    def test_credential_reuse_safeguards_present(self) -> None:
+        for kw in (
+            "--summary", "TMP_COOKIES", "TMP_PAGE", "chmod 600",
+            "umask 077", "cleanup_browser_share", "exit_on_signal",
+            "trap 'exit_on_signal INT' INT",
+            "trap 'exit_on_signal TERM' TERM",
+            "trap 'exit_on_signal HUP' HUP",
+            "trap cleanup_browser_share EXIT",
+            "never", "/tmp",
+        ):
+            assert kw in self.cmd_text, (
+                f"credential-reuse safeguard missing from browser.md: {kw!r}"
+            )
+        assert '--screenshot' not in self.cmd_text, (
+            "auth-gated private-content recipe must not persist screenshots by default"
+        )
+
+    def test_auth_gated_flow_preserves_global_routing_order(self) -> None:
+        section = self.cmd_text.split("## Auth-gated share links", 1)[1]
+        aside_mcp = first_index(section, r"Aside.*MCP|MCP.*Aside")
+        aside_cli = first_index(section, r"Aside CLI")
+        browserclaw = first_index(section, r"browserclaw")
+        assert 0 <= aside_mcp < aside_cli < browserclaw, (
+            "auth-gated flow must try Aside MCP, then Aside CLI, before browserclaw"
+        )
+        assert "fingerprint-sensitive Aside-only exception" in section
+        assert "overrides this fallback" in section
+
+    def test_auth_recipe_is_canonical_not_delegated_to_unsafe_reference(self) -> None:
+        section = self.cmd_text.split("## Auth-gated share links", 1)[1]
+        assert "safe recipe below is canonical" in section
+        assert "must not override this guarded lifecycle" in section
+        assert "fixed-path sweep snippets" in section
+        # The canonical recipe MUST embed the multi-profile sweep
+        # inline so it does not depend on operator-executed snippets.
+        assert "Multi-profile sweep" in section
+        assert '/tmp/share_full.txt' not in self.cmd_text
+        # The sweep MUST re-apply chmod 600 after a successful
+        # browserclaw write — same rationale as the skill-side test.
+        assert 'chmod 600 "$TMP_COOKIES"' in section, (
+            "browser.md auth-gated recipe must re-apply chmod 600 "
+            "after a successful sweep decrypt"
+        )
+
+    def test_no_legacy_fixed_path_used_in_auth_gated_section(self) -> None:
+        section = self.cmd_text.split("## Auth-gated share links", 1)[1]
+        assert '/tmp/share_full.txt' not in self.cmd_text
+
+    def test_referenced_browserclaw_recipes_exist_in_repo(self) -> None:
+        recipes = REPO_ROOT / "hermes" / "skills" / "browserclaw" / "references"
+        for name in ("multi-profile-cookie-scan.md", "gemini-share-link-as-user.md"):
+            assert (recipes / name).is_file(), f"browserclaw recipe missing: {recipes / name}"
+
+    def test_no_disallowed_phrases(self) -> None:
+        found = assert_none_match(self.cmd_text, DISALLOWED_PHRASES)
+        assert not found, (
+            "browser.md contains disallowed phrases:\n"
+            + "\n".join(f"  - {m}" for m in found)
+        )
+
+    def test_no_screenshot_in_any_documented_bash_block(self) -> None:
+        # Round-6 reviewer-required test: every documented bash
+        # block in browser.md MUST not contain an active
+        # --screenshot invocation. The earlier test only covered
+        # the first generic block.
+        blocks = re.findall(r"```bash\n(.*?)\n```", self.cmd_text, re.DOTALL)
+        self.assertGreater(len(blocks), 0, (
+            "browser.md must contain at least one documented bash block"
+        ))
+        for i, block in enumerate(blocks):
+            active = [
+                line for line in block.splitlines()
+                if not line.lstrip().startswith("#")
+                and ("--screenshot" in line or "--capture-har" in line)
+            ]
+            self.assertEqual(active, [], (
+                f"browser.md bash block #{i} must not contain an active "
+                f"--screenshot or --capture-har invocation; "
+                f"found: {active!r}"
+            ))
+
+    def test_command_references_skill(self) -> None:
+        # The command must still delegate to the full skill, but the inline
+        # routing order is the primary contract.
+        assert "browser-control/SKILL.md" in self.cmd_text
+        assert "playwright-ui-testing" in self.cmd_text
+        # The command must NOT carry absolute installed-skill
+        # paths like `~/.claude/skills/...`; use normal skill
+        # discovery instead.
+        assert "~/.claude/skills/" not in self.cmd_text, (
+            "browser.md must use normal skill discovery, not "
+            "absolute ~/.claude/skills/... paths"
+        )
+
+
+class BrowserSkillContractTest(_BrowserFilesBase):
+    """The browser-control skill MUST encode the same routing order verbatim."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        assert BROWSER_SKILL.is_file(), f"browser-control SKILL.md missing at {BROWSER_SKILL}"
+        cls.skill_text = read(BROWSER_SKILL)
+
+    def test_routing_order_anchors_present(self) -> None:
+        missing = assert_any_match(self.skill_text, SKILL_ROUTING_PATTERNS)
+        assert not missing, (
+            "browser-control/SKILL.md is missing required routing-order anchors:\n"
+            + "\n".join(f"  - {m}" for m in missing)
+        )
+
+    def test_routing_order_lists_aside_mcp_first(self) -> None:
+        first_aside_mcp = first_index(self.skill_text, r"aside-mcp|aside\s*mcp|Aside-MCP")
+        first_aside_cli = first_index(self.skill_text, r"aside\s+repl|aside\s+account\s+list")
+        assert first_aside_mcp >= 0, "Aside-MCP must be referenced in the skill"
+        assert first_aside_cli >= 0, "Aside CLI must be referenced in the skill"
+        assert first_aside_mcp < first_aside_cli, (
+            "Aside-MCP must appear before the Aside CLI mention in the skill"
+        )
+
+    def test_routing_order_lists_browserclaw_before_playwright_fallback(self) -> None:
+        first_browserclaw = first_index(self.skill_text, r"browserclaw")
+        first_playwright = first_index(self.skill_text, r"Playwright\s+headless")
+        assert first_browserclaw >= 0, "browserclaw must be referenced"
+        assert first_playwright >= 0, "Playwright headless fallback must be referenced"
+        assert first_browserclaw < first_playwright, (
+            "browserclaw must be a higher-priority fallback than Playwright headless"
+        )
+
+    def test_credential_reuse_safeguards_present(self) -> None:
+        for kw in (
+            "--summary", "TMP_COOKIES", "TMP_PAGE", "chmod 600",
+            "umask 077", "cleanup_browser_creds", "exit_on_signal",
+            "trap 'exit_on_signal INT' INT",
+            "trap 'exit_on_signal TERM' TERM",
+            "trap 'exit_on_signal HUP' HUP",
+            "trap cleanup_browser_creds EXIT",
+            "never",
+        ):
+            assert kw in self.skill_text, (
+                f"credential-reuse safeguard missing from skill: {kw!r}"
+            )
+        section = self.skill_text.split("## Authorized credential reuse", 1)[1].split("## Fingerprint-sensitive", 1)[0]
+        shell_block = section.split("```bash", 1)[1].split("```", 1)[0]
+        assert '--screenshot' not in shell_block
+
+    def test_secret_branch_cleans_up_cookies_and_emits_to_stdout(self) -> None:
+        section = self.skill_text.split("**Secret-bearing page branch:**", 1)[1].split("**Safeguards**", 1)[0]
+        assert "set -euo pipefail" in section, (
+            "secret branch must be fail-closed (set -euo pipefail)"
+        )
+        # The secret branch is self-contained: it runs the canonical
+        # multi-profile sweep itself to obtain $TMP_COOKIES, then runs
+        # a bare Playwright script. The sweep is what makes the branch
+        # executable end-to-end (without it the branch read an empty
+        # mktemp file and never produced a cookie artifact).
+        assert "Multi-profile sweep" in section or "multi-profile sweep" in section, (
+            "secret branch must run the multi-profile sweep to obtain cookies"
+        )
+        assert 'TMP_COOKIES="$(mktemp' in section, (
+            "secret branch must define its own $TMP_COOKIES"
+        )
+        assert 'TMP_PAGE="$(mktemp' in section, (
+            "secret branch must define its own $TMP_PAGE"
+        )
+        assert "sys.stdout.write" in section, (
+            "secret branch must emit the boolean to stdout, not a temp file"
+        )
+        # The secret branch must not actively PERSIST the boolean
+        # result to disk — but it may reference `write_text` /
+        # `Path.write_text` in a comment that explains why
+        # `chmod 600` is reapplied (browserclaw's writer uses
+        # Path.write_text and honors the umask). Allow the
+        # comment, but ban a bare call.
+        bare_write_text_calls = [
+            line for line in section.splitlines()
+            if not line.lstrip().startswith("#")
+            and ".write_text(" in line
+        ]
+        assert bare_write_text_calls == [], (
+            f"secret branch must not call .write_text() to persist the "
+            f"boolean result; found: {bare_write_text_calls!r}"
+        )
+        # Fail-closed contract: the trap stays armed across every
+        # signal — INT/TERM/HUP each have their own trap that calls
+        # cleanup then re-raises the signal so the script exits
+        # nonzero. No disarm line anywhere.
+        assert "trap -" not in section, (
+            "secret branch must NOT disarm its trap; the trap must "
+            "stay armed for the lifetime of the branch"
+        )
+        assert "exit_on_signal" in section, (
+            "secret branch must re-raise the signal so it exits nonzero"
+        )
+
+    def test_every_decrypt_output_uses_guarded_cookie_variable(self) -> None:
+        section = self.skill_text.split("## Authorized credential reuse", 1)[1].split("## Fingerprint-sensitive", 1)[0]
+        # The canonical recipe now contains TWO browserclaw decrypt
+        # invocations: the initial Chrome Default decrypt + a multi-
+        # profile sweep. Both must use the same guarded $TMP_COOKIES
+        # variable, never a fresh mktemp inside the invocation.
+        decrypt_blocks = section.split("browserclaw cookies decrypt")[1:]
+        assert len(decrypt_blocks) >= 1, "credential recipe should have at least one decrypt invocation"
+        for block in decrypt_blocks:
+            assert '--output "$TMP_COOKIES"' in block, (
+                "every browserclaw cookies decrypt invocation must use "
+                "$TMP_COOKIES, not a fresh mktemp"
+            )
+            assert '--output "$(mktemp' not in block
+        # The sweep MUST re-apply chmod 600 after a successful
+        # browserclaw write — the browserclaw writer uses
+        # Path.write_text() which honors the process umask, so a
+        # permissive umask could leave the cookie file world-
+        # readable. The trap removes the file on any later failure.
+        assert "chmod 600 \"$TMP_COOKIES\"" in section, (
+            "credential recipe must re-apply chmod 600 after a "
+            "successful sweep decrypt"
+        )
+
+    def test_fail_closed_lifecycle_present(self) -> None:
+        """The shell lifecycle must use `set -euo pipefail`, install
+        cleanup + signal-handler traps, and never disarm them.
+        """
+        assert "set -euo pipefail" in self.skill_text, (
+            "browser-control/SKILL.md must declare `set -euo pipefail` so the "
+            "credential lifecycle fails closed on any nonzero exit"
+        )
+        assert "exit_on_signal" in self.skill_text, (
+            "browser-control/SKILL.md must install exit_on_signal "
+            "handlers for INT/TERM/HUP so the script exits nonzero"
+        )
+        assert "trap 'exit_on_signal INT' INT" in self.skill_text, (
+            "browser-control/SKILL.md must trap INT to exit_on_signal"
+        )
+        assert "trap 'exit_on_signal TERM' TERM" in self.skill_text, (
+            "browser-control/SKILL.md must trap TERM to exit_on_signal"
+        )
+        assert "trap 'exit_on_signal HUP' HUP" in self.skill_text, (
+            "browser-control/SKILL.md must trap HUP to exit_on_signal"
+        )
+        assert "trap cleanup_browser_creds EXIT" in self.skill_text, (
+            "browser-control/SKILL.md must trap EXIT to cleanup_browser_creds"
+        )
+
+    def test_no_screenshot_in_any_documented_bash_block(self) -> None:
+        # Round-6 reviewer-required test: every documented bash
+        # block in browser-control/SKILL.md MUST not contain an
+        # active --screenshot invocation.
+        blocks = re.findall(r"```bash\n(.*?)\n```", self.skill_text, re.DOTALL)
+        self.assertGreater(len(blocks), 0, (
+            "browser-control/SKILL.md must contain at least one documented bash block"
+        ))
+        for i, block in enumerate(blocks):
+            active = [
+                line for line in block.splitlines()
+                if not line.lstrip().startswith("#")
+                and ("--screenshot" in line or "--capture-har" in line)
+            ]
+            self.assertEqual(active, [], (
+                f"browser-control/SKILL.md bash block #{i} must not contain "
+                f"an active --screenshot or --capture-har invocation; "
+                f"found: {active!r}"
+            ))
+
+    def test_secret_page_branch_bans_generic_persistence(self) -> None:
+        section = self.skill_text.split("**Secret-bearing page branch:**", 1)[1].split("**Safeguards**", 1)[0]
+        assert "MUST NOT execute the generic `--print-text` recipe" in section
+        assert "persist neither DOM text nor images" in section
+        assert "minimum safe non-secret DOM state in memory" in section
+        # The secret-bearing branch MUST be fail-closed and emit to stdout.
+        assert "set -euo pipefail" in section, (
+            "secret-bearing page branch must be fail-closed (`set -euo pipefail`)"
+        )
+        assert "sys.stdout.write" in section, (
+            "secret-bearing page branch must emit the boolean to stdout"
+        )
+
+    def test_headless_fallback_is_subordinate_to_fingerprint_exception(self) -> None:
+        assert "The fingerprint-sensitive Aside-only exception below overrides this fallback" in self.skill_text
+        gotchas = self.skill_text.split("## Environment gotchas", 1)[1]
+        assert "fingerprint-sensitive Aside-only exception overrides this rule" in gotchas
+        assert "never attempt cookie injection" in gotchas
+        assert "browserclaw capture" in gotchas
+        # The escape hatch must be marked as narrow / not a substitute.
+        assert re.search(r"NARROW|narrow", gotchas), (
+            "browser-control/SKILL.md must mark the browserclaw capture escape "
+            "hatch as NARROW / narrow, not as the headless fallback"
+        )
+
+    def test_no_disallowed_phrases(self) -> None:
+        found = assert_none_match(self.skill_text, DISALLOWED_PHRASES)
+        assert not found, (
+            "browser-control/SKILL.md contains disallowed phrases:\n"
+            + "\n".join(f"  - {m}" for m in found)
+        )
+
+    def test_no_har_for_credential_flows(self) -> None:
+        """The browserclaw capture/learn/reverse subcommands must be explicitly
+        banned for credential-bearing flows. Match on a multi-token phrase in
+        any order so a future re-wording that keeps one of the three tokens
+        alone doesn't silently pass."""
+        har_ban_pattern = re.compile(
+            r"(?:capture|learn|reverse).{0,80}(?:capture|learn|reverse).{0,80}(?:capture|learn|reverse)",
+            re.IGNORECASE | re.DOTALL,
+        )
+        assert har_ban_pattern.search(self.skill_text), (
+            "browser-control/SKILL.md must explicitly ban browserclaw capture/learn/reverse "
+            "for credential flows (mention all three together)"
+        )
+
+    def test_no_har_negation_in_credential_context(self) -> None:
+        """The HAR ban must be in a credential-bearing context, not a generic
+        statement. Negated phrasing must be near credential/secret/banking
+        tokens so a future reword that drops the negation still gets caught
+        by the keyword test."""
+        for kw in ("secret", "credential", "banking", "API key", "token"):
+            assert kw.lower() in self.skill_text.lower(), (
+                f"credential-bearing context token missing from skill: {kw!r}"
+            )
+
+    def test_fingerprint_sensitive_outlier_named(self) -> None:
+        """The exception list (LinkedIn / banks / Cloudflare) must be present
+        so the drop-the-cookie-copy-out rule is not retroactively removed."""
+        for kw in ("LinkedIn", "Cloudflare"):
+            assert kw in self.skill_text, (
+                f"fingerprint-sensitive outlier missing from skill: {kw!r}"
+            )
+
+    def test_authorized_credential_reuse_section_present(self) -> None:
+        """The new 'Authorized credential reuse' section must be present so
+        the previous contradiction is moved to a clean, explicit contract."""
+        assert "Authorized credential reuse" in self.skill_text, (
+            "browser-control/SKILL.md must carry an explicit 'Authorized credential reuse' section"
+        )
+
+    def test_route_task_summary_defines_success(self) -> None:
+        """The 'Route the task' summary must define what it means for a route
+        to succeed — authenticated task completion, not a single transport
+        call. This blocks the round-1 contradiction where a single tab error
+        was treated as a successful fallback."""
+        section = self.skill_text.split("## Route the task", 1)[1].split("## Routing order", 1)[0]
+        assert "authenticated task" in section.lower(), (
+            "browser-control/SKILL.md 'Route the task' summary must define "
+            "route success as authenticated task completion"
+        )
+        assert "single transport" in section.lower() or "transport error" in section.lower() or "single transport or tab call" in section.lower(), (
+            "browser-control/SKILL.md 'Route the task' summary must explicitly "
+            "state that a single transport/tab error is not enough to advance"
+        )
+
+
+class BrowserSkillAndCommandParityTest(_BrowserFilesBase):
+    """The two files must agree on the high-priority routing terms."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.cmd_text = read(BROWSER_CMD)
+        cls.skill_text = read(BROWSER_SKILL)
+
+    def test_browserclaw_in_both(self) -> None:
+        assert "browserclaw" in self.cmd_text
+        assert "browserclaw" in self.skill_text
+
+    def test_fingerprint_exception_in_both(self) -> None:
+        for kw in ("LinkedIn", "Cloudflare"):
+            assert kw in self.cmd_text, f"{kw!r} missing from browser.md"
+            assert kw in self.skill_text, f"{kw!r} missing from skill"
+
+    def test_har_ban_phrase_in_both(self) -> None:
+        # Both files must mention capture/learn/reverse in the same context
+        # so the credential-flow ban is enforced from both sides.
+        cmd_pattern = re.compile(
+            r"capture.{0,80}learn.{0,80}reverse|reverse.{0,80}learn.{0,80}capture",
+            re.IGNORECASE | re.DOTALL,
+        )
+        assert cmd_pattern.search(self.cmd_text), (
+            "browser.md must reference the capture/learn/reverse ban"
+        )
+        assert cmd_pattern.search(self.skill_text), (
+            "browser-control/SKILL.md must reference the capture/learn/reverse ban"
+        )
+
+    def test_full_routing_order_parses_and_matches_expected(self) -> None:
+        """Parse the numbered Routing order section in BOTH the command and
+        the skill, and confirm the route sequence matches the expected
+        Aside-MCP → Aside-CLI → browserclaw → Playwright headless →
+        visible/headed ordering. Catches a reordering that the loose
+        keyword tests above would silently miss."""
+        for label, path in (("command", BROWSER_CMD), ("skill", BROWSER_SKILL)):
+            text = read(path)
+            entries = parse_numbered_route_order(text)
+            sigs = [route_label_signature(label) for _, _, label in entries]
+            sigs = [s for s in sigs if s]
+            expected_sigs = [sig for sig, _ in EXPECTED_ROUTE_ORDER]
+            # The first len(expected_sigs) route entries must equal the
+            # expected sequence (the rest are unrelated numbered lists).
+            head = sigs[: len(expected_sigs)]
+            assert head == expected_sigs, (
+                f"{label} ({path}) numbered Routing order does not match "
+                f"expected sequence.\n  got:      {head}\n  expected: {expected_sigs}\n"
+                f"  full parsed signatures: {sigs}"
+            )
+
+
+class BrowserclawReferenceSafetyTest(unittest.TestCase):
+    """The two referenced browserclaw recipes MUST use the guarded mktemp
+    lifecycle. Fixed /tmp paths and unguarded screenshots are banned because
+    the new /browser command points operators to these files as background
+    references for the canonical guarded lifecycle."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        assert GEMINI_REF.is_file(), f"gemini reference missing at {GEMINI_REF}"
+        assert MULTI_REF.is_file(), f"multi-profile reference missing at {MULTI_REF}"
+        cls.gemini_text = read(GEMINI_REF)
+        cls.multi_text = read(MULTI_REF)
+
+    def test_gemini_reference_no_fixed_tmp_paths(self) -> None:
+        """The Gemini share-link reference must not contain the legacy
+        fixed /tmp paths that the round-1 review flagged as unsafe."""
+        for pat, msg in UNSAFE_FIXED_TMP_PATHS:
+            assert not re.search(pat, self.gemini_text), (
+                f"gemini-share-link-as-user.md still has unsafe path: {msg}"
+            )
+
+    def test_multi_profile_reference_no_fixed_tmp_paths(self) -> None:
+        for pat, msg in UNSAFE_FIXED_TMP_PATHS:
+            assert not re.search(pat, self.multi_text), (
+                f"multi-profile-cookie-scan.md still has unsafe path: {msg}"
+            )
+
+    def test_gemini_reference_uses_guarded_lifecycle(self) -> None:
+        # mktemp + chmod 600 + cleanup function + trap-on-exit.
+        for kw in ("mktemp", "chmod 600", "trap", "rm -f"):
+            assert kw in self.gemini_text, (
+                f"gemini-share-link-as-user.md missing guarded-lifecycle anchor: {kw!r}"
+            )
+
+    def test_multi_profile_reference_uses_guarded_lifecycle(self) -> None:
+        for kw in ("mktemp", "chmod 600", "trap", "rm -f"):
+            assert kw in self.multi_text, (
+                f"multi-profile-cookie-scan.md missing guarded-lifecycle anchor: {kw!r}"
+            )
+
+    def test_references_delegate_to_canonical_lifecycle(self) -> None:
+        """The references must explicitly defer to the canonical guarded
+        lifecycle in the /browser command and the browser-control skill,
+        so operators know not to copy them as standalone instructions."""
+        for path, text in ((GEMINI_REF, self.gemini_text), (MULTI_REF, self.multi_text)):
+            assert "browser.md" in text and "browser-control/SKILL.md" in text, (
+                f"{path} must point to the canonical guarded lifecycle in browser.md and "
+                "browser-control/SKILL.md"
+            )
+
+    def test_references_do_not_persist_screenshots_by_default(self) -> None:
+        """The references must not contain a default `--screenshot` flag
+        that lands a PNG on disk. Visual evidence requires explicit opt-in."""
+        # The Gemini reference may mention screenshots in the context of
+        # "do not write screenshots by default" — verify it is not in an
+        # active `--screenshot /tmp/...` flag.
+        for path, text in ((GEMINI_REF, self.gemini_text), (MULTI_REF, self.multi_text)):
+            assert not re.search(r"--screenshot\s+/tmp/", text), (
+                f"{path} must not contain `--screenshot /tmp/...` as an active flag"
+            )
+
+
+class AsideBrowserDefaultReconciliationTest(unittest.TestCase):
+    """The aside-browser-default skill must agree with the browser-control
+    contract: Aside is a real GUI browser (not headless); the headless-only
+    default applies to the Playwright/browserclaw fallback, not to Aside."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        assert ASIDE_SKILL.is_file(), f"aside-browser-default SKILL.md missing at {ASIDE_SKILL}"
+        cls.text = read(ASIDE_SKILL)
+
+    def test_aside_is_not_headless(self) -> None:
+        """The skill must state that Aside is a real GUI browser, not
+        headless. The 'headless-only default' applies to the Playwright /
+        browserclaw fallback, not to Aside."""
+        assert "not headless" in self.text.lower(), (
+            "aside-browser-default/SKILL.md must state Aside is not headless"
+        )
+        assert "real" in self.text.lower() and "gui" in self.text.lower(), (
+            "aside-browser-default/SKILL.md must state Aside is a real GUI browser"
+        )
+
+    def test_headless_only_default_refers_to_fallback(self) -> None:
+        """Where the skill mentions 'headless-only default', it must be in
+        the context of the Playwright/browserclaw fallback, not as a
+        property of Aside."""
+        # Find the anti-pattern line about headed mode and confirm the
+        # context names a non-Aside fallback.
+        m = re.search(
+            r"show_browser.*headed mode.*headless-only default",
+            self.text,
+            re.IGNORECASE | re.DOTALL,
+        )
+        assert m, "anti-pattern line about headed mode + headless-only default missing"
+        context = self.text[max(0, m.start() - 100): m.end() + 100].lower()
+        assert ("playwright" in context) or ("browserclaw" in context) or ("fallback" in context), (
+            "aside-browser-default/SKILL.md anti-pattern line must clarify that "
+            "the headless-only default applies to the Playwright/browserclaw "
+            "fallback, not to Aside"
+        )
+
+
+class ShellLifecycleSimulationTest(unittest.TestCase):
+    """Prove the fail-closed lifecycle invariant: a guarded mktemp
+    + chmod-600 + trap-EXIT-INT-TERM shell script removes its temp files
+    on both success and failure, and a nonzero exit code from the
+    underlying command propagates to the caller even after cleanup.
+
+    This is a LOCAL simulation — it does NOT touch any real cookie state
+    or call any real browserclaw binary. It uses a stand-in `false`
+    command to force a nonzero exit and asserts that:
+    - both TMP_COOKIES and TMP_PAGE files are removed
+    - the script's exit code is the nonzero exit of the stand-in command
+    - cleanup runs even on failure (trap fires on EXIT)
+    """
+
+    SIM_SCRIPT = """#!/usr/bin/env bash
+set -euo pipefail
+
+TMP_COOKIES="$(mktemp -t browserclaw-sim-cookies-XXXXXX.json)"
+TMP_PAGE="$(mktemp -t browserclaw-sim-page-XXXXXX.txt)"
+chmod 600 "$TMP_COOKIES" "$TMP_PAGE"
+cleanup() { rm -f "$TMP_COOKIES" "$TMP_PAGE"; }
+trap cleanup EXIT INT TERM
+
+# Simulated decrypt step. The user picks success or failure.
+${SIM_STEP}
+
+cleanup
+trap - EXIT INT TERM
+"""
+
+    def _run_sim(self, step: str) -> tuple[int, str, str]:
+        with tempfile.TemporaryDirectory() as td:
+            script_path = Path(td) / "lifecycle_sim.sh"
+            script_path.write_text(self.SIM_SCRIPT.replace("${SIM_STEP}", step))
+            script_path.chmod(0o755)
+            env = os.environ.copy()
+            proc = subprocess.run(
+                ["bash", str(script_path)],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            # Walk the temp directory for any leftover mktemp files.
+            leftovers = sorted(p.name for p in Path(td).glob("browserclaw-sim-*"))
+            return proc.returncode, proc.stderr, ",".join(leftovers) or "<none>"
+
+    def test_success_path_removes_temp_files_and_returns_zero(self) -> None:
+        rc, _, leftovers = self._run_sim(":")  # no-op, success
+        self.assertEqual(rc, 0, "success-path script must return 0")
+        self.assertEqual(leftovers, "<none>", f"success-path leftover files: {leftovers}")
+
+    def test_failure_path_removes_temp_files_and_returns_nonzero(self) -> None:
+        rc, _, leftovers = self._run_sim("false")  # force nonzero exit
+        self.assertNotEqual(rc, 0, "failure-path script must return nonzero (false exit was swallowed)")
+        self.assertEqual(leftovers, "<none>", f"failure-path leftover files: {leftovers}")
+
+    def test_failure_path_preserves_underlying_exit_code(self) -> None:
+        rc, _, _ = self._run_sim("exit 42")
+        self.assertEqual(rc, 42, "underlying exit code (42) must propagate past cleanup")
+
+    def test_signal_like_failure_via_set_euo_pipefail(self) -> None:
+        """set -euo pipefail must abort on the first failure and still
+        run the EXIT trap. We trigger set -u via an undefined variable,
+        which guarantees the script aborts regardless of compound-command
+        rules (set -u is not affected by &&/|| short-circuit semantics)."""
+        rc, _, leftovers = self._run_sim('echo "${UNDEFINED_VAR}"')
+        self.assertNotEqual(rc, 0, "set -u must abort on an undefined variable")
+        self.assertEqual(leftovers, "<none>", "EXIT trap must run on set -u abort")
+
+class _ExtractedRecipeTestBase(unittest.TestCase):
+    """Parse the documented canonical recipes from the markdown files
+    and prove the fail-closed contract by actually executing the
+    extracted snippets in a hermetic environment.
+
+    This is the regression test the round-2 reviewer asked for: it
+    reads the actual documented shell, replaces the browserclaw /
+    Playwright invocations with no-op stand-ins, and asserts cleanup,
+    nonzero propagation, and the secret-branch combined-cleanup
+    invariant.
+    """
+
+    @classmethod
+    def _extract_canonical_recipe(cls) -> str:
+        text = read(BROWSER_CMD)
+        body = text.split("## Auth-gated share links", 1)[1]
+        m = re.search(r"```bash\n(.*?)\n```", body, re.DOTALL)
+        assert m, "browser.md missing canonical bash recipe block"
+        recipe = m.group(1)
+        # macOS `mktemp -t TEMPLATE` ignores `$TMPDIR` and always
+        # writes to the per-user system temp dir. The test runtime
+        # points TMPDIR at a controlled temp dir so it can scan
+        # leftovers; rewrite the mktemp calls to use
+        # `mktemp -p "$TMPDIR/"` so the contract test is portable
+        # to GNU and BSD coreutils. The documented recipe in
+        # browser.md is unchanged.
+        recipe = re.sub(
+            r"mktemp -t ([^\s\"]+)",
+            r'mktemp -p "$TMPDIR/" \1',
+            recipe,
+        )
+        # The test must NEVER invoke the real browserclaw against
+        # the user's actual profile cookies. Replace the entire
+        # multi-profile sweep (the `set +e ... set -e` block) with
+        # a hermetic no-op that writes a single stub cookie to
+        # $TMP_COOKIES so the gate passes, then replace every
+        # remaining `env -i ... browserclaw ...` multi-line block
+        # (the inject step) with a stub that writes the page text.
+        out: list[str] = []
+        in_sweep = False
+        skipping_env_block = False
+        for line in recipe.splitlines():
+            stripped = line.strip()
+            if stripped == "set +e" and not in_sweep:
+                in_sweep = True
+                out.append(
+                    "jq -n --argjson c '[{\"name\":\"__test__\"}]' "
+                    "'{cookies:$c}' > \"$TMP_COOKIES\""
+                )
+                continue
+            if in_sweep:
+                if stripped == "set -e":
+                    in_sweep = False
+                continue
+            if line.lstrip().startswith("env -i") and line.rstrip().endswith("\\"):
+                skipping_env_block = True
+                out.append("printf 'stub page text' > \"$TMP_PAGE\"")
+                continue
+            if skipping_env_block:
+                if not line.rstrip().endswith("\\"):
+                    skipping_env_block = False
+                continue
+            out.append(line)
+        return "\n".join(out)
+
+    @classmethod
+    def _extract_secret_branch(cls) -> str:
+        text = read(BROWSER_SKILL)
+        body = text.split("**Secret-bearing page branch:**", 1)[1].split("**Safeguards**", 1)[0]
+        m = re.search(r"```bash\n(.*?)\n```", body, re.DOTALL)
+        assert m, "browser-control SKILL.md missing secret-branch bash block"
+        branch = m.group(1)
+        # Same macOS mktemp -t portability fix as the canonical
+        # recipe. Documented recipe is unchanged.
+        branch = re.sub(
+            r"mktemp -t ([^\s\"]+)",
+            r'mktemp -p "$TMPDIR/" \1',
+            branch,
+        )
+        # The branch is self-contained: it runs the canonical
+        # multi-profile sweep itself to obtain $TMP_COOKIES, then
+        # a bare Playwright script. The test must NEVER invoke
+        # the real browserclaw against the user's actual profile
+        # cookies, so replace the entire sweep (set +e ... set -e)
+        # with a hermetic no-op that writes a single stub cookie.
+        out: list[str] = []
+        in_sweep = False
+        for line in branch.splitlines():
+            stripped = line.strip()
+            if stripped == "set +e" and not in_sweep:
+                in_sweep = True
+                out.append(
+                    "jq -n --argjson c '[{\"name\":\"__test__\"}]' "
+                    "'{cookies:$c}' > \"$TMP_COOKIES\""
+                )
+                continue
+            if in_sweep:
+                if stripped == "set -e":
+                    in_sweep = False
+                continue
+            out.append(line)
+        branch = "\n".join(out)
+        # Replace the real Playwright invocation with the system
+        # python3 (no playwright installed) so the import fails
+        # predictably; the trap must remove every browserclaw
+        # temp file under TMPDIR regardless.
+        branch = branch.replace(
+            '"$HOME/.local/orch-venv/bin/python" - "$TMP_COOKIES" "$BROWSE_TARGET_URL" <<\'PY\'',
+            '/usr/bin/python3 - "$TMP_COOKIES" "http://stub" <<\'PY\'',
+        )
+        return branch
+
+    def _run_with(self, recipe: str, env_extra: dict | None = None) -> tuple[int, str, str]:
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "recipe.sh"
+            path.write_text(recipe)
+            path.chmod(0o755)
+            env = os.environ.copy()
+            env["TMPDIR"] = td
+            if env_extra:
+                env.update(env_extra)
+            proc = subprocess.run(
+                ["bash", str(path)],
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                cwd=td,
+            )
+            leftovers = sorted(p.name for p in Path(td).glob("browserclaw*"))
+            return proc.returncode, proc.stderr, ",".join(leftovers) or "<none>"
+
+    def _populate_cookies(self, count: int = 1) -> str:
+        import json as _json
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, prefix="browserclaw-ext-cookies-"
+        ) as fh:
+            _json.dump({"cookies": [{"name": f"c{i}"} for i in range(count)]}, fh)
+            path = fh.name
+        os.chmod(path, 0o600)
+        return path
+
+    def test_canonical_recipe_success_path_removes_all_credential_artifacts(self) -> None:
+        recipe = self._extract_canonical_recipe()
+        rc, stderr, leftovers = self._run_with(recipe)
+        self.assertEqual(rc, 0, f"canonical recipe failed: {stderr}")
+        self.assertEqual(leftovers, "<none>", (
+            f"canonical recipe MUST leave no browserclaw temp files "
+            f"on success; leftovers: {leftovers}"
+        ))
+
+    def test_canonical_recipe_failure_path_removes_all_credential_artifacts(self) -> None:
+        # Replace the no-op inject with `false` so set -e aborts after
+        # the cookie file has been created. The trap must still remove
+        # both $TMP_COOKIES and $TMP_PAGE.
+        recipe = self._extract_canonical_recipe()
+        recipe = recipe.replace(
+            "printf 'stub page text' > \"$TMP_PAGE\"",
+            "false  # force set -e to abort",
+        )
+        rc, _, leftovers = self._run_with(recipe)
+        self.assertNotEqual(rc, 0, "recipe MUST exit nonzero when inject fails")
+        self.assertEqual(leftovers, "<none>", (
+            f"canonical recipe MUST clean both $TMP_COOKIES and "
+            f"$TMP_PAGE on inject failure; leftovers: {leftovers}"
+        ))
+
+    def test_canonical_recipe_zero_cookie_gate_exits_nonzero(self) -> None:
+        recipe = self._extract_canonical_recipe()
+        # Replace the no-op decrypt with one that writes an EMPTY
+        # cookie JSON to $TMP_COOKIES so the gate trips.
+        recipe = recipe.replace(
+            "jq -n --argjson c '[{\"name\":\"__test__\"}]' '{cookies:$c}' > \"$TMP_COOKIES\"",
+            "jq -n --argjson c '[]' '{cookies:$c}' > \"$TMP_COOKIES\"",
+        )
+        rc, stderr, leftovers = self._run_with(recipe)
+        self.assertNotEqual(rc, 0, (
+            f"canonical recipe MUST exit nonzero on zero-cookie gate "
+            f"trip; got rc=0, stderr={stderr!r}"
+        ))
+        self.assertIn("BLOCKER", stderr, (
+            "zero-cookie gate must post a BLOCKER message to stderr"
+        ))
+        self.assertEqual(leftovers, "<none>", (
+            f"zero-cookie gate MUST still clean $TMP_COOKIES via the "
+            f"trap; leftovers: {leftovers}"
+        ))
+
+    def test_secret_branch_cleans_up_cookies_on_failure(self) -> None:
+        branch = self._extract_secret_branch()
+        with tempfile.TemporaryDirectory() as td:
+            # Place the secret branch's mktemp cookie + page text
+            # inside the TMPDIR we will pass to the test so the
+            # trap's cleanup is observable.
+            cookie_inside = Path(td) / "browserclaw-XXXXXX-cookies.json"
+            cookie_inside.write_text('{"cookies": [{"name": "x"}]}')
+            cookie_inside.chmod(0o600)
+            page_inside = Path(td) / "browserclaw-XXXXXX-page.txt"
+            page_inside.write_text("ignored")
+            page_inside.chmod(0o600)
+            script = (
+                f'export TMP_COOKIES="{cookie_inside}"\n'
+                f'export TMP_PAGE="{page_inside}"\n'
+                f"{branch}"
+            )
+            rc, stderr, leftovers = self._run_with(script, env_extra={
+                "TMP_COOKIES": str(cookie_inside),
+                "TMP_PAGE": str(page_inside),
+                "BROWSE_TARGET_URL": "http://stub",
+            })
+            self.assertNotEqual(rc, 0, (
+                f"secret branch must propagate the underlying "
+                f"ImportError exit; got rc=0, stderr={stderr!r}"
+            ))
+            self.assertEqual(leftovers, "<none>", (
+                f"secret branch trap MUST remove every browserclaw "
+                f"temp file under TMPDIR; leftovers: {leftovers}"
+            ))
+
+    def test_canonical_recipe_sigint_removes_all_credential_artifacts(self) -> None:
+        # Round-4/5 reviewer-required test: prove the canonical
+        # recipe cleans BOTH files on SIGINT AND exits nonzero
+        # (128+SIGINT=130) so callers see the signal — bash does
+        # NOT continue past the trap into a state that could
+        # recreate credential files. The recipe's signal handler
+        # re-raises the signal after cleanup.
+        recipe = self._extract_canonical_recipe()
+        # Use a short sleep so the test's wait timeout does not
+        # itself become the dominant cost.
+        recipe = recipe.replace(
+            "printf 'stub page text' > \"$TMP_PAGE\"",
+            "sleep 5 & wait $!",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "recipe.sh"
+            path.write_text(recipe)
+            path.chmod(0o755)
+            env = os.environ.copy()
+            env["TMPDIR"] = td
+            proc = subprocess.Popen(
+                ["bash", str(path)],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=td,
+            )
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                if any(Path(td).glob("browserclaw-*.json")):
+                    break
+                time.sleep(0.1)
+            self.assertTrue(any(Path(td).glob("browserclaw-*.json")), (
+                "canonical recipe must create the cookie file before "
+                "the inject step"
+            ))
+            proc.send_signal(signal.SIGINT)
+            try:
+                proc.wait(timeout=8)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+            leftovers = sorted(p.name for p in Path(td).glob("browserclaw*"))
+            self.assertEqual(leftovers, [], (
+                f"canonical recipe MUST clean BOTH $TMP_COOKIES and "
+                f"$TMP_PAGE on SIGINT; leftovers: {leftovers}"
+            ))
+            # 128 + SIGINT (2) = 130; or the trap may exit with a
+            # smaller nonzero. Accept anything > 128 to prove the
+            # signal was not silently swallowed.
+            self.assertGreater(proc.returncode, 128, (
+                f"canonical recipe MUST exit with 128+signal on SIGINT "
+                f"(got rc={proc.returncode}); bash continuing past the "
+                f"trap is the exact bug the round-5 review flagged"
+            ))
+
+    def test_canonical_recipe_sigterm_removes_all_credential_artifacts(self) -> None:
+        # Same as SIGINT but for SIGTERM. 128 + 15 = 143.
+        recipe = self._extract_canonical_recipe()
+        recipe = recipe.replace(
+            "printf 'stub page text' > \"$TMP_PAGE\"",
+            "sleep 5 & wait $!",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "recipe.sh"
+            path.write_text(recipe)
+            path.chmod(0o755)
+            env = os.environ.copy()
+            env["TMPDIR"] = td
+            proc = subprocess.Popen(
+                ["bash", str(path)],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                cwd=td,
+            )
+            deadline = time.time() + 5
+            while time.time() < deadline:
+                if any(Path(td).glob("browserclaw-*.json")):
+                    break
+                time.sleep(0.1)
+            self.assertTrue(any(Path(td).glob("browserclaw-*.json")), (
+                "canonical recipe must create the cookie file before "
+                "the inject step"
+            ))
+            proc.send_signal(signal.SIGTERM)
+            try:
+                proc.wait(timeout=8)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+            leftovers = sorted(p.name for p in Path(td).glob("browserclaw*"))
+            self.assertEqual(leftovers, [], (
+                f"canonical recipe MUST clean BOTH $TMP_COOKIES and "
+                f"$TMP_PAGE on SIGTERM; leftovers: {leftovers}"
+            ))
+            self.assertGreater(proc.returncode, 128, (
+                f"canonical recipe MUST exit with 128+signal on SIGTERM "
+                f"(got rc={proc.returncode})"
+            ))
+
+    def test_canonical_recipe_has_signal_handlers(self) -> None:
+        # Round-5 reviewer-required test: prove the canonical
+        # recipe installs INT/TERM/HUP handlers that re-raise the
+        # signal so bash does not continue past the trap.
+        section = self._extract_canonical_recipe()
+        assert "exit_on_signal" in section, (
+            "canonical recipe must install exit_on_signal handlers "
+            "for INT/TERM/HUP so the script exits nonzero on signal"
+        )
+        assert "INT" in section and "TERM" in section and "HUP" in section
+
+    def test_secret_branch_under_set_u_does_not_trip_unbound_variable(self) -> None:
+        # Round-3 reviewer-required test: run the EXACT documented
+        # secret-branch shell under `set -u` and prove the URL
+        # assignment does not trip an unbound variable on the
+        # command line.
+        branch = self._extract_secret_branch()
+        with tempfile.TemporaryDirectory() as td:
+            cookie_inside = Path(td) / "browserclaw-XXXXXX-cookies.json"
+            cookie_inside.write_text('{"cookies": [{"name": "x"}]}')
+            cookie_inside.chmod(0o600)
+            page_inside = Path(td) / "browserclaw-XXXXXX-page.txt"
+            page_inside.write_text("ignored")
+            page_inside.chmod(0o600)
+            script = (
+                f'set -u\n'
+                f'export TMP_COOKIES="{cookie_inside}"\n'
+                f'export TMP_PAGE="{page_inside}"\n'
+                f"{branch}"
+            )
+            rc, stderr, leftovers = self._run_with(script)
+            self.assertNotIn("unbound variable", stderr, (
+                f"secret branch must not trip set -u on BROWSE_TARGET_URL; "
+                f"stderr={stderr!r}"
+            ))
+            self.assertEqual(leftovers, "<none>", (
+                f"secret branch must leave no browserclaw temp files "
+                f"under TMPDIR even when the python import fails; "
+                f"leftovers: {leftovers}"
+            ))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# /browser command + browser-control skill rewrite

## Summary

This PR brings the user-scope `/browser` command and `browser-control` skill that Claude Code actually loads at runtime into the `jleechanorg/claude-commands` repo. Both files previously lived only in `~/.claude/` and could drift without a test catching them. The new contract test enforces the routing order, the fail-closed lifecycle, the no-screenshot policy, the signal handlers, the secret-page non-persistence rule, and the path/correctness of every documented bash block.

## What changed

- **`.claude/commands/browser.md`** — new `/browser` slash command with Aside-first routing order (MCP → CLI → browserclaw → unauthenticated Playwright), a fingerprint-sensitive Aside-only exception (LinkedIn, banks/brokerages, Cloudflare/Akamai targets), and a canonical guarded lifecycle for auth-gated share links (Gemini / ChatGPT / Google Docs / Notion).
- **`.claude/skills/browser-control/SKILL.md`** — matching skill body with the same routing, plus a self-contained secret-bearing page branch that runs the multi-profile sweep itself, emits a boolean to stdout only, and persists neither DOM text nor images.
- **`hermes/skills/aside-browser-default/SKILL.md`** — tighten the "show browser" opt-in language so the headless default is explicit and the headed mode requires a current-thread phrase.
- **`hermes/skills/browserclaw/references/gemini-share-link-as-user.md`** + **`multi-profile-cookie-scan.md`** — bring the canonical recipes inline with the command/skill (Edge path correction to `~/Library/Application Support/Microsoft Edge/Default/Cookies`, Aside Profile 1 enumeration, `umask 077`, `mktemp -p` for portability, fail-closed EXIT/INT/TERM/HUP trap that exits nonzero on signal).
- **`tests/test_browser_command_contract.py`** — 51 pytest tests that execute the documented recipes in hermetic temp dirs. Verified `--screenshot`/`--capture-har` absent from every bash block, no absolute `~/.claude/skills/...` paths, every `browserclaw cookies decrypt` uses the guarded `$TMP_COOKIES`, the trap removes BOTH files on success/failure/SIGINT/SIGTERM, the secret branch self-fetches cookies, signal handlers terminate nonzero (128+sig), and the extractor never invokes real `browserclaw` against user profiles.

## Why now

The user-scope command/skill were the canonical sources Claude Code was actually loading. The repo copy was missing both, so any drift in `~/.claude/` could not be caught or reviewed. The contract test runs in CI, so future drift breaks the build.

## Test evidence

```text
$ python3 -m pytest -q tests/test_browser_command_contract.py
...................................................   [100%]
51 passed in 0.59s

$ python3 -m unittest discover tests -v
Ran 59 tests in 0.61s
OK
```

The contract test executes the actual canonical recipe in a hermetic temp dir and verifies:

- `--screenshot`/`--capture-har` is absent from every documented bash block (not just the first one).
- No absolute `~/.claude/skills/...` paths in the command.
- Every `browserclaw cookies decrypt` uses the guarded `$TMP_COOKIES` and never a fresh `mktemp` inside the invocation.
- The trap removes BOTH `$TMP_COOKIES` and `$TMP_PAGE` on success, failure, SIGINT, and SIGTERM.
- The signal handlers exit with `128+sig` so bash does not continue past the trap.
- The secret-bearing branch self-fetches cookies (runs the sweep itself), emits a boolean to stdout only, and never calls `.write_text()` to persist the result.
- The extractor replaces every `set +e ... set -e` and `env -i ...` block with a hermetic no-op so the test NEVER invokes real `browserclaw` against the user's actual profiles.

## Review history

- Round 1-6 `/er`: NOT APPROVED on missing fail-closed lifecycle, trap disarm under sweep, `browserclaw write_text()` not enforcing mode `0600`, signal handlers not re-raising, tests running real `browserclaw` against user cookies.
- Round 1-6 `/advice`: NOT APPROVED on routing contradictions, Aside-Profile 1 enumeration, Edge path, signal handler termination, and hermetic tests.

This PR addresses every actionable item from the latest round-6 verdicts.

## Risk

Low. The new files are additive — Claude Code will pick up the new command/skill on next session start. The hermetic tests prove no real credential files are touched during CI runs. The fail-closed lifecycle guarantees credential-bearing temp files are removed on every signal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Documentation encodes real cookie decrypt/inject and session-copy behavior for agents; mistakes could leak credentials or route banking/LinkedIn through headless injection, though CI contract tests and fail-closed shell patterns reduce regression risk.
> 
> **Overview**
> **Adds version-controlled `/browser` and `browser-control` policy** so Claude Code’s runtime docs can’t drift from the repo without CI failing.
> 
> The **routing contract** is now explicit end-to-end: Aside MCP → Aside CLI → guarded `browserclaw cookies decrypt/inject` → unauthenticated Playwright headless → headed only on user opt-in. Advance only when a route can’t finish the **authenticated task** (not on a single tab/transport error). **Fingerprint-sensitive** targets (LinkedIn, banks/brokerages, Cloudflare/Akamai) are **Aside-only** with a one-line blocker on headless hosts—no cookie copy, capture/learn/reverse, or Playwright fallthrough.
> 
> **Credential handling** replaces the old “never copy cookies between profiles” contradiction with an **authorized cookie-copy contract**: `umask 077`, `mktemp` + `chmod 600`, inline **Aside-first multi-profile sweep** (including Aside Profile 1 and corrected Edge path), inject via `--browser-channel chromium`, ban default screenshots/HAR on credential flows, and a **secret-bearing branch** that emits only a boolean to stdout. Shell recipes use **fail-closed** `set -euo pipefail`, EXIT/INT/TERM/HUP traps that **exit 128+signal** (no `trap -` disarm).
> 
> **Supporting doc updates**: `aside-browser-default` clarifies Aside is a real GUI browser (headless default applies to Playwright/browserclaw fallback); browserclaw reference files are **background-only** and defer to the canonical recipes.
> 
> **New `tests/test_browser_command_contract.py`** (~51 tests) regex-checks both markdown files for routing order, safeguards, and banned phrases; runs **hermetic subprocess simulations** of extracted bash (stubbed browserclaw, no real cookie DBs) including success/failure, zero-cookie gate, SIGINT/SIGTERM cleanup, and secret-branch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 391e20a65fa1e432ae700d8a93cc73428e3f10ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->